### PR TITLE
Release 3.11.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.0
+current_version = 3.11.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -9,4 +9,3 @@ serialize =
 [bumpversion:file:pom.xml]
 
 [bumpversion:file:README.md]
-

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ As a Maven dependency:
 <dependency>
   <groupId>com.recurly.v3</groupId>
   <artifactId>api-client</artifactId>
-  <version>3.10.0</version>
+  <version>3.11.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation 'com.recurly.v3:api-client:3.10.0'
+implementation 'com.recurly.v3:api-client:3.11.0'
 ```
 
 You can find further release and distribution details on

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.recurly.v3</groupId>
     <artifactId>api-client</artifactId>
-    <version>3.10.0-SNAPSHOT</version>
+    <version>3.11.0-SNAPSHOT</version>
 
     <name>Recurly API V3 Java Client</name>
     <description>The official Java client for Recurly's V3 API.</description>


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-java/compare/3.10.0...HEAD)

**Implemented enhancements:**

- Fri Aug 21 16:23:02 UTC 2020 Upgrade API version v2019-10-10 [\#106](https://github.com/recurly/recurly-client-java/pull/106) ([douglasmiller](https://github.com/douglasmiller))