### PR TITLE
Interpolate path pattern has capture parens in wrong place

### DIFF
--- a/src/main/java/com/recurly/v3/BaseClient.java
+++ b/src/main/java/com/recurly/v3/BaseClient.java
@@ -251,7 +251,7 @@ public abstract class BaseClient {
 
   protected String interpolatePath(String path, final HashMap<String, String> urlParams) {
     validatePathParameters(urlParams);
-    final Pattern p = Pattern.compile("\\{([A-Za-z|_]*)\\}");
+    final Pattern p = Pattern.compile("(\\{[A-Za-z|_]*\\})");
     final Matcher m = p.matcher(path);
 
     while (m.find()) {

--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -379,6 +379,17 @@ public class BaseClientTest {
         });
   }
 
+  @Test
+  public void testInterpolatePathMatching() {
+    final MockClient client = new MockClient("apiKey");
+    final String path = "/url_path/{url_path}";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("url_path", "replacement");
+
+    final String interpolatedPath = client.interpolatePath(path, urlParams);
+    assertEquals("/url_path/replacement", interpolatedPath);
+  }
+
   protected static void setEnv(Map<String, String> newenv) throws Exception {
     try {
       Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");


### PR DESCRIPTION
Fixing an issue with the pattern matching for path interpolation. This issue only impacts the Automated Exports endpoints currently.