### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15154,7 +15154,7 @@ components:
           maxLength: 255
         company:
           type: string
-          maxLength: 50
+          maxLength: 100
         vat_number:
           type: string
           description: The VAT number of the account (to avoid having the VAT applied).
@@ -20079,6 +20079,13 @@ components:
             are provided the `plan_id` will be used.
         account:
           "$ref": "#/components/schemas/AccountCreate"
+        billing_info_id:
+          type: string
+          title: Billing Info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -21012,6 +21019,13 @@ components:
           maxLength: 3
         account:
           "$ref": "#/components/schemas/AccountPurchase"
+        billing_info_id:
+          type: string
+          title: Billing info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         collection_method:
           type: string
           title: Collection method

--- a/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
@@ -18,6 +18,15 @@ public class PurchaseCreate extends Request {
   private AccountPurchase account;
 
   /**
+   * The `billing_info_id` is the value that represents a specific billing info for an end customer.
+   * When `billing_info_id` is used to assign billing info to the subscription, all future billing
+   * events for the subscription will bill to the specified billing info.
+   */
+  @SerializedName("billing_info_id")
+  @Expose
+  private String billingInfoId;
+
+  /**
    * Must be set to manual in order to preview a purchase for an Account that does not have payment
    * information associated with the Billing Info.
    */
@@ -112,6 +121,25 @@ public class PurchaseCreate extends Request {
   /** @param account */
   public void setAccount(final AccountPurchase account) {
     this.account = account;
+  }
+
+  /**
+   * The `billing_info_id` is the value that represents a specific billing info for an end customer.
+   * When `billing_info_id` is used to assign billing info to the subscription, all future billing
+   * events for the subscription will bill to the specified billing info.
+   */
+  public String getBillingInfoId() {
+    return this.billingInfoId;
+  }
+
+  /**
+   * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
+   *     for an end customer. When `billing_info_id` is used to assign billing info to the
+   *     subscription, all future billing events for the subscription will bill to the specified
+   *     billing info.
+   */
+  public void setBillingInfoId(final String billingInfoId) {
+    this.billingInfoId = billingInfoId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -28,6 +28,15 @@ public class SubscriptionCreate extends Request {
   @Expose
   private Boolean autoRenew;
 
+  /**
+   * The `billing_info_id` is the value that represents a specific billing info for an end customer.
+   * When `billing_info_id` is used to assign billing info to the subscription, all future billing
+   * events for the subscription will bill to the specified billing info.
+   */
+  @SerializedName("billing_info_id")
+  @Expose
+  private String billingInfoId;
+
   /** Collection method */
   @SerializedName("collection_method")
   @Expose
@@ -215,6 +224,25 @@ public class SubscriptionCreate extends Request {
   /** @param autoRenew Whether the subscription renews at the end of its term. */
   public void setAutoRenew(final Boolean autoRenew) {
     this.autoRenew = autoRenew;
+  }
+
+  /**
+   * The `billing_info_id` is the value that represents a specific billing info for an end customer.
+   * When `billing_info_id` is used to assign billing info to the subscription, all future billing
+   * events for the subscription will bill to the specified billing info.
+   */
+  public String getBillingInfoId() {
+    return this.billingInfoId;
+  }
+
+  /**
+   * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
+   *     for an end customer. When `billing_info_id` is used to assign billing info to the
+   *     subscription, all future billing events for the subscription will bill to the specified
+   *     billing info.
+   */
+  public void setBillingInfoId(final String billingInfoId) {
+    this.billingInfoId = billingInfoId;
   }
 
   /** Collection method */


### PR DESCRIPTION
- Adds `billingInfoId` (with setters and getters) to `PurchaseCreate` and `SubscriptionCreate` requests.