### PR TITLE
Bump Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <okhttp3.version>3.14.8</okhttp3.version>
-        <surefire.version>3.0.0-M3</surefire.version>
+        <okhttp3.version>4.7.2</okhttp3.version>
+        <surefire.version>3.0.0-M4</surefire.version>
         <jacoco.version>0.8.5</jacoco.version>
     </properties>
 
@@ -226,7 +226,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.6</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -247,12 +247,12 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
+            <version>2.10.6</version>
         </dependency>
         <dependency>
             <groupId>com.fatboyindustrial.gson-jodatime-serialisers</groupId>
             <artifactId>gson-jodatime-serialisers</artifactId>
-            <version>1.6.0</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.surefire</groupId>
@@ -264,7 +264,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -277,13 +277,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.27.0</version>
+            <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
* Upgrades to okhttp 4 (we shouldn't be affected by breaking changes)
* Upgrades GSON and joda-time
* Upgrades testing libraries

**Passed** all smoke tests