### PR TITLE
Loosening the restrictions on generated user agent string

### DIFF
--- a/src/test/java/com/recurly/v3/HeaderInterceptorTest.java
+++ b/src/test/java/com/recurly/v3/HeaderInterceptorTest.java
@@ -34,7 +34,7 @@ public class HeaderInterceptorTest {
     // TODO this regex will change on GA
     // BETA semver sequence is forced until then
     final String agentFormat =
-        "Recurly/3\\.\\d+\\.\\d+(-SNAPSHOT)?;\\s+java\\s+\\d+\\.\\d+\\.\\d+.*";
+        "Recurly/3\\.\\d+\\.\\d+(-SNAPSHOT)?;\\s+java\\s+\\d+.*";
     assertEquals(request.getHeader("User-Agent").matches(agentFormat), true);
 
     mockWebServer.shutdown();


### PR DESCRIPTION
This test regex was too strict. Some systems only give major number. Example (`java 14`).