### PR TITLE
Fixing invalid request body (unpermitted parameters _json)

### DIFF
--- a/src/main/java/com/recurly/v3/JsonSerializer.java
+++ b/src/main/java/com/recurly/v3/JsonSerializer.java
@@ -33,6 +33,10 @@ public class JsonSerializer {
   }
 
   public String serialize(Request body) {
-    return gsonSerializer.toJson(body);
+    if (body == null) {
+      return "";
+    } else {
+      return gsonSerializer.toJson(body);
+    }
   }
 }


### PR DESCRIPTION
Updating the JsonSerializer to return empty string instead of "null" when attempting to serialize a null body.

Fixes the error:
```
Failed validation: Please remove the following unpermitted parameters from your request: _json.
```