### PR TITLE
Convert Array params to CSV strings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ As a Maven dependency:
 <dependency>
   <groupId>com.recurly.v3</groupId>
   <artifactId>api-client</artifactId>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation 'com.recurly.v3:api-client:3.1.0'
+implementation 'com.recurly.v3:api-client:3.1.1'
 ```
 
 You can find further release and distribution details on

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.recurly.v3</groupId>
     <artifactId>api-client</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <name>Recurly API V3 Java Client</name>
     <description>The official Java client for Recurly's V3 API.</description>

--- a/src/main/java/com/recurly/v3/QueryParams.java
+++ b/src/main/java/com/recurly/v3/QueryParams.java
@@ -27,7 +27,7 @@ public class QueryParams {
   }
 
   public void setIds(final List<String> ids) {
-    this.add("ids", ids);
+    this.add("ids", String.join(",", ids));
   }
 
   public void setLimit(final Integer limit) {


### PR DESCRIPTION
Fixes an issue with requesting a list of resources with specific `ids`. The server expects a CSV string of ids, but the api spec specifies that the `ids` should be specified as an array. 

This fix maintains developer happiness by maintaining the ability to specify an array of ids that are transformed to a CSV string when the request is sent to the server.

Resolves https://github.com/recurly/recurly-client-java/issues/47