### PR TITLE
Release 3.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.1
+current_version = 3.5.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ As a Maven dependency:
 <dependency>
   <groupId>com.recurly.v3</groupId>
   <artifactId>api-client</artifactId>
-  <version>3.4.1</version>
+  <version>3.5.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation 'com.recurly.v3:api-client:3.4.1'
+implementation 'com.recurly.v3:api-client:3.5.0'
 ```
 
 You can find further release and distribution details on

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.recurly.v3</groupId>
     <artifactId>api-client</artifactId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
 
     <name>Recurly API V3 Java Client</name>
     <description>The official Java client for Recurly's V3 API.</description>


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-java/compare/3.4.1...HEAD)

**Implemented enhancements:**

- Tue Apr 14 20:23:36 UTC 2020 Upgrade API version v2019-10-10 [\#84](https://github.com/recurly/recurly-client-java/pull/84) ([bhelx](https://github.com/bhelx))
- Adding \#getFirst and \#getCount methods to Pager [\#82](https://github.com/recurly/recurly-client-java/pull/82) ([douglasmiller](https://github.com/douglasmiller))

**Merged pull requests:**

- Included the to-be released changes in the changelog [\#83](https://github.com/recurly/recurly-client-java/pull/83) ([douglasmiller](https://github.com/douglasmiller))
- Updating release script to be uniform across all clients [\#81](https://github.com/recurly/recurly-client-java/pull/81) ([douglasmiller](https://github.com/douglasmiller))
- Thu Mar 26 20:43:33 UTC 2020 Upgrade API version v2019-10-10 [\#80](https://github.com/recurly/recurly-client-java/pull/80) ([bhelx](https://github.com/bhelx))