### PR TITLE
Adding #getFirst and #getCount methods to Pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,39 @@ while (accounts.hasMore()) {
 }
 ```
 
+#### Additional Pager Methods
+
+In addition to the methods to facilitate pagination, the Pager class provides 2 helper methods:
+
+1. getFirst
+2. getCount
+
+##### First
+
+The Pager's `getFirst` method can be used to fetch only the first resource from the endpoint for the given QueryParams.
+
+```java
+DateTime beginTime = new DateTime(2020, 1, 1, 0, 0);
+QueryParams params = new QueryParams();
+params.setBeginTime(beginTime);
+Pager<Account> accounts = client.listAccounts(params);
+Account account = accounts.getFirst();
+System.out.println(account.getCode());
+```
+
+##### Count
+
+The Pager's `getCount` method will return the total number of resources that are available at the requested endpoint for the given QueryParams.
+
+```java
+DateTime beginTime = new DateTime(2020, 1, 1, 0, 0);
+QueryParams params = new QueryParams();
+params.setBeginTime(beginTime);
+Pager<Account> accounts = client.listAccounts(params);
+int total = accounts.getCount();
+System.out.println("There are " + total + " accounts since " + beginTime);
+```
+
 ### Creating Resources
 
 Every `create*` and `update*` method on the client takes a `Request` object that forms the request. This allows you

--- a/src/main/java/com/recurly/v3/Pager.java
+++ b/src/main/java/com/recurly/v3/Pager.java
@@ -63,6 +63,23 @@ public class Pager<T extends Resource> implements Iterable<T> {
     return data;
   }
 
+  public T getFirst() {
+    HashMap<String, Object> firstParams = (HashMap<String, Object>)this.queryParams.clone();
+    firstParams.put("limit", 1);
+    Pager<T> pager =
+        this.client.makeRequest("GET", this.next, firstParams, this.parameterizedType);
+    PagerIterator iterator = pager.iterator();
+    if (iterator.hasNext()) {
+      return (T)iterator.next();
+    } else {
+      return null;
+    }
+  }
+
+  public int getCount() {
+    return this.client.getRecordCount(this.next, this.queryParams);
+  }
+
   public void getNextPage() {
     if (this.next == null) {
       throw new NoSuchElementException();


### PR DESCRIPTION
Adds the `getFirst` and `getCount` methods to the `Pager` class.

The `getFirst` method will perform a request to the API with the `limit` set to 1 and will only return the first result from the server.

The `getCount` method will perform a `HEAD` request to the API for the appropriate endpoint. The value of the response header, `recurly-total-records`, will be returned. This is the total number of records that will be returned by the pager.