### PR TITLE
Included the to-be released changes in the changelog

### DIFF
--- a/scripts/changelog
+++ b/scripts/changelog
@@ -6,6 +6,8 @@ if [ -z "$GITHUB_TOKEN" ]; then
 else
   if [ "$1" == "--pending" ]; then
     github_changelog_generator -t $GITHUB_TOKEN --unreleased-only -o "$2"
+  elif [ "$1" == "--release-tag" ]; then
+    github_changelog_generator -t $GITHUB_TOKEN --unreleased true --unreleased-label "$2"
   else
     github_changelog_generator -t $GITHUB_TOKEN
   fi

--- a/scripts/release
+++ b/scripts/release
@@ -5,8 +5,8 @@ set -e
 RELEASED_LOG="/tmp/java-pending-changes.md"
 THIS_VERSION=$(./scripts/bump --this-version)
 
-# Finally need to update the full changelog
-./scripts/changelog
+# Generate the changelog with changes in this release
+./scripts/changelog --release-tag "$THIS_VERSION"
 git add CHANGELOG.md
 git commit -m "Update Changelog for Release $THIS_VERSION"
 git push origin master


### PR DESCRIPTION
This will allow the unreleased changes to be included in the changelog with the correct release tag label prior to the release tag being generated.

The primary benefit of this is that the full changelog will be included in the release tag.