### PR TITLE
Fix format script

### DIFF
--- a/scripts/format
+++ b/scripts/format
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java -jar ./bin/google-java-format-1.7-all-deps.jar -i $(git ls-files|grep \.java$)
+java -jar ./bin/google-java-format-1.7-all-deps.jar -i $(ls src/main/java/com/recurly/v3/**/*.java)


### PR DESCRIPTION
Using git ls-files doesn't work in situations where files have been
removed and not comited. Instead of trying to get it to work with
ls-files, it's much simpler and more robust to use a normal `ls` and format every
file.