### PR TITLE
Add test for query params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
                         <exclude>**/v3/resources/*</exclude>
                         <exclude>**/v3/Client.*</exclude>
                         <exclude>**/v3/exception/*</exclude>
+                        <exclude>**/v3/QueryParams.*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/src/main/java/com/recurly/v3/QueryParams.java
+++ b/src/main/java/com/recurly/v3/QueryParams.java
@@ -22,11 +22,7 @@ public class QueryParams {
     return this.params;
   }
 
-  public void setParams(HashMap<String, Object> params) {
-    this.params = params;
-  }
-
-  public void add(String key, Object value) {
+  private void add(String key, Object value) {
     this.params.put(key, value);
   }
 

--- a/src/test/java/com/recurly/v3/JsonSerializerTest.java
+++ b/src/test/java/com/recurly/v3/JsonSerializerTest.java
@@ -6,7 +6,6 @@ import com.recurly.v3.fixtures.DateTimeTestClass;
 import com.recurly.v3.fixtures.MyRequest;
 import com.recurly.v3.fixtures.MyResource;
 import org.junit.jupiter.api.Test;
-import com.recurly.v3.ApiException;
 import org.joda.time.DateTime;
 
 public class JsonSerializerTest {

--- a/src/test/java/com/recurly/v3/QueryParamsTest.java
+++ b/src/test/java/com/recurly/v3/QueryParamsTest.java
@@ -1,0 +1,23 @@
+package com.recurly.v3;
+
+import org.junit.jupiter.api.Test;
+
+import javax.management.Query;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QueryParamsTest {
+  @Test
+  public void testConstructor() {
+    QueryParams qp = new QueryParams();
+    assertEquals(qp.getParams(), new HashMap<String, Object>());
+  }
+
+  @Test
+  public void testSetLimit() {
+    QueryParams qp = new QueryParams();
+    qp.setLimit(200);
+    assertEquals(qp.getParams().get("limit"), 200);
+  }
+}


### PR DESCRIPTION
Adds a couple of tests around the query params. `setLimit` is the only portion that's truly generated (everything else that I'm testing here is written directly into the generator template). The rest of the dynamic methods do not have tests around them, but there's no way to exclude them from coverage unless we exclude the entire class (which may be the best option, but I haven't done that just yet).