### PR TITLE
Add settings.xml for docker maven dependency caching

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,3 @@
+<settings>
+    <localRepository>../../root/.m2/</localRepository>
+</settings>


### PR DESCRIPTION
This specifies where maven dependencies should be stored in the pg docker image.