### PR TITLE
Fixing release script

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,3 +1,5 @@
+user=recurly
+project=recurly-client-java
 unreleased=false
 exclude-labels=question,bug?,duplicate
 issues-wo-labels=false

--- a/scripts/release
+++ b/scripts/release
@@ -12,10 +12,10 @@ git commit -m "Update Changelog for Release $THIS_VERSION"
 git push origin master
 
 # publish
-echo "mvn versions:set -DnewVersion=$THIS_VERSION"
-echo "mvn clean package"
-echo "mvn deploy"
-echo "mvn versions:revert"
+mvn versions:set -DnewVersion="$THIS_VERSION"
+mvn clean package
+mvn deploy
+mvn versions:revert
 
 # create release
 hub release create -c -F "$RELEASED_LOG" "$THIS_VERSION"


### PR DESCRIPTION
The internal use release script incorrectly was echoing the commands to build and deploy instead of running them.