### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/src/main/java/com/recurly/v3/BaseClient.java
+++ b/src/main/java/com/recurly/v3/BaseClient.java
@@ -5,10 +5,13 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.List;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import okhttp3.*;
 import okhttp3.Request.Builder;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -227,11 +230,22 @@ public abstract class BaseClient {
     }
   }
 
+  private void validatePathParameters(final HashMap<String, String> urlParams) {
+    Map<String, String> invalidParams = urlParams.entrySet().stream()
+        .filter(p -> p.getValue() == null || p.getValue().trim().isEmpty())
+        .collect(Collectors.toMap(e->e.getKey(),e->e.getValue()));
+    if (!invalidParams.isEmpty()) {
+      String invalidKeys = String.join(",", invalidParams.keySet());
+      throw new RecurlyException(invalidKeys + " cannot be an empty value");
+    }
+  }
+
   protected String interpolatePath(final String path) {
     return interpolatePath(path, new HashMap<String, String>());
   }
 
   protected String interpolatePath(String path, final HashMap<String, String> urlParams) {
+    validatePathParameters(urlParams);
     final Pattern p = Pattern.compile("\\{([A-Za-z|_]*)\\}");
     final Matcher m = p.matcher(path);
 

--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -219,6 +219,21 @@ public class BaseClientTest {
     assertEquals("/accounts/accountId/notes/noteId", interpolatedPath);
   }
 
+  @Test
+  public void testInterpolatePathValidations() {
+    final MockClient client = new MockClient("apiKey");
+    final String path = "/accounts/{account_id}/notes/{account_note_id}";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("account_id", "");
+    urlParams.put("account_note_id", "");
+
+    assertThrows(
+        RecurlyException.class,
+        () -> {
+          client.interpolatePath(path, urlParams);
+        });
+  }
+
   protected static void setEnv(Map<String, String> newenv) throws Exception {
     try {
       Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");


### PR DESCRIPTION
Adding a validation method that will ensure that path parameters are not empty strings to address issues where a `get_*` operation (`/resources/{resource_id}`) does not get handled by the API as a `list_*` operations (`/resources/`).