### PR TITLE
Updating error hierarchy and providing error handling for non-json error responses

### DIFF
--- a/src/main/java/com/recurly/v3/exception/BadGatewayException.java
+++ b/src/main/java/com/recurly/v3/exception/BadGatewayException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class BadGatewayException extends ServerException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public BadGatewayException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/BadRequestException.java
+++ b/src/main/java/com/recurly/v3/exception/BadRequestException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class BadRequestException extends ApiException {
+public class BadRequestException extends ClientException {
 
   public BadRequestException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/ClientException.java
+++ b/src/main/java/com/recurly/v3/exception/ClientException.java
@@ -5,11 +5,12 @@
  */
 package com.recurly.v3.exception;
 
+import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class ClientException extends ApiException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public ClientException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
+++ b/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
@@ -72,7 +72,7 @@ public class ExceptionFactory {
 
   @SuppressWarnings("unchecked")
   public static <T extends RecurlyException> T getExceptionClass(Response response) {
-    String requestId = response.header("X-Request-Id", "");
+    String requestId = response.header("X-Request-Id", "none");
     int code = response.code();
     String message = "Unexpected " + code + " Error. Recurly Request Id: " + requestId;
     switch (code) {

--- a/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
+++ b/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
@@ -8,6 +8,7 @@ package com.recurly.v3.exception;
 import com.recurly.v3.ApiException;
 import com.recurly.v3.RecurlyException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
+import okhttp3.Response;
 
 public class ExceptionFactory {
 
@@ -67,5 +68,41 @@ public class ExceptionFactory {
         return (T) new RateLimitedException(e.getMessage(), e);
     }
     return (T) apiException;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends RecurlyException> T getExceptionClass(Response response) {
+    String requestId = response.header("X-Request-Id", "");
+    int code = response.code();
+    String message = "Unexpected " + code + " Error. Recurly Request Id: " + requestId;
+    switch (code) {
+      case 500:
+        return (T) new InternalServerException(message, null);
+      case 502:
+        return (T) new BadGatewayException(message, null);
+      case 503:
+        return (T) new ServiceUnavailableException(message, null);
+      case 304:
+        return (T) new NotModifiedException(message, null);
+      case 400:
+        return (T) new BadRequestException(message, null);
+      case 401:
+        return (T) new UnauthorizedException(message, null);
+      case 402:
+        return (T) new PaymentRequiredException(message, null);
+      case 403:
+        return (T) new ForbiddenException(message, null);
+      case 404:
+        return (T) new NotFoundException(message, null);
+      case 406:
+        return (T) new NotAcceptableException(message, null);
+      case 412:
+        return (T) new PreconditionFailedException(message, null);
+      case 422:
+        return (T) new UnprocessableEntityException(message, null);
+      case 429:
+        return (T) new TooManyRequestsException(message, null);
+    }
+    return (T) new ApiException(message, null);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ForbiddenException.java
+++ b/src/main/java/com/recurly/v3/exception/ForbiddenException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class ForbiddenException extends ClientException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public ForbiddenException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ImmutableSubscriptionException.java
+++ b/src/main/java/com/recurly/v3/exception/ImmutableSubscriptionException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class ImmutableSubscriptionException extends ApiException {
+public class ImmutableSubscriptionException extends UnprocessableEntityException {
 
   public ImmutableSubscriptionException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/InternalServerException.java
+++ b/src/main/java/com/recurly/v3/exception/InternalServerException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class InternalServerException extends ApiException {
+public class InternalServerException extends ServerException {
 
   public InternalServerException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/InvalidApiKeyException.java
+++ b/src/main/java/com/recurly/v3/exception/InvalidApiKeyException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class InvalidApiKeyException extends ApiException {
+public class InvalidApiKeyException extends ForbiddenException {
 
   public InvalidApiKeyException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/InvalidApiVersionException.java
+++ b/src/main/java/com/recurly/v3/exception/InvalidApiVersionException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class InvalidApiVersionException extends ApiException {
+public class InvalidApiVersionException extends NotAcceptableException {
 
   public InvalidApiVersionException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/InvalidContentTypeException.java
+++ b/src/main/java/com/recurly/v3/exception/InvalidContentTypeException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class InvalidContentTypeException extends ApiException {
+public class InvalidContentTypeException extends BadRequestException {
 
   public InvalidContentTypeException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/InvalidPermissionsException.java
+++ b/src/main/java/com/recurly/v3/exception/InvalidPermissionsException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class InvalidPermissionsException extends ApiException {
+public class InvalidPermissionsException extends ForbiddenException {
 
   public InvalidPermissionsException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/InvalidTokenException.java
+++ b/src/main/java/com/recurly/v3/exception/InvalidTokenException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class InvalidTokenException extends ApiException {
+public class InvalidTokenException extends UnprocessableEntityException {
 
   public InvalidTokenException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/MissingFeatureException.java
+++ b/src/main/java/com/recurly/v3/exception/MissingFeatureException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class MissingFeatureException extends ApiException {
+public class MissingFeatureException extends UnprocessableEntityException {
 
   public MissingFeatureException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/NotAcceptableException.java
+++ b/src/main/java/com/recurly/v3/exception/NotAcceptableException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class NotAcceptableException extends ClientException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public NotAcceptableException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/NotFoundException.java
+++ b/src/main/java/com/recurly/v3/exception/NotFoundException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class NotFoundException extends ApiException {
+public class NotFoundException extends ClientException {
 
   public NotFoundException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/NotModifiedException.java
+++ b/src/main/java/com/recurly/v3/exception/NotModifiedException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class NotModifiedException extends ResponseException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public NotModifiedException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/PaymentRequiredException.java
+++ b/src/main/java/com/recurly/v3/exception/PaymentRequiredException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class PaymentRequiredException extends ClientException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public PaymentRequiredException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/PreconditionFailedException.java
+++ b/src/main/java/com/recurly/v3/exception/PreconditionFailedException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class PreconditionFailedException extends ClientException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public PreconditionFailedException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/RedirectionException.java
+++ b/src/main/java/com/recurly/v3/exception/RedirectionException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class RedirectionException extends ResponseException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public RedirectionException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ResponseException.java
+++ b/src/main/java/com/recurly/v3/exception/ResponseException.java
@@ -5,11 +5,12 @@
  */
 package com.recurly.v3.exception;
 
+import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class ResponseException extends ApiException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public ResponseException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ServerException.java
+++ b/src/main/java/com/recurly/v3/exception/ServerException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class ServerException extends ResponseException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public ServerException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ServiceUnavailableException.java
+++ b/src/main/java/com/recurly/v3/exception/ServiceUnavailableException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class ServiceUnavailableException extends ServerException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public ServiceUnavailableException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/SimultaneousRequestException.java
+++ b/src/main/java/com/recurly/v3/exception/SimultaneousRequestException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class SimultaneousRequestException extends ApiException {
+public class SimultaneousRequestException extends UnprocessableEntityException {
 
   public SimultaneousRequestException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/TooManyRequestsException.java
+++ b/src/main/java/com/recurly/v3/exception/TooManyRequestsException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class TooManyRequestsException extends ClientException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public TooManyRequestsException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/TransactionException.java
+++ b/src/main/java/com/recurly/v3/exception/TransactionException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class TransactionException extends ApiException {
+public class TransactionException extends UnprocessableEntityException {
 
   public TransactionException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/UnauthorizedException.java
+++ b/src/main/java/com/recurly/v3/exception/UnauthorizedException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class UnauthorizedException extends ApiException {
+public class UnauthorizedException extends ClientException {
 
   public UnauthorizedException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/UnavailableInApiVersionException.java
+++ b/src/main/java/com/recurly/v3/exception/UnavailableInApiVersionException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class UnavailableInApiVersionException extends ApiException {
+public class UnavailableInApiVersionException extends NotAcceptableException {
 
   public UnavailableInApiVersionException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/UnknownApiVersionException.java
+++ b/src/main/java/com/recurly/v3/exception/UnknownApiVersionException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class UnknownApiVersionException extends ApiException {
+public class UnknownApiVersionException extends NotAcceptableException {
 
   public UnknownApiVersionException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/main/java/com/recurly/v3/exception/UnprocessableEntityException.java
+++ b/src/main/java/com/recurly/v3/exception/UnprocessableEntityException.java
@@ -7,9 +7,9 @@ package com.recurly.v3.exception;
 
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class RateLimitedException extends TooManyRequestsException {
+public class UnprocessableEntityException extends ClientException {
 
-  public RateLimitedException(String message, ErrorMayHaveTransaction e) {
+  public UnprocessableEntityException(String message, ErrorMayHaveTransaction e) {
     super(message, e);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ValidationException.java
+++ b/src/main/java/com/recurly/v3/exception/ValidationException.java
@@ -5,10 +5,9 @@
  */
 package com.recurly.v3.exception;
 
-import com.recurly.v3.ApiException;
 import com.recurly.v3.resources.ErrorMayHaveTransaction;
 
-public class ValidationException extends ApiException {
+public class ValidationException extends UnprocessableEntityException {
 
   public ValidationException(String message, ErrorMayHaveTransaction e) {
     super(message, e);

--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -160,6 +160,25 @@ public class BaseClientTest {
   }
 
   @Test
+  public void testNonJsonError0() throws IOException {
+    final Call mCall = mock(Call.class);
+    Answer answer = (i) -> { return mCall; };
+    Headers headers = new Headers.Builder().build();
+    MediaType contentType = MediaType.get("text/html; charset=UTF-8");
+    when(mCall.execute()).thenReturn(MockClient.buildResponse(0, "Not A Real Status", "<html>badness</html>", headers, contentType));
+
+    OkHttpClient mockOkHttpClient = MockClient.getMockOkHttpClient(answer);
+
+    final MockClient client = new MockClient("apiKey", mockOkHttpClient);
+
+    assertThrows(
+        ApiException.class,
+        () -> {
+          client.getResource("code-aaron");
+        });
+  }
+
+  @Test
   public void testNonJsonError500() throws IOException {
     final Call mCall = mock(Call.class);
     Answer answer = (i) -> { return mCall; };

--- a/src/test/java/com/recurly/v3/fixtures/MockClient.java
+++ b/src/test/java/com/recurly/v3/fixtures/MockClient.java
@@ -89,6 +89,11 @@ public class MockClient extends BaseClient {
   }
 
   public static final Response buildResponse(Integer code, String message, String response, Headers headers) {
+    MediaType contentType = MediaType.get("application/json; charset=utf-8");
+    return buildResponse(code, message, response, headers, contentType);
+  }
+
+  public static final Response buildResponse(Integer code, String message, String response, Headers headers, MediaType contentType) {
     final Request mRequest = new Request.Builder().url("https://v3.recurly.com").build();
 
     final Response mResponse =
@@ -97,7 +102,7 @@ public class MockClient extends BaseClient {
             .protocol(okhttp3.Protocol.HTTP_1_1)
             .code(code) // status code
             .message(message)
-            .body(ResponseBody.create(MediaType.get("application/json; charset=utf-8"), response))
+            .body(ResponseBody.create(contentType, response))
             .headers(headers)
             .build();
     return mResponse;


### PR DESCRIPTION
Non-breaking update to error classes to give them a hierarchical structure. This will facilitate differentiating between a `ClientException` and a `ServerException` for example.

New error classes have also been added to be parent classes for some existing errors (e.g. `ForbiddenException` is a new class and both `InvalidApiKeyException` and `InvalidPermissionsException` extend it)

Most importantly, this update allows the client library to gracefully handle non-json errors in the rare occasions when they occur. These errors will be based on the HTTP status code of the response and will fall back to the existing `ApiException` if there is not a defined mapping.
