### PR TITLE
Specify transitive dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,5 +277,22 @@
             <version>2.1</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Specify versions of transitive dependencies
+            xerces:xercesImpl introduced through jacoco-maven-plugin and doxia-core
+              - can be removed when mvn dependency:list shows version 2.12.0 or higher and no snyk reported vulnerabilities
+            plexus:plexus-utils introduced through jacoco-maven-plugin, maven-compiler-plugin, and others
+              - can be removed when mvn dependency:list shows version 3.0.24 or higher and no snyk reported vulnerabilities
+        -->
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.12.0</version>
+        </dependency>
+        <dependency>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+          <version>3.2.1</version>
+      </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The transitive deps for xercesImpl and plexus-utils were out of date and therefore flagged by Snyk. This updates them to non-vulnerable versions. Unit tests pass locally and jacoco still successfully creates the report when you increment the `forkCount` to 1.