### PR TITLE
Test for fallback to generic api error

### DIFF
--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -1,10 +1,12 @@
 package com.recurly.v3;
 
+import com.recurly.v3.exception.ExceptionFactory;
 import com.recurly.v3.exception.InternalServerException;
 import com.recurly.v3.exception.InvalidApiKeyException;
 import com.recurly.v3.exception.NotFoundException;
 import com.recurly.v3.exception.TransactionException;
 import com.recurly.v3.exception.ValidationException;
+import com.recurly.v3.ApiException;
 import com.recurly.v3.fixtures.MockClient;
 import com.recurly.v3.fixtures.MockQueryParams;
 import com.recurly.v3.fixtures.MyRequest;
@@ -15,6 +17,7 @@ import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Response;
 
 import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
@@ -231,6 +234,26 @@ public class BaseClientTest {
         () -> {
           client.getResource("code-aaron");
         });
+  }
+
+  @Test
+  public void testUnknownError() throws IOException {
+    final Call mCall = mock(Call.class);
+    Answer answer = (i) -> { return mCall; };
+    final Response response = MockClient.buildResponse(999, "Unknown", getErrorJson("unknown"));
+    when(mCall.execute()).thenReturn(response);
+
+    OkHttpClient mockOkHttpClient = MockClient.getMockOkHttpClient(answer);
+
+    final MockClient client = new MockClient("apiKey", mockOkHttpClient);
+    // asserts that generic api exception is thrown for unknown error
+    assertThrows(
+        ApiException.class,
+        () -> {
+          client.getResource("code-aaron");
+        }); 
+    final RecurlyException exception = ExceptionFactory.getExceptionClass(response);
+    assertTrue(exception.toString().contains("ApiException"));
   }
 
   @Test


### PR DESCRIPTION
Add a test case to verify that unknown error types are thrown as a generic ApiException

See https://github.com/recurly/recurly-client-python/pull/372, https://github.com/recurly/recurly-client-ruby/pull/641 and https://github.com/recurly/recurly-client-dotnet/pull/587 for reference.