### PR TITLE
Adds support for Enums where applicable

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14667,7 +14667,7 @@ components:
       in: query
       description: Filter by type field.
       schema:
-        "$ref": "#/components/schemas/LineItemTypeEnum"
+        "$ref": "#/components/schemas/LintItemTypeEnum"
     filter_transaction_type:
       name: type
       in: query
@@ -17602,7 +17602,7 @@ components:
           title: Line item type
           description: Charges are positive line items that debit the account. Credits
             are negative line items that credit the account.
-          "$ref": "#/components/schemas/LineItemTypeEnum"
+          "$ref": "#/components/schemas/LintItemTypeEnum"
         item_code:
           type: string
           title: Item Code
@@ -17923,7 +17923,7 @@ components:
           description: Line item type. If `item_code`/`item_id` is present then `type`
             should not be present. If `item_code`/`item_id` is not present then `type`
             is required.
-          "$ref": "#/components/schemas/LineItemTypeEnum"
+          "$ref": "#/components/schemas/LintItemTypeEnum"
         credit_reason_code:
           title: Credit reason code
           description: The reason the credit was given when line item is `type=credit`.
@@ -20718,7 +20718,7 @@ components:
       enum:
       - invoiced
       - pending
-    LineItemTypeEnum:
+    LintItemTypeEnum:
       type: string
       enum:
       - charge

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -1489,7 +1489,7 @@ paths:
           try {
               final AccountAcquisitionUpdatable acqUpdate = new AccountAcquisitionUpdatable();
               acqUpdate.setCampaign("big-event-campaign");
-              acqUpdate.setChannel("social_media");
+              acqUpdate.setChannel(Constants.Channel.SOCIAL_MEDIA);
               acqUpdate.setSubchannel("twitter");
 
               final AccountAcquisition accountAcquisition = client.updateAccountAcquisition(accountId, acqUpdate);
@@ -3241,7 +3241,7 @@ paths:
           try {
               InvoiceCreate invoiceCreate = new InvoiceCreate();
               invoiceCreate.setCurrency("USD");
-              invoiceCreate.setCollectionMethod("automatic");
+              invoiceCreate.setCollectionMethod(Constants.CollectionMethod.AUTOMATIC);
 
               InvoiceCollection collection = client.createInvoice(accountId, invoiceCreate);
               System.out.println("Created Invoice");
@@ -3412,7 +3412,7 @@ paths:
           try {
               InvoiceCreate invoiceCreate = new InvoiceCreate();
               invoiceCreate.setCurrency("USD");
-              invoiceCreate.setCollectionMethod("automatic");
+              invoiceCreate.setCollectionMethod(Constants.CollectionMethod.AUTOMATIC);
 
               InvoiceCollection collection = client.previewInvoice(accountId, invoiceCreate);
               System.out.println("Previewed Invoice due at " + collection.getChargeInvoice().getDueAt());
@@ -3690,7 +3690,7 @@ paths:
               LineItemCreate lineItemCreate = new LineItemCreate();
               lineItemCreate.setCurrency("USD");
               lineItemCreate.setUnitAmount(1000.0f);
-              lineItemCreate.setType("charge"); // choose "credit" for a credit
+              lineItemCreate.setType(Constants.LineItemType.CHARGE); // choose "credit" for a credit
 
               LineItem lineItem = client.createLineItem(accountId, lineItemCreate);
               System.out.println("Created line item " + lineItem.getUuid());
@@ -5296,7 +5296,7 @@ paths:
               currencies.add(couponPrice);
 
               couponCreate.setCurrencies(currencies);
-              couponCreate.setDiscountType("fixed");
+              couponCreate.setDiscountType(Constants.DiscountType.FIXED);
 
               Coupon coupon = client.createCoupon(couponCreate);
               System.out.println("Created coupon " + coupon.getCode());
@@ -6475,7 +6475,7 @@ paths:
               itemReq.setDescription("Item Description");
               itemReq.setExternalSku("a35JE-44");
               itemReq.setAccountingCode("item-code-127");
-              itemReq.setRevenueScheduleType("at_range_end");
+              itemReq.setRevenueScheduleType(Constants.RevenueScheduleType.AT_RANGE_END);
 
               List<CustomField> customFields = new ArrayList<>();
               CustomField customField = new CustomField();
@@ -8862,7 +8862,7 @@ paths:
           try {
               final InvoiceRefund invoiceRefund = new InvoiceRefund();
               invoiceRefund.setCreditCustomerNotes("Notes on credits");
-              invoiceRefund.setType("amount"); // could also be "line_items"
+              invoiceRefund.setType(Constants.InvoiceRefundType.AMOUNT); // could also be "line_items"
               invoiceRefund.setAmount(100f);
 
               final Invoice invoice = client.refundInvoice(invoiceId, invoiceRefund);
@@ -11744,7 +11744,7 @@ paths:
         source: |
           try {
               QueryParams queryParams = new QueryParams();
-              queryParams.setRefund("none"); // "full" for a full refund, "partial" for prorated refund
+              queryParams.setRefund(Constants.RefundType.NONE); // "full" for a full refund, "partial" for prorated refund
               client.terminateSubscription(subscriptionId, queryParams);
               System.out.println("Terminated Subscription: " + subscriptionId);
           } catch (ValidationException e) {
@@ -12629,7 +12629,7 @@ paths:
               SubscriptionChangeCreate changeCreate = new SubscriptionChangeCreate();
 
               changeCreate.setPlanCode(newPlanCode);
-              changeCreate.setTimeframe("now"); // choose "now" or "renewal"
+              changeCreate.setTimeframe(Constants.ChangeTimeframe.NOW); // choose "now" or "renewal"
 
               SubscriptionChange change = client.createSubscriptionChange(subscriptionId, changeCreate);
               System.out.println("Created subscription " + change.getId());
@@ -14667,7 +14667,7 @@ components:
       in: query
       description: Filter by type field.
       schema:
-        "$ref": "#/components/schemas/LintItemTypeEnum"
+        "$ref": "#/components/schemas/LineItemTypeEnum"
     filter_transaction_type:
       name: type
       in: query
@@ -16134,8 +16134,8 @@ components:
             Brazilian tax identifier for all tax paying residents.
         tax_identifier_type:
           type: string
-          enum: 
-          "$ref": "#/components/schemas/TaxIdentifierTypeEnum"
+          enum:
+            "$ref": "#/components/schemas/TaxIdentifierTypeEnum"
           description: this field and a value of 'cpf' are required if adding a billing
             info that is an elo or hipercard type in Brazil.
         primary_payment_method:
@@ -17602,7 +17602,7 @@ components:
           title: Line item type
           description: Charges are positive line items that debit the account. Credits
             are negative line items that credit the account.
-          "$ref": "#/components/schemas/LintItemTypeEnum"
+          "$ref": "#/components/schemas/LineItemTypeEnum"
         item_code:
           type: string
           title: Item Code
@@ -17923,7 +17923,7 @@ components:
           description: Line item type. If `item_code`/`item_id` is present then `type`
             should not be present. If `item_code`/`item_id` is not present then `type`
             is required.
-          "$ref": "#/components/schemas/LintItemTypeEnum"
+          "$ref": "#/components/schemas/LineItemTypeEnum"
         credit_reason_code:
           title: Credit reason code
           description: The reason the credit was given when line item is `type=credit`.
@@ -18534,6 +18534,22 @@ components:
             cannot be provided.
       required:
       - currency
+    TierPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          minimum: 0
+          maximum: 1000000
+      required:
+      - currency
     Pricing:
       type: object
       properties:
@@ -18564,7 +18580,7 @@ components:
           type: array
           title: Tier pricing
           items:
-            "$ref": "#/components/schemas/Pricing"
+            "$ref": "#/components/schemas/TierPricing"
           minItems: 1
       required:
       - currencies
@@ -20702,7 +20718,7 @@ components:
       enum:
       - invoiced
       - pending
-    LintItemTypeEnum:
+    LineItemTypeEnum:
       type: string
       enum:
       - charge

--- a/scripts/clean
+++ b/scripts/clean
@@ -2,6 +2,7 @@
 
 rm -f src/main/java/com/recurly/v3/Client.java
 rm -f src/main/java/com/recurly/v3/QueryParams.java
+rm -f src/main/java/com/recurly/v3/Constants.java
 rm -f src/main/java/com/recurly/v3/requests/*
 rm -f src/main/java/com/recurly/v3/resources/*
 rm -f src/main/java/com/recurly/v3/exception/*

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -1,0 +1,1758 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Constants {
+  
+    public enum RelatedType {
+      UNDEFINED,
+    
+      @SerializedName("account")
+      ACCOUNT,
+    
+      @SerializedName("item")
+      ITEM,
+    
+      @SerializedName("subscription")
+      SUBSCRIPTION,
+    
+    };
+  
+    public enum RefundType {
+      UNDEFINED,
+    
+      @SerializedName("full")
+      FULL,
+    
+      @SerializedName("none")
+      NONE,
+    
+      @SerializedName("partial")
+      PARTIAL,
+    
+    };
+  
+    public enum AlphanumericSort {
+      UNDEFINED,
+    
+      @SerializedName("asc")
+      ASC,
+    
+      @SerializedName("desc")
+      DESC,
+    
+    };
+  
+    public enum UsageSort {
+      UNDEFINED,
+    
+      @SerializedName("recorded_timestamp")
+      RECORDED_TIMESTAMP,
+    
+      @SerializedName("usage_timestamp")
+      USAGE_TIMESTAMP,
+    
+    };
+  
+    public enum UsageType {
+      UNDEFINED,
+    
+      @SerializedName("price")
+      PRICE,
+    
+      @SerializedName("percentage")
+      PERCENTAGE,
+    
+    };
+  
+    public enum BillingStatus {
+      UNDEFINED,
+    
+      @SerializedName("unbilled")
+      UNBILLED,
+    
+      @SerializedName("billed")
+      BILLED,
+    
+      @SerializedName("all")
+      ALL,
+    
+    };
+  
+    public enum TimestampSort {
+      UNDEFINED,
+    
+      @SerializedName("created_at")
+      CREATED_AT,
+    
+      @SerializedName("updated_at")
+      UPDATED_AT,
+    
+    };
+  
+    public enum ActiveState {
+      UNDEFINED,
+    
+      @SerializedName("active")
+      ACTIVE,
+    
+      @SerializedName("inactive")
+      INACTIVE,
+    
+    };
+  
+    public enum FilterSubscriptionState {
+      UNDEFINED,
+    
+      @SerializedName("active")
+      ACTIVE,
+    
+      @SerializedName("canceled")
+      CANCELED,
+    
+      @SerializedName("expired")
+      EXPIRED,
+    
+      @SerializedName("future")
+      FUTURE,
+    
+      @SerializedName("in_trial")
+      IN_TRIAL,
+    
+      @SerializedName("live")
+      LIVE,
+    
+    };
+  
+    public enum True {
+      UNDEFINED,
+    
+      @SerializedName("true")
+      TRUE,
+    
+    };
+  
+    public enum LineItemState {
+      UNDEFINED,
+    
+      @SerializedName("invoiced")
+      INVOICED,
+    
+      @SerializedName("pending")
+      PENDING,
+    
+    };
+  
+    public enum LineItemType {
+      UNDEFINED,
+    
+      @SerializedName("charge")
+      CHARGE,
+    
+      @SerializedName("credit")
+      CREDIT,
+    
+    };
+  
+    public enum FilterTransactionType {
+      UNDEFINED,
+    
+      @SerializedName("authorization")
+      AUTHORIZATION,
+    
+      @SerializedName("capture")
+      CAPTURE,
+    
+      @SerializedName("payment")
+      PAYMENT,
+    
+      @SerializedName("purchase")
+      PURCHASE,
+    
+      @SerializedName("refund")
+      REFUND,
+    
+      @SerializedName("verify")
+      VERIFY,
+    
+    };
+  
+    public enum FilterInvoiceType {
+      UNDEFINED,
+    
+      @SerializedName("charge")
+      CHARGE,
+    
+      @SerializedName("credit")
+      CREDIT,
+    
+      @SerializedName("legacy")
+      LEGACY,
+    
+      @SerializedName("non-legacy")
+      NON_LEGACY,
+    
+    };
+  
+    public enum Channel {
+      UNDEFINED,
+    
+      @SerializedName("advertising")
+      ADVERTISING,
+    
+      @SerializedName("blog")
+      BLOG,
+    
+      @SerializedName("direct_traffic")
+      DIRECT_TRAFFIC,
+    
+      @SerializedName("email")
+      EMAIL,
+    
+      @SerializedName("events")
+      EVENTS,
+    
+      @SerializedName("marketing_content")
+      MARKETING_CONTENT,
+    
+      @SerializedName("organic_search")
+      ORGANIC_SEARCH,
+    
+      @SerializedName("other")
+      OTHER,
+    
+      @SerializedName("outbound_sales")
+      OUTBOUND_SALES,
+    
+      @SerializedName("paid_search")
+      PAID_SEARCH,
+    
+      @SerializedName("public_relations")
+      PUBLIC_RELATIONS,
+    
+      @SerializedName("referral")
+      REFERRAL,
+    
+      @SerializedName("social_media")
+      SOCIAL_MEDIA,
+    
+    };
+  
+    public enum PreferredLocale {
+      UNDEFINED,
+    
+      @SerializedName("da-DK")
+      DA_DK,
+    
+      @SerializedName("de-CH")
+      DE_CH,
+    
+      @SerializedName("de-DE")
+      DE_DE,
+    
+      @SerializedName("en-AU")
+      EN_AU,
+    
+      @SerializedName("en-CA")
+      EN_CA,
+    
+      @SerializedName("en-GB")
+      EN_GB,
+    
+      @SerializedName("en-NZ")
+      EN_NZ,
+    
+      @SerializedName("en-US")
+      EN_US,
+    
+      @SerializedName("es-ES")
+      ES_ES,
+    
+      @SerializedName("es-MX")
+      ES_MX,
+    
+      @SerializedName("es-US")
+      ES_US,
+    
+      @SerializedName("fr-CA")
+      FR_CA,
+    
+      @SerializedName("fr-FR")
+      FR_FR,
+    
+      @SerializedName("hi-IN")
+      HI_IN,
+    
+      @SerializedName("ja-JP")
+      JA_JP,
+    
+      @SerializedName("nl-BE")
+      NL_BE,
+    
+      @SerializedName("nl-NL")
+      NL_NL,
+    
+      @SerializedName("pt-BR")
+      PT_BR,
+    
+      @SerializedName("pt-PT")
+      PT_PT,
+    
+      @SerializedName("ru-RU")
+      RU_RU,
+    
+      @SerializedName("tr-TR")
+      TR_TR,
+    
+      @SerializedName("zh-CN")
+      ZH_CN,
+    
+    };
+  
+    public enum BillTo {
+      UNDEFINED,
+    
+      @SerializedName("parent")
+      PARENT,
+    
+      @SerializedName("self")
+      SELF,
+    
+    };
+  
+    public enum GatewayTransactionType {
+      UNDEFINED,
+    
+      @SerializedName("moto")
+      MOTO,
+    
+    };
+  
+    public enum KountDecision {
+      UNDEFINED,
+    
+      @SerializedName("approve")
+      APPROVE,
+    
+      @SerializedName("decline")
+      DECLINE,
+    
+      @SerializedName("escalate")
+      ESCALATE,
+    
+      @SerializedName("review")
+      REVIEW,
+    
+    };
+  
+    public enum CouponState {
+      UNDEFINED,
+    
+      @SerializedName("expired")
+      EXPIRED,
+    
+      @SerializedName("maxed_out")
+      MAXED_OUT,
+    
+      @SerializedName("redeemable")
+      REDEEMABLE,
+    
+    };
+  
+    public enum CouponDuration {
+      UNDEFINED,
+    
+      @SerializedName("forever")
+      FOREVER,
+    
+      @SerializedName("single_use")
+      SINGLE_USE,
+    
+      @SerializedName("temporal")
+      TEMPORAL,
+    
+    };
+  
+    public enum TemporalUnit {
+      UNDEFINED,
+    
+      @SerializedName("day")
+      DAY,
+    
+      @SerializedName("month")
+      MONTH,
+    
+      @SerializedName("week")
+      WEEK,
+    
+      @SerializedName("year")
+      YEAR,
+    
+    };
+  
+    public enum FreeTrialUnit {
+      UNDEFINED,
+    
+      @SerializedName("day")
+      DAY,
+    
+      @SerializedName("month")
+      MONTH,
+    
+      @SerializedName("week")
+      WEEK,
+    
+    };
+  
+    public enum RedemptionResource {
+      UNDEFINED,
+    
+      @SerializedName("account")
+      ACCOUNT,
+    
+      @SerializedName("subscription")
+      SUBSCRIPTION,
+    
+    };
+  
+    public enum CouponType {
+      UNDEFINED,
+    
+      @SerializedName("bulk")
+      BULK,
+    
+      @SerializedName("single_code")
+      SINGLE_CODE,
+    
+    };
+  
+    public enum DiscountType {
+      UNDEFINED,
+    
+      @SerializedName("fixed")
+      FIXED,
+    
+      @SerializedName("free_trial")
+      FREE_TRIAL,
+    
+      @SerializedName("percent")
+      PERCENT,
+    
+    };
+  
+    public enum AddOnSource {
+      UNDEFINED,
+    
+      @SerializedName("plan_add_on")
+      PLAN_ADD_ON,
+    
+      @SerializedName("item")
+      ITEM,
+    
+    };
+  
+    public enum AddOnType {
+      UNDEFINED,
+    
+      @SerializedName("fixed")
+      FIXED,
+    
+      @SerializedName("usage")
+      USAGE,
+    
+    };
+  
+    public enum AddOnTypeCreate {
+      UNDEFINED,
+    
+      @SerializedName("fixed")
+      FIXED,
+    
+      @SerializedName("usage")
+      USAGE,
+    
+    };
+  
+    public enum UsageTypeCreate {
+      UNDEFINED,
+    
+      @SerializedName("price")
+      PRICE,
+    
+      @SerializedName("percentage")
+      PERCENTAGE,
+    
+    };
+  
+    public enum TierType {
+      UNDEFINED,
+    
+      @SerializedName("flat")
+      FLAT,
+    
+      @SerializedName("tiered")
+      TIERED,
+    
+      @SerializedName("stairstep")
+      STAIRSTEP,
+    
+      @SerializedName("volume")
+      VOLUME,
+    
+    };
+  
+    public enum CreditPaymentAction {
+      UNDEFINED,
+    
+      @SerializedName("payment")
+      PAYMENT,
+    
+      @SerializedName("reduction")
+      REDUCTION,
+    
+      @SerializedName("refund")
+      REFUND,
+    
+      @SerializedName("write_off")
+      WRITE_OFF,
+    
+    };
+  
+    public enum UserAccess {
+      UNDEFINED,
+    
+      @SerializedName("api_only")
+      API_ONLY,
+    
+      @SerializedName("read_only")
+      READ_ONLY,
+    
+      @SerializedName("write")
+      WRITE,
+    
+    };
+  
+    public enum RevenueScheduleType {
+      UNDEFINED,
+    
+      @SerializedName("at_range_end")
+      AT_RANGE_END,
+    
+      @SerializedName("at_range_start")
+      AT_RANGE_START,
+    
+      @SerializedName("evenly")
+      EVENLY,
+    
+      @SerializedName("never")
+      NEVER,
+    
+    };
+  
+    public enum InvoiceType {
+      UNDEFINED,
+    
+      @SerializedName("charge")
+      CHARGE,
+    
+      @SerializedName("credit")
+      CREDIT,
+    
+      @SerializedName("legacy")
+      LEGACY,
+    
+    };
+  
+    public enum Origin {
+      UNDEFINED,
+    
+      @SerializedName("credit")
+      CREDIT,
+    
+      @SerializedName("gift_card")
+      GIFT_CARD,
+    
+      @SerializedName("immediate_change")
+      IMMEDIATE_CHANGE,
+    
+      @SerializedName("line_item_refund")
+      LINE_ITEM_REFUND,
+    
+      @SerializedName("open_amount_refund")
+      OPEN_AMOUNT_REFUND,
+    
+      @SerializedName("purchase")
+      PURCHASE,
+    
+      @SerializedName("renewal")
+      RENEWAL,
+    
+      @SerializedName("termination")
+      TERMINATION,
+    
+      @SerializedName("write_off")
+      WRITE_OFF,
+    
+      @SerializedName("prepayment")
+      PREPAYMENT,
+    
+    };
+  
+    public enum InvoiceState {
+      UNDEFINED,
+    
+      @SerializedName("open")
+      OPEN,
+    
+      @SerializedName("pending")
+      PENDING,
+    
+      @SerializedName("processing")
+      PROCESSING,
+    
+      @SerializedName("past_due")
+      PAST_DUE,
+    
+      @SerializedName("paid")
+      PAID,
+    
+      @SerializedName("closed")
+      CLOSED,
+    
+      @SerializedName("failed")
+      FAILED,
+    
+      @SerializedName("voided")
+      VOIDED,
+    
+    };
+  
+    public enum CollectionMethod {
+      UNDEFINED,
+    
+      @SerializedName("automatic")
+      AUTOMATIC,
+    
+      @SerializedName("manual")
+      MANUAL,
+    
+    };
+  
+    public enum InvoiceRefundType {
+      UNDEFINED,
+    
+      @SerializedName("amount")
+      AMOUNT,
+    
+      @SerializedName("line_items")
+      LINE_ITEMS,
+    
+    };
+  
+    public enum RefuneMethod {
+      UNDEFINED,
+    
+      @SerializedName("all_credit")
+      ALL_CREDIT,
+    
+      @SerializedName("all_transaction")
+      ALL_TRANSACTION,
+    
+      @SerializedName("credit_first")
+      CREDIT_FIRST,
+    
+      @SerializedName("transaction_first")
+      TRANSACTION_FIRST,
+    
+    };
+  
+    public enum ExternalPaymentMethod {
+      UNDEFINED,
+    
+      @SerializedName("ach")
+      ACH,
+    
+      @SerializedName("amazon")
+      AMAZON,
+    
+      @SerializedName("apple_pay")
+      APPLE_PAY,
+    
+      @SerializedName("check")
+      CHECK,
+    
+      @SerializedName("credit_card")
+      CREDIT_CARD,
+    
+      @SerializedName("eft")
+      EFT,
+    
+      @SerializedName("money_order")
+      MONEY_ORDER,
+    
+      @SerializedName("other")
+      OTHER,
+    
+      @SerializedName("paypal")
+      PAYPAL,
+    
+      @SerializedName("roku")
+      ROKU,
+    
+      @SerializedName("sepadirectdebit")
+      SEPADIRECTDEBIT,
+    
+      @SerializedName("wire_transfer")
+      WIRE_TRANSFER,
+    
+    };
+  
+    public enum LineItemRevenueScheduleType {
+      UNDEFINED,
+    
+      @SerializedName("at_invoice")
+      AT_INVOICE,
+    
+      @SerializedName("at_range_end")
+      AT_RANGE_END,
+    
+      @SerializedName("at_range_start")
+      AT_RANGE_START,
+    
+      @SerializedName("evenly")
+      EVENLY,
+    
+      @SerializedName("never")
+      NEVER,
+    
+    };
+  
+    public enum LegacyCategory {
+      UNDEFINED,
+    
+      @SerializedName("applied_credit")
+      APPLIED_CREDIT,
+    
+      @SerializedName("carryforward")
+      CARRYFORWARD,
+    
+      @SerializedName("charge")
+      CHARGE,
+    
+      @SerializedName("credit")
+      CREDIT,
+    
+    };
+  
+    public enum LineItemOrigin {
+      UNDEFINED,
+    
+      @SerializedName("add_on")
+      ADD_ON,
+    
+      @SerializedName("add_on_trial")
+      ADD_ON_TRIAL,
+    
+      @SerializedName("carryforward")
+      CARRYFORWARD,
+    
+      @SerializedName("coupon")
+      COUPON,
+    
+      @SerializedName("credit")
+      CREDIT,
+    
+      @SerializedName("debit")
+      DEBIT,
+    
+      @SerializedName("one_time")
+      ONE_TIME,
+    
+      @SerializedName("plan")
+      PLAN,
+    
+      @SerializedName("plan_trial")
+      PLAN_TRIAL,
+    
+      @SerializedName("setup_fee")
+      SETUP_FEE,
+    
+      @SerializedName("prepayment")
+      PREPAYMENT,
+    
+    };
+  
+    public enum FullCreditReasonCode {
+      UNDEFINED,
+    
+      @SerializedName("general")
+      GENERAL,
+    
+      @SerializedName("gift_card")
+      GIFT_CARD,
+    
+      @SerializedName("promotional")
+      PROMOTIONAL,
+    
+      @SerializedName("refund")
+      REFUND,
+    
+      @SerializedName("service")
+      SERVICE,
+    
+      @SerializedName("write_off")
+      WRITE_OFF,
+    
+    };
+  
+    public enum PartialCreditReasonCode {
+      UNDEFINED,
+    
+      @SerializedName("general")
+      GENERAL,
+    
+      @SerializedName("promotional")
+      PROMOTIONAL,
+    
+      @SerializedName("service")
+      SERVICE,
+    
+    };
+  
+    public enum LineItemCreateOrigin {
+      UNDEFINED,
+    
+      @SerializedName("external_gift_card")
+      EXTERNAL_GIFT_CARD,
+    
+      @SerializedName("prepayment")
+      PREPAYMENT,
+    
+    };
+  
+    public enum IntervalUnit {
+      UNDEFINED,
+    
+      @SerializedName("days")
+      DAYS,
+    
+      @SerializedName("months")
+      MONTHS,
+    
+    };
+  
+    public enum AddressRequirement {
+      UNDEFINED,
+    
+      @SerializedName("full")
+      FULL,
+    
+      @SerializedName("none")
+      NONE,
+    
+      @SerializedName("streetzip")
+      STREETZIP,
+    
+      @SerializedName("zip")
+      ZIP,
+    
+    };
+  
+    public enum SiteMode {
+      UNDEFINED,
+    
+      @SerializedName("development")
+      DEVELOPMENT,
+    
+      @SerializedName("production")
+      PRODUCTION,
+    
+      @SerializedName("sandbox")
+      SANDBOX,
+    
+    };
+  
+    public enum Features {
+      UNDEFINED,
+    
+      @SerializedName("credit_memos")
+      CREDIT_MEMOS,
+    
+      @SerializedName("manual_invoicing")
+      MANUAL_INVOICING,
+    
+      @SerializedName("only_bill_what_changed")
+      ONLY_BILL_WHAT_CHANGED,
+    
+      @SerializedName("subscription_terms")
+      SUBSCRIPTION_TERMS,
+    
+    };
+  
+    public enum SubscriptionState {
+      UNDEFINED,
+    
+      @SerializedName("active")
+      ACTIVE,
+    
+      @SerializedName("canceled")
+      CANCELED,
+    
+      @SerializedName("expired")
+      EXPIRED,
+    
+      @SerializedName("failed")
+      FAILED,
+    
+      @SerializedName("future")
+      FUTURE,
+    
+      @SerializedName("paused")
+      PAUSED,
+    
+    };
+  
+    public enum Timeframe {
+      UNDEFINED,
+    
+      @SerializedName("bill_date")
+      BILL_DATE,
+    
+      @SerializedName("term_end")
+      TERM_END,
+    
+    };
+  
+    public enum ChangeTimeframe {
+      UNDEFINED,
+    
+      @SerializedName("bill_date")
+      BILL_DATE,
+    
+      @SerializedName("now")
+      NOW,
+    
+      @SerializedName("renewal")
+      RENEWAL,
+    
+      @SerializedName("term_end")
+      TERM_END,
+    
+    };
+  
+    public enum TransactionType {
+      UNDEFINED,
+    
+      @SerializedName("authorization")
+      AUTHORIZATION,
+    
+      @SerializedName("capture")
+      CAPTURE,
+    
+      @SerializedName("purchase")
+      PURCHASE,
+    
+      @SerializedName("refund")
+      REFUND,
+    
+      @SerializedName("verify")
+      VERIFY,
+    
+    };
+  
+    public enum TransactionOrigin {
+      UNDEFINED,
+    
+      @SerializedName("api")
+      API,
+    
+      @SerializedName("chargeback")
+      CHARGEBACK,
+    
+      @SerializedName("force_collect")
+      FORCE_COLLECT,
+    
+      @SerializedName("hpp")
+      HPP,
+    
+      @SerializedName("merchant")
+      MERCHANT,
+    
+      @SerializedName("recurly_admin")
+      RECURLY_ADMIN,
+    
+      @SerializedName("recurlyjs")
+      RECURLYJS,
+    
+      @SerializedName("recurring")
+      RECURRING,
+    
+      @SerializedName("refunded_externally")
+      REFUNDED_EXTERNALLY,
+    
+      @SerializedName("transparent")
+      TRANSPARENT,
+    
+    };
+  
+    public enum TransactionStatus {
+      UNDEFINED,
+    
+      @SerializedName("chargeback")
+      CHARGEBACK,
+    
+      @SerializedName("declined")
+      DECLINED,
+    
+      @SerializedName("error")
+      ERROR,
+    
+      @SerializedName("pending")
+      PENDING,
+    
+      @SerializedName("processing")
+      PROCESSING,
+    
+      @SerializedName("scheduled")
+      SCHEDULED,
+    
+      @SerializedName("success")
+      SUCCESS,
+    
+      @SerializedName("void")
+      VOID,
+    
+    };
+  
+    public enum CvvCheck {
+      UNDEFINED,
+    
+      @SerializedName("D")
+      D,
+    
+      @SerializedName("I")
+      I,
+    
+      @SerializedName("M")
+      M,
+    
+      @SerializedName("N")
+      N,
+    
+      @SerializedName("P")
+      P,
+    
+      @SerializedName("S")
+      S,
+    
+      @SerializedName("U")
+      U,
+    
+      @SerializedName("X")
+      X,
+    
+    };
+  
+    public enum AvsCheck {
+      UNDEFINED,
+    
+      @SerializedName("A")
+      A,
+    
+      @SerializedName("B")
+      B,
+    
+      @SerializedName("C")
+      C,
+    
+      @SerializedName("D")
+      D,
+    
+      @SerializedName("E")
+      E,
+    
+      @SerializedName("F")
+      F,
+    
+      @SerializedName("G")
+      G,
+    
+      @SerializedName("H")
+      H,
+    
+      @SerializedName("I")
+      I,
+    
+      @SerializedName("J")
+      J,
+    
+      @SerializedName("K")
+      K,
+    
+      @SerializedName("L")
+      L,
+    
+      @SerializedName("M")
+      M,
+    
+      @SerializedName("N")
+      N,
+    
+      @SerializedName("O")
+      O,
+    
+      @SerializedName("P")
+      P,
+    
+      @SerializedName("Q")
+      Q,
+    
+      @SerializedName("R")
+      R,
+    
+      @SerializedName("S")
+      S,
+    
+      @SerializedName("T")
+      T,
+    
+      @SerializedName("U")
+      U,
+    
+      @SerializedName("V")
+      V,
+    
+      @SerializedName("W")
+      W,
+    
+      @SerializedName("X")
+      X,
+    
+      @SerializedName("Y")
+      Y,
+    
+      @SerializedName("Z")
+      Z,
+    
+    };
+  
+    public enum CouponCodeState {
+      UNDEFINED,
+    
+      @SerializedName("expired")
+      EXPIRED,
+    
+      @SerializedName("inactive")
+      INACTIVE,
+    
+      @SerializedName("maxed_out")
+      MAXED_OUT,
+    
+      @SerializedName("redeemable")
+      REDEEMABLE,
+    
+    };
+  
+    public enum PaymentMethod {
+      UNDEFINED,
+    
+      @SerializedName("amazon")
+      AMAZON,
+    
+      @SerializedName("amazon_billing_agreement")
+      AMAZON_BILLING_AGREEMENT,
+    
+      @SerializedName("apple_pay")
+      APPLE_PAY,
+    
+      @SerializedName("bank_account_info")
+      BANK_ACCOUNT_INFO,
+    
+      @SerializedName("check")
+      CHECK,
+    
+      @SerializedName("credit_card")
+      CREDIT_CARD,
+    
+      @SerializedName("eft")
+      EFT,
+    
+      @SerializedName("gateway_token")
+      GATEWAY_TOKEN,
+    
+      @SerializedName("iban_bank_account")
+      IBAN_BANK_ACCOUNT,
+    
+      @SerializedName("money_order")
+      MONEY_ORDER,
+    
+      @SerializedName("other")
+      OTHER,
+    
+      @SerializedName("paypal")
+      PAYPAL,
+    
+      @SerializedName("paypal_billing_agreement")
+      PAYPAL_BILLING_AGREEMENT,
+    
+      @SerializedName("roku")
+      ROKU,
+    
+      @SerializedName("sepadirectdebit")
+      SEPADIRECTDEBIT,
+    
+      @SerializedName("wire_transfer")
+      WIRE_TRANSFER,
+    
+    };
+  
+    public enum CardType {
+      UNDEFINED,
+    
+      @SerializedName("American Express")
+      AMERICAN_EXPRESS,
+    
+      @SerializedName("Dankort")
+      DANKORT,
+    
+      @SerializedName("Diners Club")
+      DINERS_CLUB,
+    
+      @SerializedName("Discover")
+      DISCOVER,
+    
+      @SerializedName("Forbrugsforeningen")
+      FORBRUGSFORENINGEN,
+    
+      @SerializedName("JCB")
+      JCB,
+    
+      @SerializedName("Laser")
+      LASER,
+    
+      @SerializedName("Maestro")
+      MAESTRO,
+    
+      @SerializedName("MasterCard")
+      MASTERCARD,
+    
+      @SerializedName("Test Card")
+      TEST_CARD,
+    
+      @SerializedName("Union Pay")
+      UNION_PAY,
+    
+      @SerializedName("Unknown")
+      UNKNOWN,
+    
+      @SerializedName("Visa")
+      VISA,
+    
+    };
+  
+    public enum AccountType {
+      UNDEFINED,
+    
+      @SerializedName("checking")
+      CHECKING,
+    
+      @SerializedName("savings")
+      SAVINGS,
+    
+    };
+  
+    public enum ErrorType {
+      UNDEFINED,
+    
+      @SerializedName("bad_request")
+      BAD_REQUEST,
+    
+      @SerializedName("immutable_subscription")
+      IMMUTABLE_SUBSCRIPTION,
+    
+      @SerializedName("internal_server_error")
+      INTERNAL_SERVER_ERROR,
+    
+      @SerializedName("invalid_api_key")
+      INVALID_API_KEY,
+    
+      @SerializedName("invalid_api_version")
+      INVALID_API_VERSION,
+    
+      @SerializedName("invalid_content_type")
+      INVALID_CONTENT_TYPE,
+    
+      @SerializedName("invalid_permissions")
+      INVALID_PERMISSIONS,
+    
+      @SerializedName("invalid_token")
+      INVALID_TOKEN,
+    
+      @SerializedName("missing_feature")
+      MISSING_FEATURE,
+    
+      @SerializedName("not_found")
+      NOT_FOUND,
+    
+      @SerializedName("rate_limited")
+      RATE_LIMITED,
+    
+      @SerializedName("service_not_available")
+      SERVICE_NOT_AVAILABLE,
+    
+      @SerializedName("simultaneous_request")
+      SIMULTANEOUS_REQUEST,
+    
+      @SerializedName("transaction")
+      TRANSACTION,
+    
+      @SerializedName("unauthorized")
+      UNAUTHORIZED,
+    
+      @SerializedName("unavailable_in_api_version")
+      UNAVAILABLE_IN_API_VERSION,
+    
+      @SerializedName("unknown_api_version")
+      UNKNOWN_API_VERSION,
+    
+      @SerializedName("validation")
+      VALIDATION,
+    
+    };
+  
+    public enum ErrorCategory {
+      UNDEFINED,
+    
+      @SerializedName("three_d_secure_required")
+      THREE_D_SECURE_REQUIRED,
+    
+      @SerializedName("three_d_secure_action_required")
+      THREE_D_SECURE_ACTION_REQUIRED,
+    
+      @SerializedName("amazon")
+      AMAZON,
+    
+      @SerializedName("api_error")
+      API_ERROR,
+    
+      @SerializedName("approved")
+      APPROVED,
+    
+      @SerializedName("communication")
+      COMMUNICATION,
+    
+      @SerializedName("configuration")
+      CONFIGURATION,
+    
+      @SerializedName("duplicate")
+      DUPLICATE,
+    
+      @SerializedName("fraud")
+      FRAUD,
+    
+      @SerializedName("hard")
+      HARD,
+    
+      @SerializedName("invalid")
+      INVALID,
+    
+      @SerializedName("not_enabled")
+      NOT_ENABLED,
+    
+      @SerializedName("not_supported")
+      NOT_SUPPORTED,
+    
+      @SerializedName("recurly")
+      RECURLY,
+    
+      @SerializedName("referral")
+      REFERRAL,
+    
+      @SerializedName("skles")
+      SKLES,
+    
+      @SerializedName("soft")
+      SOFT,
+    
+      @SerializedName("unknown")
+      UNKNOWN,
+    
+    };
+  
+    public enum ErrorCode {
+      UNDEFINED,
+    
+      @SerializedName("ach_cancel")
+      ACH_CANCEL,
+    
+      @SerializedName("ach_chargeback")
+      ACH_CHARGEBACK,
+    
+      @SerializedName("ach_credit_return")
+      ACH_CREDIT_RETURN,
+    
+      @SerializedName("ach_exception")
+      ACH_EXCEPTION,
+    
+      @SerializedName("ach_return")
+      ACH_RETURN,
+    
+      @SerializedName("ach_transactions_not_supported")
+      ACH_TRANSACTIONS_NOT_SUPPORTED,
+    
+      @SerializedName("ach_validation_exception")
+      ACH_VALIDATION_EXCEPTION,
+    
+      @SerializedName("amazon_amount_exceeded")
+      AMAZON_AMOUNT_EXCEEDED,
+    
+      @SerializedName("amazon_invalid_authorization_status")
+      AMAZON_INVALID_AUTHORIZATION_STATUS,
+    
+      @SerializedName("amazon_invalid_close_attempt")
+      AMAZON_INVALID_CLOSE_ATTEMPT,
+    
+      @SerializedName("amazon_invalid_create_order_reference")
+      AMAZON_INVALID_CREATE_ORDER_REFERENCE,
+    
+      @SerializedName("amazon_invalid_order_status")
+      AMAZON_INVALID_ORDER_STATUS,
+    
+      @SerializedName("amazon_not_authorized")
+      AMAZON_NOT_AUTHORIZED,
+    
+      @SerializedName("amazon_order_not_modifiable")
+      AMAZON_ORDER_NOT_MODIFIABLE,
+    
+      @SerializedName("amazon_transaction_count_exceeded")
+      AMAZON_TRANSACTION_COUNT_EXCEEDED,
+    
+      @SerializedName("api_error")
+      API_ERROR,
+    
+      @SerializedName("approved")
+      APPROVED,
+    
+      @SerializedName("approved_fraud_review")
+      APPROVED_FRAUD_REVIEW,
+    
+      @SerializedName("authorization_already_captured")
+      AUTHORIZATION_ALREADY_CAPTURED,
+    
+      @SerializedName("authorization_amount_depleted")
+      AUTHORIZATION_AMOUNT_DEPLETED,
+    
+      @SerializedName("authorization_expired")
+      AUTHORIZATION_EXPIRED,
+    
+      @SerializedName("batch_processing_error")
+      BATCH_PROCESSING_ERROR,
+    
+      @SerializedName("billing_agreement_already_accepted")
+      BILLING_AGREEMENT_ALREADY_ACCEPTED,
+    
+      @SerializedName("billing_agreement_not_accepted")
+      BILLING_AGREEMENT_NOT_ACCEPTED,
+    
+      @SerializedName("call_issuer")
+      CALL_ISSUER,
+    
+      @SerializedName("call_issuer_update_cardholder_data")
+      CALL_ISSUER_UPDATE_CARDHOLDER_DATA,
+    
+      @SerializedName("cannot_refund_unsettled_transactions")
+      CANNOT_REFUND_UNSETTLED_TRANSACTIONS,
+    
+      @SerializedName("card_not_activated")
+      CARD_NOT_ACTIVATED,
+    
+      @SerializedName("card_type_not_accepted")
+      CARD_TYPE_NOT_ACCEPTED,
+    
+      @SerializedName("cardholder_requested_stop")
+      CARDHOLDER_REQUESTED_STOP,
+    
+      @SerializedName("contact_gateway")
+      CONTACT_GATEWAY,
+    
+      @SerializedName("currency_not_supported")
+      CURRENCY_NOT_SUPPORTED,
+    
+      @SerializedName("customer_canceled_transaction")
+      CUSTOMER_CANCELED_TRANSACTION,
+    
+      @SerializedName("cvv_required")
+      CVV_REQUIRED,
+    
+      @SerializedName("declined")
+      DECLINED,
+    
+      @SerializedName("declined_card_number")
+      DECLINED_CARD_NUMBER,
+    
+      @SerializedName("declined_exception")
+      DECLINED_EXCEPTION,
+    
+      @SerializedName("declined_expiration_date")
+      DECLINED_EXPIRATION_DATE,
+    
+      @SerializedName("declined_missing_data")
+      DECLINED_MISSING_DATA,
+    
+      @SerializedName("declined_saveable")
+      DECLINED_SAVEABLE,
+    
+      @SerializedName("declined_security_code")
+      DECLINED_SECURITY_CODE,
+    
+      @SerializedName("deposit_referenced_chargeback")
+      DEPOSIT_REFERENCED_CHARGEBACK,
+    
+      @SerializedName("duplicate_transaction")
+      DUPLICATE_TRANSACTION,
+    
+      @SerializedName("exceeds_daily_limit")
+      EXCEEDS_DAILY_LIMIT,
+    
+      @SerializedName("expired_card")
+      EXPIRED_CARD,
+    
+      @SerializedName("finbot_unavailable")
+      FINBOT_UNAVAILABLE,
+    
+      @SerializedName("fraud_address")
+      FRAUD_ADDRESS,
+    
+      @SerializedName("fraud_address_recurly")
+      FRAUD_ADDRESS_RECURLY,
+    
+      @SerializedName("fraud_advanced_verification")
+      FRAUD_ADVANCED_VERIFICATION,
+    
+      @SerializedName("fraud_gateway")
+      FRAUD_GATEWAY,
+    
+      @SerializedName("fraud_generic")
+      FRAUD_GENERIC,
+    
+      @SerializedName("fraud_ip_address")
+      FRAUD_IP_ADDRESS,
+    
+      @SerializedName("fraud_risk_check")
+      FRAUD_RISK_CHECK,
+    
+      @SerializedName("fraud_security_code")
+      FRAUD_SECURITY_CODE,
+    
+      @SerializedName("fraud_stolen_card")
+      FRAUD_STOLEN_CARD,
+    
+      @SerializedName("fraud_too_many_attempts")
+      FRAUD_TOO_MANY_ATTEMPTS,
+    
+      @SerializedName("fraud_velocity")
+      FRAUD_VELOCITY,
+    
+      @SerializedName("gateway_error")
+      GATEWAY_ERROR,
+    
+      @SerializedName("gateway_rate_limited")
+      GATEWAY_RATE_LIMITED,
+    
+      @SerializedName("gateway_timeout")
+      GATEWAY_TIMEOUT,
+    
+      @SerializedName("gateway_token_not_found")
+      GATEWAY_TOKEN_NOT_FOUND,
+    
+      @SerializedName("gateway_unavailable")
+      GATEWAY_UNAVAILABLE,
+    
+      @SerializedName("insufficient_funds")
+      INSUFFICIENT_FUNDS,
+    
+      @SerializedName("invalid_account_number")
+      INVALID_ACCOUNT_NUMBER,
+    
+      @SerializedName("invalid_amount")
+      INVALID_AMOUNT,
+    
+      @SerializedName("invalid_card_number")
+      INVALID_CARD_NUMBER,
+    
+      @SerializedName("invalid_data")
+      INVALID_DATA,
+    
+      @SerializedName("invalid_email")
+      INVALID_EMAIL,
+    
+      @SerializedName("invalid_gateway_configuration")
+      INVALID_GATEWAY_CONFIGURATION,
+    
+      @SerializedName("invalid_issuer")
+      INVALID_ISSUER,
+    
+      @SerializedName("invalid_login")
+      INVALID_LOGIN,
+    
+      @SerializedName("invalid_merchant_type")
+      INVALID_MERCHANT_TYPE,
+    
+      @SerializedName("invalid_transaction")
+      INVALID_TRANSACTION,
+    
+      @SerializedName("issuer_unavailable")
+      ISSUER_UNAVAILABLE,
+    
+      @SerializedName("merch_max_transaction_limit_exceeded")
+      MERCH_MAX_TRANSACTION_LIMIT_EXCEEDED,
+    
+      @SerializedName("moneybot_unavailable")
+      MONEYBOT_UNAVAILABLE,
+    
+      @SerializedName("no_billing_information")
+      NO_BILLING_INFORMATION,
+    
+      @SerializedName("no_gateway")
+      NO_GATEWAY,
+    
+      @SerializedName("no_gateway_found_for_transaction_amount")
+      NO_GATEWAY_FOUND_FOR_TRANSACTION_AMOUNT,
+    
+      @SerializedName("partial_approval")
+      PARTIAL_APPROVAL,
+    
+      @SerializedName("partial_credits_not_supported")
+      PARTIAL_CREDITS_NOT_SUPPORTED,
+    
+      @SerializedName("payment_cannot_void_authorization")
+      PAYMENT_CANNOT_VOID_AUTHORIZATION,
+    
+      @SerializedName("payment_not_accepted")
+      PAYMENT_NOT_ACCEPTED,
+    
+      @SerializedName("paypal_account_issue")
+      PAYPAL_ACCOUNT_ISSUE,
+    
+      @SerializedName("paypal_cannot_pay_self")
+      PAYPAL_CANNOT_PAY_SELF,
+    
+      @SerializedName("paypal_declined_use_alternate")
+      PAYPAL_DECLINED_USE_ALTERNATE,
+    
+      @SerializedName("paypal_expired_reference_id")
+      PAYPAL_EXPIRED_REFERENCE_ID,
+    
+      @SerializedName("paypal_hard_decline")
+      PAYPAL_HARD_DECLINE,
+    
+      @SerializedName("paypal_invalid_billing_agreement")
+      PAYPAL_INVALID_BILLING_AGREEMENT,
+    
+      @SerializedName("paypal_primary_declined")
+      PAYPAL_PRIMARY_DECLINED,
+    
+      @SerializedName("processor_unavailable")
+      PROCESSOR_UNAVAILABLE,
+    
+      @SerializedName("recurly_error")
+      RECURLY_ERROR,
+    
+      @SerializedName("recurly_failed_to_get_token")
+      RECURLY_FAILED_TO_GET_TOKEN,
+    
+      @SerializedName("recurly_token_mismatch")
+      RECURLY_TOKEN_MISMATCH,
+    
+      @SerializedName("recurly_token_not_found")
+      RECURLY_TOKEN_NOT_FOUND,
+    
+      @SerializedName("reference_transactions_not_enabled")
+      REFERENCE_TRANSACTIONS_NOT_ENABLED,
+    
+      @SerializedName("restricted_card")
+      RESTRICTED_CARD,
+    
+      @SerializedName("restricted_card_chargeback")
+      RESTRICTED_CARD_CHARGEBACK,
+    
+      @SerializedName("simultaneous")
+      SIMULTANEOUS,
+    
+      @SerializedName("ssl_error")
+      SSL_ERROR,
+    
+      @SerializedName("temporary_hold")
+      TEMPORARY_HOLD,
+    
+      @SerializedName("three_d_secure_authentication")
+      THREE_D_SECURE_AUTHENTICATION,
+    
+      @SerializedName("three_d_secure_not_supported")
+      THREE_D_SECURE_NOT_SUPPORTED,
+    
+      @SerializedName("too_many_attempts")
+      TOO_MANY_ATTEMPTS,
+    
+      @SerializedName("total_credit_exceeds_capture")
+      TOTAL_CREDIT_EXCEEDS_CAPTURE,
+    
+      @SerializedName("transaction_already_refunded")
+      TRANSACTION_ALREADY_REFUNDED,
+    
+      @SerializedName("transaction_already_voided")
+      TRANSACTION_ALREADY_VOIDED,
+    
+      @SerializedName("transaction_cannot_be_authorized")
+      TRANSACTION_CANNOT_BE_AUTHORIZED,
+    
+      @SerializedName("transaction_cannot_be_refunded")
+      TRANSACTION_CANNOT_BE_REFUNDED,
+    
+      @SerializedName("transaction_cannot_be_refunded_currently")
+      TRANSACTION_CANNOT_BE_REFUNDED_CURRENTLY,
+    
+      @SerializedName("transaction_cannot_be_voided")
+      TRANSACTION_CANNOT_BE_VOIDED,
+    
+      @SerializedName("transaction_failed_to_settle")
+      TRANSACTION_FAILED_TO_SETTLE,
+    
+      @SerializedName("transaction_not_found")
+      TRANSACTION_NOT_FOUND,
+    
+      @SerializedName("transaction_settled")
+      TRANSACTION_SETTLED,
+    
+      @SerializedName("transaction_stale_at_gateway")
+      TRANSACTION_STALE_AT_GATEWAY,
+    
+      @SerializedName("try_again")
+      TRY_AGAIN,
+    
+      @SerializedName("unknown")
+      UNKNOWN,
+    
+      @SerializedName("vaultly_service_unavailable")
+      VAULTLY_SERVICE_UNAVAILABLE,
+    
+      @SerializedName("zero_dollar_auth_not_supported")
+      ZERO_DOLLAR_AUTH_NOT_SUPPORTED,
+    
+    };
+  
+    public enum TaxIdentifierType {
+      UNDEFINED,
+    
+      @SerializedName("cpf")
+      CPF,
+    
+    };
+  
+}

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -149,7 +149,7 @@ public class Constants {
     
     };
   
-    public enum LineItemType {
+    public enum LintItemType {
       UNDEFINED,
     
       @SerializedName("charge")

--- a/src/main/java/com/recurly/v3/JsonSerializer.java
+++ b/src/main/java/com/recurly/v3/JsonSerializer.java
@@ -2,8 +2,18 @@ package com.recurly.v3;
 
 import com.fatboyindustrial.gsonjodatime.Converters;
 import com.google.gson.*;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
 import com.recurly.v3.exception.ExceptionFactory;
+
+import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.joda.time.DateTime;
 
 public class JsonSerializer {
@@ -20,6 +30,7 @@ public class JsonSerializer {
       new GsonBuilder()
           .excludeFieldsWithoutExposeAnnotation()
           .registerTypeAdapter(DateTime.class, new DateDeserializer())
+          .registerTypeAdapterFactory(new RecurlyEnumTypeAdapterFactory())
           .create();
 
   public <T> T deserialize(String responseBody, final Type resourceClass) {
@@ -37,6 +48,64 @@ public class JsonSerializer {
       return "";
     } else {
       return gsonSerializer.toJson(body);
+    }
+  }
+
+  // Based on the EnumTypeAdapter from gson:
+  // https://github.com/google/gson/blob/gson-parent-2.8.6/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java#L773
+  private static final class RecurlyEnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
+    private final Map<String, T> nameToConstant = new HashMap<String, T>();
+    private final Map<T, String> constantToName = new HashMap<T, String>();
+
+    public RecurlyEnumTypeAdapter(Class<T> classOfT) {
+      try {
+        for (T constant : classOfT.getEnumConstants()) {
+          String name = constant.name();
+          SerializedName annotation = classOfT.getField(name).getAnnotation(SerializedName.class);
+          if (annotation != null) {
+            name = annotation.value();
+            for (String alternate : annotation.alternate()) {
+              nameToConstant.put(alternate, constant);
+            }
+          }
+          nameToConstant.put(name, constant);
+          constantToName.put(constant, name);
+        }
+      } catch (NoSuchFieldException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    public T read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      T constant = nameToConstant.get(in.nextString());
+      if (constant == null) {
+        return nameToConstant.get("UNDEFINED");
+      }
+      return constant;
+    }
+
+    public void write(JsonWriter out, T value) throws IOException {
+      out.value(value == null ? null : constantToName.get(value));
+    }
+  }
+
+  // Based on the TypeAdapterFactory in gson:
+  // https://github.com/google/gson/blob/gson-parent-2.8.6/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java#L808
+  private class RecurlyEnumTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+      Class<? super T> rawType = typeToken.getRawType();
+      if (!Enum.class.isAssignableFrom(rawType) || rawType == Enum.class) {
+        return null;
+      }
+      if (!rawType.isEnum()) {
+        rawType = rawType.getSuperclass(); // handle anonymous subclasses
+      }
+      return (TypeAdapter<T>) new RecurlyEnumTypeAdapter(rawType);
     }
   }
 }

--- a/src/main/java/com/recurly/v3/QueryParams.java
+++ b/src/main/java/com/recurly/v3/QueryParams.java
@@ -34,15 +34,15 @@ public class QueryParams {
     this.add("limit", limit);
   }
 
-  public void setOrder(final String order) {
+  public void setOrder(final Constants.AlphanumericSort order) {
     this.add("order", order);
   }
 
-  public void setSort(final String sort) {
+  public void setSort(final Constants.TimestampSort sort) {
     this.add("sort", sort);
   }
 
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.add("state", state);
   }
 
@@ -62,27 +62,27 @@ public class QueryParams {
     this.add("subscriber", subscriber);
   }
 
-  public void setPastDue(final String pastDue) {
+  public void setPastDue(final Constants.True pastDue) {
     this.add("past_due", pastDue);
   }
 
-  public void setType(final String type) {
+  public void setType(final Constants.FilterInvoiceType type) {
     this.add("type", type);
   }
 
-  public void setOriginal(final String original) {
+  public void setOriginal(final Constants.True original) {
     this.add("original", original);
   }
 
-  public void setSuccess(final String success) {
+  public void setSuccess(final Constants.True success) {
     this.add("success", success);
   }
 
-  public void setRelatedType(final String relatedType) {
+  public void setRelatedType(final Constants.RelatedType relatedType) {
     this.add("related_type", relatedType);
   }
 
-  public void setRefund(final String refund) {
+  public void setRefund(final Constants.RefundType refund) {
     this.add("refund", refund);
   }
 
@@ -90,7 +90,7 @@ public class QueryParams {
     this.add("charge", charge);
   }
 
-  public void setBillingStatus(final String billingStatus) {
+  public void setBillingStatus(final Constants.BillingStatus billingStatus) {
     this.add("billing_status", billingStatus);
   }
 }

--- a/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
+++ b/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
@@ -16,61 +16,63 @@ public class ExceptionFactory {
   public static <T extends RecurlyException> T getExceptionClass(ApiException apiException) {
     ErrorMayHaveTransaction e = apiException.getError();
     switch (e.getType()) {
-      case "bad_request":
+      case BAD_REQUEST:
         return (T) new BadRequestException(e.getMessage(), e);
 
-      case "immutable_subscription":
+      case IMMUTABLE_SUBSCRIPTION:
         return (T) new ImmutableSubscriptionException(e.getMessage(), e);
 
-      case "internal_server_error":
+      case INTERNAL_SERVER_ERROR:
         return (T) new InternalServerException(e.getMessage(), e);
 
-      case "invalid_api_key":
+      case INVALID_API_KEY:
         return (T) new InvalidApiKeyException(e.getMessage(), e);
 
-      case "invalid_api_version":
+      case INVALID_API_VERSION:
         return (T) new InvalidApiVersionException(e.getMessage(), e);
 
-      case "invalid_content_type":
+      case INVALID_CONTENT_TYPE:
         return (T) new InvalidContentTypeException(e.getMessage(), e);
 
-      case "invalid_permissions":
+      case INVALID_PERMISSIONS:
         return (T) new InvalidPermissionsException(e.getMessage(), e);
 
-      case "invalid_token":
+      case INVALID_TOKEN:
         return (T) new InvalidTokenException(e.getMessage(), e);
 
-      case "missing_feature":
+      case MISSING_FEATURE:
         return (T) new MissingFeatureException(e.getMessage(), e);
 
-      case "not_found":
+      case NOT_FOUND:
         return (T) new NotFoundException(e.getMessage(), e);
 
-      case "rate_limited":
+      case RATE_LIMITED:
         return (T) new RateLimitedException(e.getMessage(), e);
 
-      case "service_not_available":
+      case SERVICE_NOT_AVAILABLE:
         return (T) new ServiceNotAvailableException(e.getMessage(), e);
 
-      case "simultaneous_request":
+      case SIMULTANEOUS_REQUEST:
         return (T) new SimultaneousRequestException(e.getMessage(), e);
 
-      case "transaction":
+      case TRANSACTION:
         return (T) new TransactionException(e.getMessage(), e);
 
-      case "unauthorized":
+      case UNAUTHORIZED:
         return (T) new UnauthorizedException(e.getMessage(), e);
 
-      case "unavailable_in_api_version":
+      case UNAVAILABLE_IN_API_VERSION:
         return (T) new UnavailableInApiVersionException(e.getMessage(), e);
 
-      case "unknown_api_version":
+      case UNKNOWN_API_VERSION:
         return (T) new UnknownApiVersionException(e.getMessage(), e);
 
-      case "validation":
+      case VALIDATION:
         return (T) new ValidationException(e.getMessage(), e);
+
+      default:
+        return (T) apiException;
     }
-    return (T) apiException;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
+++ b/src/main/java/com/recurly/v3/exception/ExceptionFactory.java
@@ -109,7 +109,8 @@ public class ExceptionFactory {
         return (T) new UnprocessableEntityException(message, null);
       case 429:
         return (T) new TooManyRequestsException(message, null);
+      default:
+        return (T) new ApiException(message, null);
     }
-    return (T) new ApiException(message, null);
   }
 }

--- a/src/main/java/com/recurly/v3/requests/AccountAcquisitionUpdatable.java
+++ b/src/main/java/com/recurly/v3/requests/AccountAcquisitionUpdatable.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -22,7 +23,7 @@ public class AccountAcquisitionUpdatable extends Request {
   /** The channel through which the account was acquired. */
   @SerializedName("channel")
   @Expose
-  private String channel;
+  private Constants.Channel channel;
 
   /** Account balance */
   @SerializedName("cost")
@@ -52,12 +53,12 @@ public class AccountAcquisitionUpdatable extends Request {
   }
 
   /** The channel through which the account was acquired. */
-  public String getChannel() {
+  public Constants.Channel getChannel() {
     return this.channel;
   }
 
   /** @param channel The channel through which the account was acquired. */
-  public void setChannel(final String channel) {
+  public void setChannel(final Constants.Channel channel) {
     this.channel = channel;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AccountCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AccountCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -27,7 +28,7 @@ public class AccountCreate extends Request {
    */
   @SerializedName("bill_to")
   @Expose
-  private String billTo;
+  private Constants.BillTo billTo;
 
   @SerializedName("billing_info")
   @Expose
@@ -113,7 +114,7 @@ public class AccountCreate extends Request {
    */
   @SerializedName("preferred_locale")
   @Expose
-  private String preferredLocale;
+  private Constants.PreferredLocale preferredLocale;
 
   @SerializedName("shipping_addresses")
   @Expose
@@ -133,7 +134,7 @@ public class AccountCreate extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /** A secondary value for the account. */
   @SerializedName("username")
@@ -170,7 +171,7 @@ public class AccountCreate extends Request {
    * An enumerable describing the billing behavior of the account, specifically whether the account
    * is self-paying or will rely on the parent account to pay.
    */
-  public String getBillTo() {
+  public Constants.BillTo getBillTo() {
     return this.billTo;
   }
 
@@ -178,7 +179,7 @@ public class AccountCreate extends Request {
    * @param billTo An enumerable describing the billing behavior of the account, specifically
    *     whether the account is self-paying or will rely on the parent account to pay.
    */
-  public void setBillTo(final String billTo) {
+  public void setBillTo(final Constants.BillTo billTo) {
     this.billTo = billTo;
   }
 
@@ -350,7 +351,7 @@ public class AccountCreate extends Request {
    * Used to determine the language and locale of emails sent on behalf of the merchant to the
    * customer. The list of locales is restricted to those the merchant has enabled on the site.
    */
-  public String getPreferredLocale() {
+  public Constants.PreferredLocale getPreferredLocale() {
     return this.preferredLocale;
   }
 
@@ -359,7 +360,7 @@ public class AccountCreate extends Request {
    *     the merchant to the customer. The list of locales is restricted to those the merchant has
    *     enabled on the site.
    */
-  public void setPreferredLocale(final String preferredLocale) {
+  public void setPreferredLocale(final Constants.PreferredLocale preferredLocale) {
     this.preferredLocale = preferredLocale;
   }
 
@@ -392,7 +393,7 @@ public class AccountCreate extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -401,7 +402,7 @@ public class AccountCreate extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AccountPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/AccountPurchase.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -27,7 +28,7 @@ public class AccountPurchase extends Request {
    */
   @SerializedName("bill_to")
   @Expose
-  private String billTo;
+  private Constants.BillTo billTo;
 
   @SerializedName("billing_info")
   @Expose
@@ -121,7 +122,7 @@ public class AccountPurchase extends Request {
    */
   @SerializedName("preferred_locale")
   @Expose
-  private String preferredLocale;
+  private Constants.PreferredLocale preferredLocale;
 
   /**
    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the
@@ -137,7 +138,7 @@ public class AccountPurchase extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /** A secondary value for the account. */
   @SerializedName("username")
@@ -174,7 +175,7 @@ public class AccountPurchase extends Request {
    * An enumerable describing the billing behavior of the account, specifically whether the account
    * is self-paying or will rely on the parent account to pay.
    */
-  public String getBillTo() {
+  public Constants.BillTo getBillTo() {
     return this.billTo;
   }
 
@@ -182,7 +183,7 @@ public class AccountPurchase extends Request {
    * @param billTo An enumerable describing the billing behavior of the account, specifically
    *     whether the account is self-paying or will rely on the parent account to pay.
    */
-  public void setBillTo(final String billTo) {
+  public void setBillTo(final Constants.BillTo billTo) {
     this.billTo = billTo;
   }
 
@@ -370,7 +371,7 @@ public class AccountPurchase extends Request {
    * Used to determine the language and locale of emails sent on behalf of the merchant to the
    * customer. The list of locales is restricted to those the merchant has enabled on the site.
    */
-  public String getPreferredLocale() {
+  public Constants.PreferredLocale getPreferredLocale() {
     return this.preferredLocale;
   }
 
@@ -379,7 +380,7 @@ public class AccountPurchase extends Request {
    *     the merchant to the customer. The list of locales is restricted to those the merchant has
    *     enabled on the site.
    */
-  public void setPreferredLocale(final String preferredLocale) {
+  public void setPreferredLocale(final Constants.PreferredLocale preferredLocale) {
     this.preferredLocale = preferredLocale;
   }
 
@@ -403,7 +404,7 @@ public class AccountPurchase extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -412,7 +413,7 @@ public class AccountPurchase extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AccountUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/AccountUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -23,7 +24,7 @@ public class AccountUpdate extends Request {
    */
   @SerializedName("bill_to")
   @Expose
-  private String billTo;
+  private Constants.BillTo billTo;
 
   @SerializedName("billing_info")
   @Expose
@@ -104,7 +105,7 @@ public class AccountUpdate extends Request {
    */
   @SerializedName("preferred_locale")
   @Expose
-  private String preferredLocale;
+  private Constants.PreferredLocale preferredLocale;
 
   /**
    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the
@@ -120,7 +121,7 @@ public class AccountUpdate extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /** A secondary value for the account. */
   @SerializedName("username")
@@ -148,7 +149,7 @@ public class AccountUpdate extends Request {
    * An enumerable describing the billing behavior of the account, specifically whether the account
    * is self-paying or will rely on the parent account to pay.
    */
-  public String getBillTo() {
+  public Constants.BillTo getBillTo() {
     return this.billTo;
   }
 
@@ -156,7 +157,7 @@ public class AccountUpdate extends Request {
    * @param billTo An enumerable describing the billing behavior of the account, specifically
    *     whether the account is self-paying or will rely on the parent account to pay.
    */
-  public void setBillTo(final String billTo) {
+  public void setBillTo(final Constants.BillTo billTo) {
     this.billTo = billTo;
   }
 
@@ -315,7 +316,7 @@ public class AccountUpdate extends Request {
    * Used to determine the language and locale of emails sent on behalf of the merchant to the
    * customer. The list of locales is restricted to those the merchant has enabled on the site.
    */
-  public String getPreferredLocale() {
+  public Constants.PreferredLocale getPreferredLocale() {
     return this.preferredLocale;
   }
 
@@ -324,7 +325,7 @@ public class AccountUpdate extends Request {
    *     the merchant to the customer. The list of locales is restricted to those the merchant has
    *     enabled on the site.
    */
-  public void setPreferredLocale(final String preferredLocale) {
+  public void setPreferredLocale(final Constants.PreferredLocale preferredLocale) {
     this.preferredLocale = preferredLocale;
   }
 
@@ -348,7 +349,7 @@ public class AccountUpdate extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -357,7 +358,7 @@ public class AccountUpdate extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -25,7 +26,7 @@ public class AddOnCreate extends Request {
   /** Whether the add-on type is fixed, or usage-based. */
   @SerializedName("add_on_type")
   @Expose
-  private String addOnType;
+  private Constants.AddOnTypeCreate addOnType;
 
   /**
    * Used by Avalara for Communications taxes. The transaction type in combination with the service
@@ -144,7 +145,7 @@ public class AddOnCreate extends Request {
    */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
@@ -165,7 +166,7 @@ public class AddOnCreate extends Request {
    */
   @SerializedName("tier_type")
   @Expose
-  private String tierType;
+  private Constants.TierType tierType;
 
   /**
    * If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object must include one to
@@ -192,7 +193,7 @@ public class AddOnCreate extends Request {
    */
   @SerializedName("usage_type")
   @Expose
-  private String usageType;
+  private Constants.UsageTypeCreate usageType;
 
   /**
    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to
@@ -213,12 +214,12 @@ public class AddOnCreate extends Request {
   }
 
   /** Whether the add-on type is fixed, or usage-based. */
-  public String getAddOnType() {
+  public Constants.AddOnTypeCreate getAddOnType() {
     return this.addOnType;
   }
 
   /** @param addOnType Whether the add-on type is fixed, or usage-based. */
-  public void setAddOnType(final String addOnType) {
+  public void setAddOnType(final Constants.AddOnTypeCreate addOnType) {
     this.addOnType = addOnType;
   }
 
@@ -454,7 +455,7 @@ public class AddOnCreate extends Request {
    * `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the
    * request as the value will be set from the item.
    */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
@@ -463,7 +464,7 @@ public class AddOnCreate extends Request {
    *     schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must
    *     be absent in the request as the value will be set from the item.
    */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -495,7 +496,7 @@ public class AddOnCreate extends Request {
    * [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to
    * configure quantity-based pricing models.
    */
-  public String getTierType() {
+  public Constants.TierType getTierType() {
     return this.tierType;
   }
 
@@ -505,7 +506,7 @@ public class AddOnCreate extends Request {
    *     [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
    *     to configure quantity-based pricing models.
    */
-  public void setTierType(final String tierType) {
+  public void setTierType(final Constants.TierType tierType) {
     this.tierType = tierType;
   }
 
@@ -552,7 +553,7 @@ public class AddOnCreate extends Request {
    * [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview
    * of how to configure usage add-ons.
    */
-  public String getUsageType() {
+  public Constants.UsageTypeCreate getUsageType() {
     return this.usageType;
   }
 
@@ -561,7 +562,7 @@ public class AddOnCreate extends Request {
    *     [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an
    *     overview of how to configure usage add-ons.
    */
-  public void setUsageType(final String usageType) {
+  public void setUsageType(final Constants.UsageTypeCreate usageType) {
     this.usageType = usageType;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -117,7 +118,7 @@ public class AddOnUpdate extends Request {
    */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
@@ -353,7 +354,7 @@ public class AddOnUpdate extends Request {
    * `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the
    * request as the value will be set from the item.
    */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
@@ -362,7 +363,7 @@ public class AddOnUpdate extends Request {
    *     schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must
    *     be absent in the request as the value will be set from the item.
    */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -140,7 +141,7 @@ public class BillingInfoCreate extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /** VAT number */
   @SerializedName("vat_number")
@@ -407,7 +408,7 @@ public class BillingInfoCreate extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -416,7 +417,7 @@ public class BillingInfoCreate extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/CouponCreate.java
+++ b/src/main/java/com/recurly/v3/requests/CouponCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -47,7 +48,7 @@ public class CouponCreate extends Request {
    */
   @SerializedName("coupon_type")
   @Expose
-  private String couponType;
+  private Constants.CouponType couponType;
 
   /**
    * Fixed discount currencies by currency. Required if the coupon type is `fixed`. This parameter
@@ -67,7 +68,7 @@ public class CouponCreate extends Request {
   /** The type of discount provided by the coupon (how the amount discounted is calculated) */
   @SerializedName("discount_type")
   @Expose
-  private String discountType;
+  private Constants.DiscountType discountType;
 
   /**
    * This field does not apply when the discount_type is `free_trial`. - "single_use" coupons
@@ -77,7 +78,7 @@ public class CouponCreate extends Request {
    */
   @SerializedName("duration")
   @Expose
-  private String duration;
+  private Constants.CouponDuration duration;
 
   /**
    * Sets the duration of time the `free_trial_unit` is for. Required if `discount_type` is
@@ -93,7 +94,7 @@ public class CouponCreate extends Request {
    */
   @SerializedName("free_trial_unit")
   @Expose
-  private String freeTrialUnit;
+  private Constants.FreeTrialUnit freeTrialUnit;
 
   /**
    * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or
@@ -161,7 +162,7 @@ public class CouponCreate extends Request {
    */
   @SerializedName("redemption_resource")
   @Expose
-  private String redemptionResource;
+  private Constants.RedemptionResource redemptionResource;
 
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by
@@ -177,7 +178,7 @@ public class CouponCreate extends Request {
    */
   @SerializedName("temporal_unit")
   @Expose
-  private String temporalUnit;
+  private Constants.TemporalUnit temporalUnit;
 
   /**
    * On a bulk coupon, the template from which unique coupon codes are generated. - You must start
@@ -252,7 +253,7 @@ public class CouponCreate extends Request {
    * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a
    * `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  public String getCouponType() {
+  public Constants.CouponType getCouponType() {
     return this.couponType;
   }
 
@@ -260,7 +261,7 @@ public class CouponCreate extends Request {
    * @param couponType Whether the coupon is "single_code" or "bulk". Bulk coupons will require a
    *     `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  public void setCouponType(final String couponType) {
+  public void setCouponType(final Constants.CouponType couponType) {
     this.couponType = couponType;
   }
 
@@ -296,7 +297,7 @@ public class CouponCreate extends Request {
   }
 
   /** The type of discount provided by the coupon (how the amount discounted is calculated) */
-  public String getDiscountType() {
+  public Constants.DiscountType getDiscountType() {
     return this.discountType;
   }
 
@@ -304,7 +305,7 @@ public class CouponCreate extends Request {
    * @param discountType The type of discount provided by the coupon (how the amount discounted is
    *     calculated)
    */
-  public void setDiscountType(final String discountType) {
+  public void setDiscountType(final Constants.DiscountType discountType) {
     this.discountType = discountType;
   }
 
@@ -314,7 +315,7 @@ public class CouponCreate extends Request {
    * determined by the `temporal_unit` and `temporal_amount` attributes. - "forever" coupons will
    * apply to invoices forever.
    */
-  public String getDuration() {
+  public Constants.CouponDuration getDuration() {
     return this.duration;
   }
 
@@ -324,7 +325,7 @@ public class CouponCreate extends Request {
    *     invoices for the duration determined by the `temporal_unit` and `temporal_amount`
    *     attributes. - "forever" coupons will apply to invoices forever.
    */
-  public void setDuration(final String duration) {
+  public void setDuration(final Constants.CouponDuration duration) {
     this.duration = duration;
   }
 
@@ -348,7 +349,7 @@ public class CouponCreate extends Request {
    * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine
    * the duration of time the coupon is for. Required if `discount_type` is `free_trial`.
    */
-  public String getFreeTrialUnit() {
+  public Constants.FreeTrialUnit getFreeTrialUnit() {
     return this.freeTrialUnit;
   }
 
@@ -357,7 +358,7 @@ public class CouponCreate extends Request {
    *     `free_trial_amount` to determine the duration of time the coupon is for. Required if
    *     `discount_type` is `free_trial`.
    */
-  public void setFreeTrialUnit(final String freeTrialUnit) {
+  public void setFreeTrialUnit(final Constants.FreeTrialUnit freeTrialUnit) {
     this.freeTrialUnit = freeTrialUnit;
   }
 
@@ -487,7 +488,7 @@ public class CouponCreate extends Request {
    * Whether the discount is for all eligible charges on the account, or only a specific
    * subscription.
    */
-  public String getRedemptionResource() {
+  public Constants.RedemptionResource getRedemptionResource() {
     return this.redemptionResource;
   }
 
@@ -495,7 +496,7 @@ public class CouponCreate extends Request {
    * @param redemptionResource Whether the discount is for all eligible charges on the account, or
    *     only a specific subscription.
    */
-  public void setRedemptionResource(final String redemptionResource) {
+  public void setRedemptionResource(final Constants.RedemptionResource redemptionResource) {
     this.redemptionResource = redemptionResource;
   }
 
@@ -520,7 +521,7 @@ public class CouponCreate extends Request {
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define
    * the duration that the coupon will be applied to invoices for.
    */
-  public String getTemporalUnit() {
+  public Constants.TemporalUnit getTemporalUnit() {
     return this.temporalUnit;
   }
 
@@ -528,7 +529,7 @@ public class CouponCreate extends Request {
    * @param temporalUnit If `duration` is "temporal" than `temporal_unit` is multiplied by
    *     `temporal_amount` to define the duration that the coupon will be applied to invoices for.
    */
-  public void setTemporalUnit(final String temporalUnit) {
+  public void setTemporalUnit(final Constants.TemporalUnit temporalUnit) {
     this.temporalUnit = temporalUnit;
   }
 

--- a/src/main/java/com/recurly/v3/requests/ExternalRefund.java
+++ b/src/main/java/com/recurly/v3/requests/ExternalRefund.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import org.joda.time.DateTime;
@@ -21,7 +22,7 @@ public class ExternalRefund extends Request {
   /** Payment method used for external refund transaction. */
   @SerializedName("payment_method")
   @Expose
-  private String paymentMethod;
+  private Constants.ExternalPaymentMethod paymentMethod;
 
   /** Date the external refund payment was made. Defaults to the current date-time. */
   @SerializedName("refunded_at")
@@ -39,12 +40,12 @@ public class ExternalRefund extends Request {
   }
 
   /** Payment method used for external refund transaction. */
-  public String getPaymentMethod() {
+  public Constants.ExternalPaymentMethod getPaymentMethod() {
     return this.paymentMethod;
   }
 
   /** @param paymentMethod Payment method used for external refund transaction. */
-  public void setPaymentMethod(final String paymentMethod) {
+  public void setPaymentMethod(final Constants.ExternalPaymentMethod paymentMethod) {
     this.paymentMethod = paymentMethod;
   }
 

--- a/src/main/java/com/recurly/v3/requests/ExternalTransaction.java
+++ b/src/main/java/com/recurly/v3/requests/ExternalTransaction.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import org.joda.time.DateTime;
@@ -31,7 +32,7 @@ public class ExternalTransaction extends Request {
   /** Payment method used for external transaction. */
   @SerializedName("payment_method")
   @Expose
-  private String paymentMethod;
+  private Constants.ExternalPaymentMethod paymentMethod;
 
   /** The total amount of the transcaction. Cannot excceed the invoice total. */
   public Float getAmount() {
@@ -67,12 +68,12 @@ public class ExternalTransaction extends Request {
   }
 
   /** Payment method used for external transaction. */
-  public String getPaymentMethod() {
+  public Constants.ExternalPaymentMethod getPaymentMethod() {
     return this.paymentMethod;
   }
 
   /** @param paymentMethod Payment method used for external transaction. */
-  public void setPaymentMethod(final String paymentMethod) {
+  public void setPaymentMethod(final Constants.ExternalPaymentMethod paymentMethod) {
     this.paymentMethod = paymentMethod;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/InvoiceCollect.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceCollect.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -35,7 +36,7 @@ public class InvoiceCollect extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
@@ -76,7 +77,7 @@ public class InvoiceCollect extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -85,7 +86,7 @@ public class InvoiceCollect extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/InvoiceCreate.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -29,7 +30,7 @@ public class InvoiceCreate extends Request {
    */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /**
    * This will default to the Customer Notes text specified on the Invoice Settings for credit
@@ -102,7 +103,7 @@ public class InvoiceCreate extends Request {
    * customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH
    * bank payment.
    */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
@@ -113,7 +114,7 @@ public class InvoiceCreate extends Request {
    *     transaction or have the customer pay the invoice with an automatic method, like credit
    *     card, PayPal, Amazon, or ACH bank payment.
    */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 

--- a/src/main/java/com/recurly/v3/requests/InvoiceRefund.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceRefund.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -62,12 +63,12 @@ public class InvoiceRefund extends Request {
    */
   @SerializedName("refund_method")
   @Expose
-  private String refundMethod;
+  private Constants.RefuneMethod refundMethod;
 
   /** The type of refund. Amount and line items cannot both be specified in the request. */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.InvoiceRefundType type;
 
   /**
    * The amount to be refunded. The amount will be split between the line items. If no amount is
@@ -150,7 +151,7 @@ public class InvoiceRefund extends Request {
    * back to transactions, using transactions from previous invoices if necessary. Only available
    * when the Credit Invoices feature is enabled.
    */
-  public String getRefundMethod() {
+  public Constants.RefuneMethod getRefundMethod() {
     return this.refundMethod;
   }
 
@@ -165,19 +166,19 @@ public class InvoiceRefund extends Request {
    *     `all_transaction` – Refunds the entire amount back to transactions, using transactions from
    *     previous invoices if necessary. Only available when the Credit Invoices feature is enabled.
    */
-  public void setRefundMethod(final String refundMethod) {
+  public void setRefundMethod(final Constants.RefuneMethod refundMethod) {
     this.refundMethod = refundMethod;
   }
 
   /** The type of refund. Amount and line items cannot both be specified in the request. */
-  public String getType() {
+  public Constants.InvoiceRefundType getType() {
     return this.type;
   }
 
   /**
    * @param type The type of refund. Amount and line items cannot both be specified in the request.
    */
-  public void setType(final String type) {
+  public void setType(final Constants.InvoiceRefundType type) {
     this.type = type;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/ItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/ItemCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -78,7 +79,7 @@ public class ItemCreate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
@@ -221,12 +222,12 @@ public class ItemCreate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/ItemUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/ItemUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -78,7 +79,7 @@ public class ItemUpdate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
@@ -221,12 +222,12 @@ public class ItemUpdate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -160,7 +160,7 @@ public class LineItemCreate extends Request {
    */
   @SerializedName("type")
   @Expose
-  private Constants.LineItemType type;
+  private Constants.LintItemType type;
 
   /**
    * A positive or negative amount with `type=charge` will result in a positive `unit_amount`. A
@@ -459,7 +459,7 @@ public class LineItemCreate extends Request {
    * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If
    * `item_code`/`item_id` is not present then `type` is required.
    */
-  public Constants.LineItemType getType() {
+  public Constants.LintItemType getType() {
     return this.type;
   }
 
@@ -467,7 +467,7 @@ public class LineItemCreate extends Request {
    * @param type Line item type. If `item_code`/`item_id` is present then `type` should not be
    *     present. If `item_code`/`item_id` is not present then `type` is required.
    */
-  public void setType(final Constants.LineItemType type) {
+  public void setType(final Constants.LintItemType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import org.joda.time.DateTime;
@@ -50,7 +51,7 @@ public class LineItemCreate extends Request {
    */
   @SerializedName("credit_reason_code")
   @Expose
-  private String creditReasonCode;
+  private Constants.PartialCreditReasonCode creditReasonCode;
 
   /**
    * 3-letter ISO 4217 currency code. If `item_code`/`item_id` is part of the request then
@@ -100,7 +101,7 @@ public class LineItemCreate extends Request {
    */
   @SerializedName("origin")
   @Expose
-  private String origin;
+  private Constants.LineItemCreateOrigin origin;
 
   /**
    * Optional field to track a product code or SKU for the line item. This can be used to later
@@ -123,7 +124,7 @@ public class LineItemCreate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.LineItemRevenueScheduleType revenueScheduleType;
 
   /**
    * If an end date is present, this is value indicates the beginning of a billing time range. If no
@@ -159,7 +160,7 @@ public class LineItemCreate extends Request {
    */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.LineItemType type;
 
   /**
    * A positive or negative amount with `type=charge` will result in a positive `unit_amount`. A
@@ -236,7 +237,7 @@ public class LineItemCreate extends Request {
    * feature is enabled, the value can be set and will default to `general`. When the Credit
    * Invoices feature is not enabled, the value will always be `null`.
    */
-  public String getCreditReasonCode() {
+  public Constants.PartialCreditReasonCode getCreditReasonCode() {
     return this.creditReasonCode;
   }
 
@@ -245,7 +246,7 @@ public class LineItemCreate extends Request {
    *     the Credit Invoices feature is enabled, the value can be set and will default to `general`.
    *     When the Credit Invoices feature is not enabled, the value will always be `null`.
    */
-  public void setCreditReasonCode(final String creditReasonCode) {
+  public void setCreditReasonCode(final Constants.PartialCreditReasonCode creditReasonCode) {
     this.creditReasonCode = creditReasonCode;
   }
 
@@ -334,7 +335,7 @@ public class LineItemCreate extends Request {
    * allowed if `type` is `charge` and `tax_exempt` is left blank or set to true. This origin
    * creates a charge and opposite credit on the account to be used for future invoices.
    */
-  public String getOrigin() {
+  public Constants.LineItemCreateOrigin getOrigin() {
     return this.origin;
   }
 
@@ -346,7 +347,7 @@ public class LineItemCreate extends Request {
    *     true. This origin creates a charge and opposite credit on the account to be used for future
    *     invoices.
    */
-  public void setOrigin(final String origin) {
+  public void setOrigin(final Constants.LineItemCreateOrigin origin) {
     this.origin = origin;
   }
 
@@ -387,12 +388,13 @@ public class LineItemCreate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.LineItemRevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(
+      final Constants.LineItemRevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -457,7 +459,7 @@ public class LineItemCreate extends Request {
    * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If
    * `item_code`/`item_id` is not present then `type` is required.
    */
-  public String getType() {
+  public Constants.LineItemType getType() {
     return this.type;
   }
 
@@ -465,7 +467,7 @@ public class LineItemCreate extends Request {
    * @param type Line item type. If `item_code`/`item_id` is present then `type` should not be
    *     present. If `item_code`/`item_id` is not present then `type` is required.
    */
-  public void setType(final String type) {
+  public void setType(final Constants.LineItemType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/recurly/v3/requests/PlanCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -96,7 +97,7 @@ public class PlanCreate extends Request {
   /** Unit for the plan's billing interval. */
   @SerializedName("interval_unit")
   @Expose
-  private String intervalUnit;
+  private Constants.IntervalUnit intervalUnit;
 
   /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's
@@ -109,7 +110,7 @@ public class PlanCreate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it
@@ -122,7 +123,7 @@ public class PlanCreate extends Request {
   /** Setup fee revenue schedule type */
   @SerializedName("setup_fee_revenue_schedule_type")
   @Expose
-  private String setupFeeRevenueScheduleType;
+  private Constants.RevenueScheduleType setupFeeRevenueScheduleType;
 
   /**
    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
@@ -160,7 +161,7 @@ public class PlanCreate extends Request {
   /** Units for the plan's trial period. */
   @SerializedName("trial_unit")
   @Expose
-  private String trialUnit;
+  private Constants.IntervalUnit trialUnit;
 
   /**
    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to
@@ -323,12 +324,12 @@ public class PlanCreate extends Request {
   }
 
   /** Unit for the plan's billing interval. */
-  public String getIntervalUnit() {
+  public Constants.IntervalUnit getIntervalUnit() {
     return this.intervalUnit;
   }
 
   /** @param intervalUnit Unit for the plan's billing interval. */
-  public void setIntervalUnit(final String intervalUnit) {
+  public void setIntervalUnit(final Constants.IntervalUnit intervalUnit) {
     this.intervalUnit = intervalUnit;
   }
 
@@ -349,12 +350,12 @@ public class PlanCreate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -375,12 +376,13 @@ public class PlanCreate extends Request {
   }
 
   /** Setup fee revenue schedule type */
-  public String getSetupFeeRevenueScheduleType() {
+  public Constants.RevenueScheduleType getSetupFeeRevenueScheduleType() {
     return this.setupFeeRevenueScheduleType;
   }
 
   /** @param setupFeeRevenueScheduleType Setup fee revenue schedule type */
-  public void setSetupFeeRevenueScheduleType(final String setupFeeRevenueScheduleType) {
+  public void setSetupFeeRevenueScheduleType(
+      final Constants.RevenueScheduleType setupFeeRevenueScheduleType) {
     this.setupFeeRevenueScheduleType = setupFeeRevenueScheduleType;
   }
 
@@ -455,12 +457,12 @@ public class PlanCreate extends Request {
   }
 
   /** Units for the plan's trial period. */
-  public String getTrialUnit() {
+  public Constants.IntervalUnit getTrialUnit() {
     return this.trialUnit;
   }
 
   /** @param trialUnit Units for the plan's trial period. */
-  public void setTrialUnit(final String trialUnit) {
+  public void setTrialUnit(final Constants.IntervalUnit trialUnit) {
     this.trialUnit = trialUnit;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/PlanUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -99,7 +100,7 @@ public class PlanUpdate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it
@@ -112,7 +113,7 @@ public class PlanUpdate extends Request {
   /** Setup fee revenue schedule type */
   @SerializedName("setup_fee_revenue_schedule_type")
   @Expose
-  private String setupFeeRevenueScheduleType;
+  private Constants.RevenueScheduleType setupFeeRevenueScheduleType;
 
   /**
    * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
@@ -150,7 +151,7 @@ public class PlanUpdate extends Request {
   /** Units for the plan's trial period. */
   @SerializedName("trial_unit")
   @Expose
-  private String trialUnit;
+  private Constants.IntervalUnit trialUnit;
 
   /**
    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to
@@ -319,12 +320,12 @@ public class PlanUpdate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -345,12 +346,13 @@ public class PlanUpdate extends Request {
   }
 
   /** Setup fee revenue schedule type */
-  public String getSetupFeeRevenueScheduleType() {
+  public Constants.RevenueScheduleType getSetupFeeRevenueScheduleType() {
     return this.setupFeeRevenueScheduleType;
   }
 
   /** @param setupFeeRevenueScheduleType Setup fee revenue schedule type */
-  public void setSetupFeeRevenueScheduleType(final String setupFeeRevenueScheduleType) {
+  public void setSetupFeeRevenueScheduleType(
+      final Constants.RevenueScheduleType setupFeeRevenueScheduleType) {
     this.setupFeeRevenueScheduleType = setupFeeRevenueScheduleType;
   }
 
@@ -425,12 +427,12 @@ public class PlanUpdate extends Request {
   }
 
   /** Units for the plan's trial period. */
-  public String getTrialUnit() {
+  public Constants.IntervalUnit getTrialUnit() {
     return this.trialUnit;
   }
 
   /** @param trialUnit Units for the plan's trial period. */
-  public void setTrialUnit(final String trialUnit) {
+  public void setTrialUnit(final Constants.IntervalUnit trialUnit) {
     this.trialUnit = trialUnit;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -32,7 +33,7 @@ public class PurchaseCreate extends Request {
    */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /** A list of coupon_codes to be redeemed on the subscription or account during the purchase. */
   @SerializedName("coupon_codes")
@@ -107,7 +108,7 @@ public class PurchaseCreate extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /** VAT reverse charge notes for cross border European tax settlement. */
   @SerializedName("vat_reverse_charge_notes")
@@ -146,7 +147,7 @@ public class PurchaseCreate extends Request {
    * Must be set to manual in order to preview a purchase for an Account that does not have payment
    * information associated with the Billing Info.
    */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
@@ -154,7 +155,7 @@ public class PurchaseCreate extends Request {
    * @param collectionMethod Must be set to manual in order to preview a purchase for an Account
    *     that does not have payment information associated with the Billing Info.
    */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -310,7 +311,7 @@ public class PurchaseCreate extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -319,7 +320,7 @@ public class PurchaseCreate extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionAddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionAddOnCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -21,7 +22,7 @@ public class SubscriptionAddOnCreate extends Request {
    */
   @SerializedName("add_on_source")
   @Expose
-  private String addOnSource;
+  private Constants.AddOnSource addOnSource;
 
   /**
    * If `add_on_source` is set to `plan_add_on` or left blank, then plan's add-on `code` should be
@@ -40,7 +41,7 @@ public class SubscriptionAddOnCreate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
@@ -78,7 +79,7 @@ public class SubscriptionAddOnCreate extends Request {
    * associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to
    * `item`, then the associated add-on data will be pulled from the site's item catalog.
    */
-  public String getAddOnSource() {
+  public Constants.AddOnSource getAddOnSource() {
     return this.addOnSource;
   }
 
@@ -89,7 +90,7 @@ public class SubscriptionAddOnCreate extends Request {
    *     `true` and this field is set to `item`, then the associated add-on data will be pulled from
    *     the site's item catalog.
    */
-  public void setAddOnSource(final String addOnSource) {
+  public void setAddOnSource(final Constants.AddOnSource addOnSource) {
     this.addOnSource = addOnSource;
   }
 
@@ -122,12 +123,12 @@ public class SubscriptionAddOnCreate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionAddOnUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionAddOnUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -21,7 +22,7 @@ public class SubscriptionAddOnUpdate extends Request {
    */
   @SerializedName("add_on_source")
   @Expose
-  private String addOnSource;
+  private Constants.AddOnSource addOnSource;
 
   /**
    * If a code is provided without an id, the subscription add-on attributes will be set to the
@@ -50,7 +51,7 @@ public class SubscriptionAddOnUpdate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
@@ -81,7 +82,7 @@ public class SubscriptionAddOnUpdate extends Request {
    * associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to
    * `item`, then the associated add-on data will be pulled from the site's item catalog.
    */
-  public String getAddOnSource() {
+  public Constants.AddOnSource getAddOnSource() {
     return this.addOnSource;
   }
 
@@ -92,7 +93,7 @@ public class SubscriptionAddOnUpdate extends Request {
    *     `true` and this field is set to `item`, then the associated add-on data will be pulled from
    *     the site's item catalog.
    */
-  public void setAddOnSource(final String addOnSource) {
+  public void setAddOnSource(final Constants.AddOnSource addOnSource) {
     this.addOnSource = addOnSource;
   }
 
@@ -145,12 +146,12 @@ public class SubscriptionAddOnUpdate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCancel.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCancel.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -20,7 +21,7 @@ public class SubscriptionCancel extends Request {
    */
   @SerializedName("timeframe")
   @Expose
-  private String timeframe;
+  private Constants.Timeframe timeframe;
 
   /**
    * The timeframe parameter controls when the expiration takes place. The `bill_date` timeframe
@@ -28,7 +29,7 @@ public class SubscriptionCancel extends Request {
    * `term_end` timeframe causes the subscription to continue to bill until the end of the
    * subscription term, then expire.
    */
-  public String getTimeframe() {
+  public Constants.Timeframe getTimeframe() {
     return this.timeframe;
   }
 
@@ -38,7 +39,7 @@ public class SubscriptionCancel extends Request {
    *     to bill next. The `term_end` timeframe causes the subscription to continue to bill until
    *     the end of the subscription term, then expire.
    */
-  public void setTimeframe(final String timeframe) {
+  public void setTimeframe(final Constants.Timeframe timeframe) {
     this.timeframe = timeframe;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -36,7 +37,7 @@ public class SubscriptionChangeCreate extends Request {
   /** Collection method */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /**
    * A list of coupon_codes to be redeemed on the subscription during the change. Only allowed if
@@ -94,7 +95,7 @@ public class SubscriptionChangeCreate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** The shipping address can currently only be changed immediately, using SubscriptionUpdate. */
   @SerializedName("shipping")
@@ -111,7 +112,7 @@ public class SubscriptionChangeCreate extends Request {
    */
   @SerializedName("timeframe")
   @Expose
-  private String timeframe;
+  private Constants.ChangeTimeframe timeframe;
 
   /**
    * An optional type designation for the payment gateway transaction created by this request.
@@ -119,7 +120,7 @@ public class SubscriptionChangeCreate extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /**
    * Optionally, sets custom pricing for the subscription, overriding the plan's default unit
@@ -168,12 +169,12 @@ public class SubscriptionChangeCreate extends Request {
   }
 
   /** Collection method */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
   /** @param collectionMethod Collection method */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -288,12 +289,12 @@ public class SubscriptionChangeCreate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -318,7 +319,7 @@ public class SubscriptionChangeCreate extends Request {
    * `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe
    * option is accepted as an alias for `term_end`.
    */
-  public String getTimeframe() {
+  public Constants.ChangeTimeframe getTimeframe() {
     return this.timeframe;
   }
 
@@ -330,7 +331,7 @@ public class SubscriptionChangeCreate extends Request {
    *     timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing
    *     date. The `renewal` timeframe option is accepted as an alias for `term_end`.
    */
-  public void setTimeframe(final String timeframe) {
+  public void setTimeframe(final Constants.ChangeTimeframe timeframe) {
     this.timeframe = timeframe;
   }
 
@@ -338,7 +339,7 @@ public class SubscriptionChangeCreate extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -347,7 +348,7 @@ public class SubscriptionChangeCreate extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -40,7 +41,7 @@ public class SubscriptionCreate extends Request {
   /** Collection method */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /** A list of coupon_codes to be redeemed on the subscription or account during the purchase. */
   @SerializedName("coupon_codes")
@@ -137,7 +138,7 @@ public class SubscriptionCreate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Create a shipping address on the account and assign it to the subscription. */
   @SerializedName("shipping")
@@ -176,7 +177,7 @@ public class SubscriptionCreate extends Request {
    */
   @SerializedName("transaction_type")
   @Expose
-  private String transactionType;
+  private Constants.GatewayTransactionType transactionType;
 
   /**
    * If set, overrides the default trial behavior for the subscription. The date must be in the
@@ -243,12 +244,12 @@ public class SubscriptionCreate extends Request {
   }
 
   /** Collection method */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
   /** @param collectionMethod Collection method */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -445,12 +446,12 @@ public class SubscriptionCreate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -520,7 +521,7 @@ public class SubscriptionCreate extends Request {
    * An optional type designation for the payment gateway transaction created by this request.
    * Supports 'moto' value, which is the acronym for mail order and telephone transactions.
    */
-  public String getTransactionType() {
+  public Constants.GatewayTransactionType getTransactionType() {
     return this.transactionType;
   }
 
@@ -529,7 +530,7 @@ public class SubscriptionCreate extends Request {
    *     by this request. Supports 'moto' value, which is the acronym for mail order and telephone
    *     transactions.
    */
-  public void setTransactionType(final String transactionType) {
+  public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -71,7 +72,7 @@ public class SubscriptionPurchase extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Create a shipping address on the account and assign it to the subscription. */
   @SerializedName("shipping")
@@ -222,12 +223,12 @@ public class SubscriptionPurchase extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 import java.util.List;
@@ -31,7 +32,7 @@ public class SubscriptionUpdate extends Request {
   /** Change collection method */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /**
    * The custom fields will only be altered when they are included in a request. Sending an empty
@@ -92,7 +93,7 @@ public class SubscriptionUpdate extends Request {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Subscription shipping details */
   @SerializedName("shipping")
@@ -137,12 +138,12 @@ public class SubscriptionUpdate extends Request {
   }
 
   /** Change collection method */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
   /** @param collectionMethod Change collection method */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -263,12 +264,12 @@ public class SubscriptionUpdate extends Request {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/requests/Tier.java
+++ b/src/main/java/com/recurly/v3/requests/Tier.java
@@ -16,7 +16,7 @@ public class Tier extends Request {
   /** Tier pricing */
   @SerializedName("currencies")
   @Expose
-  private List<Pricing> currencies;
+  private List<TierPricing> currencies;
 
   /** Ending quantity */
   @SerializedName("ending_quantity")
@@ -24,12 +24,12 @@ public class Tier extends Request {
   private Integer endingQuantity;
 
   /** Tier pricing */
-  public List<Pricing> getCurrencies() {
+  public List<TierPricing> getCurrencies() {
     return this.currencies;
   }
 
   /** @param currencies Tier pricing */
-  public void setCurrencies(final List<Pricing> currencies) {
+  public void setCurrencies(final List<TierPricing> currencies) {
     this.currencies = currencies;
   }
 

--- a/src/main/java/com/recurly/v3/requests/TierPricing.java
+++ b/src/main/java/com/recurly/v3/requests/TierPricing.java
@@ -1,0 +1,44 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class TierPricing extends Request {
+
+  /** 3-letter ISO 4217 currency code. */
+  @SerializedName("currency")
+  @Expose
+  private String currency;
+
+  /** Unit price */
+  @SerializedName("unit_amount")
+  @Expose
+  private Float unitAmount;
+
+  /** 3-letter ISO 4217 currency code. */
+  public String getCurrency() {
+    return this.currency;
+  }
+
+  /** @param currency 3-letter ISO 4217 currency code. */
+  public void setCurrency(final String currency) {
+    this.currency = currency;
+  }
+
+  /** Unit price */
+  public Float getUnitAmount() {
+    return this.unitAmount;
+  }
+
+  /** @param unitAmount Unit price */
+  public void setUnitAmount(final Float unitAmount) {
+    this.unitAmount = unitAmount;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/Account.java
+++ b/src/main/java/com/recurly/v3/resources/Account.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -23,7 +24,7 @@ public class Account extends Resource {
    */
   @SerializedName("bill_to")
   @Expose
-  private String billTo;
+  private Constants.BillTo billTo;
 
   @SerializedName("billing_info")
   @Expose
@@ -152,7 +153,7 @@ public class Account extends Resource {
    */
   @SerializedName("preferred_locale")
   @Expose
-  private String preferredLocale;
+  private Constants.PreferredLocale preferredLocale;
 
   /** The shipping addresses on the account. */
   @SerializedName("shipping_addresses")
@@ -162,7 +163,7 @@ public class Account extends Resource {
   /** Accounts can be either active or inactive. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /**
    * The tax status of the account. `true` exempts tax on the account, `false` applies tax on the
@@ -203,7 +204,7 @@ public class Account extends Resource {
    * An enumerable describing the billing behavior of the account, specifically whether the account
    * is self-paying or will rely on the parent account to pay.
    */
-  public String getBillTo() {
+  public Constants.BillTo getBillTo() {
     return this.billTo;
   }
 
@@ -211,7 +212,7 @@ public class Account extends Resource {
    * @param billTo An enumerable describing the billing behavior of the account, specifically
    *     whether the account is self-paying or will rely on the parent account to pay.
    */
-  public void setBillTo(final String billTo) {
+  public void setBillTo(final Constants.BillTo billTo) {
     this.billTo = billTo;
   }
 
@@ -471,7 +472,7 @@ public class Account extends Resource {
    * Used to determine the language and locale of emails sent on behalf of the merchant to the
    * customer.
    */
-  public String getPreferredLocale() {
+  public Constants.PreferredLocale getPreferredLocale() {
     return this.preferredLocale;
   }
 
@@ -479,7 +480,7 @@ public class Account extends Resource {
    * @param preferredLocale Used to determine the language and locale of emails sent on behalf of
    *     the merchant to the customer.
    */
-  public void setPreferredLocale(final String preferredLocale) {
+  public void setPreferredLocale(final Constants.PreferredLocale preferredLocale) {
     this.preferredLocale = preferredLocale;
   }
 
@@ -494,12 +495,12 @@ public class Account extends Resource {
   }
 
   /** Accounts can be either active or inactive. */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state Accounts can be either active or inactive. */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AccountAcquisition.java
+++ b/src/main/java/com/recurly/v3/resources/AccountAcquisition.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -27,7 +28,7 @@ public class AccountAcquisition extends Resource {
   /** The channel through which the account was acquired. */
   @SerializedName("channel")
   @Expose
-  private String channel;
+  private Constants.Channel channel;
 
   /** Account balance */
   @SerializedName("cost")
@@ -86,12 +87,12 @@ public class AccountAcquisition extends Resource {
   }
 
   /** The channel through which the account was acquired. */
-  public String getChannel() {
+  public Constants.Channel getChannel() {
     return this.channel;
   }
 
   /** @param channel The channel through which the account was acquired. */
-  public void setChannel(final String channel) {
+  public void setChannel(final Constants.Channel channel) {
     this.channel = channel;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AddOn.java
+++ b/src/main/java/com/recurly/v3/resources/AddOn.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -24,7 +25,7 @@ public class AddOn extends Resource {
   /** Whether the add-on type is fixed, or usage-based. */
   @SerializedName("add_on_type")
   @Expose
-  private String addOnType;
+  private Constants.AddOnType addOnType;
 
   /**
    * Used by Avalara for Communications taxes. The transaction type in combination with the service
@@ -128,12 +129,12 @@ public class AddOn extends Resource {
    */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Add-ons can be either active or inactive. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
@@ -152,7 +153,7 @@ public class AddOn extends Resource {
    */
   @SerializedName("tier_type")
   @Expose
-  private String tierType;
+  private Constants.TierType tierType;
 
   /** Tiers */
   @SerializedName("tiers")
@@ -175,7 +176,7 @@ public class AddOn extends Resource {
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
   @SerializedName("usage_type")
   @Expose
-  private String usageType;
+  private Constants.UsageType usageType;
 
   /**
    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to
@@ -194,12 +195,12 @@ public class AddOn extends Resource {
   }
 
   /** Whether the add-on type is fixed, or usage-based. */
-  public String getAddOnType() {
+  public Constants.AddOnType getAddOnType() {
     return this.addOnType;
   }
 
   /** @param addOnType Whether the add-on type is fixed, or usage-based. */
-  public void setAddOnType(final String addOnType) {
+  public void setAddOnType(final Constants.AddOnType addOnType) {
     this.addOnType = addOnType;
   }
 
@@ -406,7 +407,7 @@ public class AddOn extends Resource {
    * `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the
    * request as the value will be set from the item.
    */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
@@ -415,17 +416,17 @@ public class AddOn extends Resource {
    *     schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must
    *     be absent in the request as the value will be set from the item.
    */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
   /** Add-ons can be either active or inactive. */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state Add-ons can be either active or inactive. */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 
@@ -453,7 +454,7 @@ public class AddOn extends Resource {
    * [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to
    * configure quantity-based pricing models.
    */
-  public String getTierType() {
+  public Constants.TierType getTierType() {
     return this.tierType;
   }
 
@@ -463,7 +464,7 @@ public class AddOn extends Resource {
    *     [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
    *     to configure quantity-based pricing models.
    */
-  public void setTierType(final String tierType) {
+  public void setTierType(final Constants.TierType tierType) {
     this.tierType = tierType;
   }
 
@@ -504,12 +505,12 @@ public class AddOn extends Resource {
   }
 
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
-  public String getUsageType() {
+  public Constants.UsageType getUsageType() {
     return this.usageType;
   }
 
   /** @param usageType Type of usage, returns usage type if `add_on_type` is `usage`. */
-  public void setUsageType(final String usageType) {
+  public void setUsageType(final Constants.UsageType usageType) {
     this.usageType = usageType;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/AddOnMini.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnMini.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class AddOnMini extends Resource {
@@ -22,7 +23,7 @@ public class AddOnMini extends Resource {
   /** Whether the add-on type is fixed, or usage-based. */
   @SerializedName("add_on_type")
   @Expose
-  private String addOnType;
+  private Constants.AddOnType addOnType;
 
   /** The unique identifier for the add-on within its plan. */
   @SerializedName("code")
@@ -70,7 +71,7 @@ public class AddOnMini extends Resource {
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
   @SerializedName("usage_type")
   @Expose
-  private String usageType;
+  private Constants.UsageType usageType;
 
   /**
    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to
@@ -89,12 +90,12 @@ public class AddOnMini extends Resource {
   }
 
   /** Whether the add-on type is fixed, or usage-based. */
-  public String getAddOnType() {
+  public Constants.AddOnType getAddOnType() {
     return this.addOnType;
   }
 
   /** @param addOnType Whether the add-on type is fixed, or usage-based. */
-  public void setAddOnType(final String addOnType) {
+  public void setAddOnType(final Constants.AddOnType addOnType) {
     this.addOnType = addOnType;
   }
 
@@ -190,12 +191,12 @@ public class AddOnMini extends Resource {
   }
 
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
-  public String getUsageType() {
+  public Constants.UsageType getUsageType() {
     return this.usageType;
   }
 
   /** @param usageType Type of usage, returns usage type if `add_on_type` is `usage`. */
-  public void setUsageType(final String usageType) {
+  public void setUsageType(final Constants.UsageType usageType) {
     this.usageType = usageType;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/Coupon.java
+++ b/src/main/java/com/recurly/v3/resources/Coupon.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class Coupon extends Resource {
    */
   @SerializedName("coupon_type")
   @Expose
-  private String couponType;
+  private Constants.CouponType couponType;
 
   /** Created at */
   @SerializedName("created_at")
@@ -67,7 +68,7 @@ public class Coupon extends Resource {
    */
   @SerializedName("duration")
   @Expose
-  private String duration;
+  private Constants.CouponDuration duration;
 
   /** The date and time the coupon was expired early or reached its `max_redemptions`. */
   @SerializedName("expired_at")
@@ -85,7 +86,7 @@ public class Coupon extends Resource {
    */
   @SerializedName("free_trial_unit")
   @Expose
-  private String freeTrialUnit;
+  private Constants.FreeTrialUnit freeTrialUnit;
 
   /**
    * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or
@@ -162,12 +163,12 @@ public class Coupon extends Resource {
    */
   @SerializedName("redemption_resource")
   @Expose
-  private String redemptionResource;
+  private Constants.RedemptionResource redemptionResource;
 
   /** Indicates if the coupon is redeemable, and if it is not, why. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.CouponState state;
 
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by
@@ -183,7 +184,7 @@ public class Coupon extends Resource {
    */
   @SerializedName("temporal_unit")
   @Expose
-  private String temporalUnit;
+  private Constants.TemporalUnit temporalUnit;
 
   /** On a bulk coupon, the template from which unique coupon codes are generated. */
   @SerializedName("unique_code_template")
@@ -261,7 +262,7 @@ public class Coupon extends Resource {
    * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a
    * `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  public String getCouponType() {
+  public Constants.CouponType getCouponType() {
     return this.couponType;
   }
 
@@ -269,7 +270,7 @@ public class Coupon extends Resource {
    * @param couponType Whether the coupon is "single_code" or "bulk". Bulk coupons will require a
    *     `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  public void setCouponType(final String couponType) {
+  public void setCouponType(final Constants.CouponType couponType) {
     this.couponType = couponType;
   }
 
@@ -303,7 +304,7 @@ public class Coupon extends Resource {
    * - "single_use" coupons applies to the first invoice only. - "temporal" coupons will apply to
    * invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes.
    */
-  public String getDuration() {
+  public Constants.CouponDuration getDuration() {
     return this.duration;
   }
 
@@ -312,7 +313,7 @@ public class Coupon extends Resource {
    *     will apply to invoices for the duration determined by the `temporal_unit` and
    *     `temporal_amount` attributes.
    */
-  public void setDuration(final String duration) {
+  public void setDuration(final Constants.CouponDuration duration) {
     this.duration = duration;
   }
 
@@ -343,7 +344,7 @@ public class Coupon extends Resource {
    * Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine
    * the duration of time the coupon is for.
    */
-  public String getFreeTrialUnit() {
+  public Constants.FreeTrialUnit getFreeTrialUnit() {
     return this.freeTrialUnit;
   }
 
@@ -351,7 +352,7 @@ public class Coupon extends Resource {
    * @param freeTrialUnit Description of the unit of time the coupon is for. Used with
    *     `free_trial_amount` to determine the duration of time the coupon is for.
    */
-  public void setFreeTrialUnit(final String freeTrialUnit) {
+  public void setFreeTrialUnit(final Constants.FreeTrialUnit freeTrialUnit) {
     this.freeTrialUnit = freeTrialUnit;
   }
 
@@ -499,7 +500,7 @@ public class Coupon extends Resource {
    * Whether the discount is for all eligible charges on the account, or only a specific
    * subscription.
    */
-  public String getRedemptionResource() {
+  public Constants.RedemptionResource getRedemptionResource() {
     return this.redemptionResource;
   }
 
@@ -507,17 +508,17 @@ public class Coupon extends Resource {
    * @param redemptionResource Whether the discount is for all eligible charges on the account, or
    *     only a specific subscription.
    */
-  public void setRedemptionResource(final String redemptionResource) {
+  public void setRedemptionResource(final Constants.RedemptionResource redemptionResource) {
     this.redemptionResource = redemptionResource;
   }
 
   /** Indicates if the coupon is redeemable, and if it is not, why. */
-  public String getState() {
+  public Constants.CouponState getState() {
     return this.state;
   }
 
   /** @param state Indicates if the coupon is redeemable, and if it is not, why. */
-  public void setState(final String state) {
+  public void setState(final Constants.CouponState state) {
     this.state = state;
   }
 
@@ -542,7 +543,7 @@ public class Coupon extends Resource {
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define
    * the duration that the coupon will be applied to invoices for.
    */
-  public String getTemporalUnit() {
+  public Constants.TemporalUnit getTemporalUnit() {
     return this.temporalUnit;
   }
 
@@ -550,7 +551,7 @@ public class Coupon extends Resource {
    * @param temporalUnit If `duration` is "temporal" than `temporal_unit` is multiplied by
    *     `temporal_amount` to define the duration that the coupon will be applied to invoices for.
    */
-  public void setTemporalUnit(final String temporalUnit) {
+  public void setTemporalUnit(final Constants.TemporalUnit temporalUnit) {
     this.temporalUnit = temporalUnit;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CouponDiscount.java
+++ b/src/main/java/com/recurly/v3/resources/CouponDiscount.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class CouponDiscount extends Resource {
 
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.DiscountType type;
 
   /** This is only present when `type=fixed`. */
   public List<CouponDiscountPricing> getCurrencies() {
@@ -61,12 +62,12 @@ public class CouponDiscount extends Resource {
     this.trial = trial;
   }
 
-  public String getType() {
+  public Constants.DiscountType getType() {
     return this.type;
   }
 
   /** @param type */
-  public void setType(final String type) {
+  public void setType(final Constants.DiscountType type) {
     this.type = type;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/CouponDiscountTrial.java
+++ b/src/main/java/com/recurly/v3/resources/CouponDiscountTrial.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class CouponDiscountTrial extends Resource {
@@ -19,7 +20,7 @@ public class CouponDiscountTrial extends Resource {
   /** Temporal unit of the free trial */
   @SerializedName("unit")
   @Expose
-  private String unit;
+  private Constants.FreeTrialUnit unit;
 
   /** Trial length measured in the units specified by the sibling `unit` property */
   public Integer getLength() {
@@ -32,12 +33,12 @@ public class CouponDiscountTrial extends Resource {
   }
 
   /** Temporal unit of the free trial */
-  public String getUnit() {
+  public Constants.FreeTrialUnit getUnit() {
     return this.unit;
   }
 
   /** @param unit Temporal unit of the free trial */
-  public void setUnit(final String unit) {
+  public void setUnit(final Constants.FreeTrialUnit unit) {
     this.unit = unit;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/CouponMini.java
+++ b/src/main/java/com/recurly/v3/resources/CouponMini.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -23,7 +24,7 @@ public class CouponMini extends Resource {
    */
   @SerializedName("coupon_type")
   @Expose
-  private String couponType;
+  private Constants.CouponType couponType;
 
   /**
    * Details of the discount a coupon applies. Will contain a `type` property and one of the
@@ -56,7 +57,7 @@ public class CouponMini extends Resource {
   /** Indicates if the coupon is redeemable, and if it is not, why. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.CouponState state;
 
   /** The code the customer enters to redeem the coupon. */
   public String getCode() {
@@ -72,7 +73,7 @@ public class CouponMini extends Resource {
    * Whether the coupon is "single_code" or "bulk". Bulk coupons will require a
    * `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  public String getCouponType() {
+  public Constants.CouponType getCouponType() {
     return this.couponType;
   }
 
@@ -80,7 +81,7 @@ public class CouponMini extends Resource {
    * @param couponType Whether the coupon is "single_code" or "bulk". Bulk coupons will require a
    *     `unique_code_template` and will generate unique codes through the `/generate` endpoint.
    */
-  public void setCouponType(final String couponType) {
+  public void setCouponType(final Constants.CouponType couponType) {
     this.couponType = couponType;
   }
 
@@ -144,12 +145,12 @@ public class CouponMini extends Resource {
   }
 
   /** Indicates if the coupon is redeemable, and if it is not, why. */
-  public String getState() {
+  public Constants.CouponState getState() {
     return this.state;
   }
 
   /** @param state Indicates if the coupon is redeemable, and if it is not, why. */
-  public void setState(final String state) {
+  public void setState(final Constants.CouponState state) {
     this.state = state;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/CouponRedemption.java
+++ b/src/main/java/com/recurly/v3/resources/CouponRedemption.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -56,7 +57,7 @@ public class CouponRedemption extends Resource {
   /** Coupon Redemption state */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /** Last updated at */
   @SerializedName("updated_at")
@@ -150,12 +151,12 @@ public class CouponRedemption extends Resource {
   }
 
   /** Coupon Redemption state */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state Coupon Redemption state */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CouponRedemptionMini.java
+++ b/src/main/java/com/recurly/v3/resources/CouponRedemptionMini.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -41,7 +42,7 @@ public class CouponRedemptionMini extends Resource {
   /** Invoice state */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   public CouponMini getCoupon() {
     return this.coupon;
@@ -98,12 +99,12 @@ public class CouponRedemptionMini extends Resource {
   }
 
   /** Invoice state */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state Invoice state */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/CreditPayment.java
+++ b/src/main/java/com/recurly/v3/resources/CreditPayment.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -20,7 +21,7 @@ public class CreditPayment extends Resource {
   /** The action for which the credit was created. */
   @SerializedName("action")
   @Expose
-  private String action;
+  private Constants.CreditPaymentAction action;
 
   /** Total credit payment amount applied to the charge invoice. */
   @SerializedName("amount")
@@ -94,12 +95,12 @@ public class CreditPayment extends Resource {
   }
 
   /** The action for which the credit was created. */
-  public String getAction() {
+  public Constants.CreditPaymentAction getAction() {
     return this.action;
   }
 
   /** @param action The action for which the credit was created. */
-  public void setAction(final String action) {
+  public void setAction(final Constants.CreditPaymentAction action) {
     this.action = action;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CustomFieldDefinition.java
+++ b/src/main/java/com/recurly/v3/resources/CustomFieldDefinition.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -51,7 +52,7 @@ public class CustomFieldDefinition extends Resource {
   /** Related Recurly object type */
   @SerializedName("related_type")
   @Expose
-  private String relatedType;
+  private Constants.RelatedType relatedType;
 
   /** Displayed as a tooltip when editing the field in the Recurly admin UI. */
   @SerializedName("tooltip")
@@ -72,7 +73,7 @@ public class CustomFieldDefinition extends Resource {
    */
   @SerializedName("user_access")
   @Expose
-  private String userAccess;
+  private Constants.UserAccess userAccess;
 
   /** Created at */
   public DateTime getCreatedAt() {
@@ -150,12 +151,12 @@ public class CustomFieldDefinition extends Resource {
   }
 
   /** Related Recurly object type */
-  public String getRelatedType() {
+  public Constants.RelatedType getRelatedType() {
     return this.relatedType;
   }
 
   /** @param relatedType Related Recurly object type */
-  public void setRelatedType(final String relatedType) {
+  public void setRelatedType(final Constants.RelatedType relatedType) {
     this.relatedType = relatedType;
   }
 
@@ -186,7 +187,7 @@ public class CustomFieldDefinition extends Resource {
    * the API. - `write` - Users with the Customers role will be able to view and edit this field's
    * data via the admin UI.
    */
-  public String getUserAccess() {
+  public Constants.UserAccess getUserAccess() {
     return this.userAccess;
   }
 
@@ -197,7 +198,7 @@ public class CustomFieldDefinition extends Resource {
    *     will only be available via the API. - `write` - Users with the Customers role will be able
    *     to view and edit this field's data via the admin UI.
    */
-  public void setUserAccess(final String userAccess) {
+  public void setUserAccess(final Constants.UserAccess userAccess) {
     this.userAccess = userAccess;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/Error.java
+++ b/src/main/java/com/recurly/v3/resources/Error.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +27,7 @@ public class Error extends Resource {
   /** Type */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.ErrorType type;
 
   /** Message */
   public String getMessage() {
@@ -49,12 +50,12 @@ public class Error extends Resource {
   }
 
   /** Type */
-  public String getType() {
+  public Constants.ErrorType getType() {
     return this.type;
   }
 
   /** @param type Type */
-  public void setType(final String type) {
+  public void setType(final Constants.ErrorType type) {
     this.type = type;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/ErrorMayHaveTransaction.java
+++ b/src/main/java/com/recurly/v3/resources/ErrorMayHaveTransaction.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ public class ErrorMayHaveTransaction extends Resource {
   /** Type */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.ErrorType type;
 
   /** Message */
   public String getMessage() {
@@ -64,12 +65,12 @@ public class ErrorMayHaveTransaction extends Resource {
   }
 
   /** Type */
-  public String getType() {
+  public Constants.ErrorType getType() {
     return this.type;
   }
 
   /** @param type Type */
-  public void setType(final String type) {
+  public void setType(final Constants.ErrorType type) {
     this.type = type;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/FraudInfo.java
+++ b/src/main/java/com/recurly/v3/resources/FraudInfo.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.Map;
 
@@ -15,7 +16,7 @@ public class FraudInfo extends Resource {
   /** Kount decision */
   @SerializedName("decision")
   @Expose
-  private String decision;
+  private Constants.KountDecision decision;
 
   /** Kount rules */
   @SerializedName("risk_rules_triggered")
@@ -28,12 +29,12 @@ public class FraudInfo extends Resource {
   private Integer score;
 
   /** Kount decision */
-  public String getDecision() {
+  public Constants.KountDecision getDecision() {
     return this.decision;
   }
 
   /** @param decision Kount decision */
-  public void setDecision(final String decision) {
+  public void setDecision(final Constants.KountDecision decision) {
     this.decision = decision;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -50,7 +51,7 @@ public class Invoice extends Resource {
    */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /** Created at */
   @SerializedName("created_at")
@@ -121,7 +122,7 @@ public class Invoice extends Resource {
   /** The event that created the invoice. */
   @SerializedName("origin")
   @Expose
-  private String origin;
+  private Constants.Origin origin;
 
   /** The total amount of successful payments transaction on this invoice. */
   @SerializedName("paid")
@@ -153,7 +154,7 @@ public class Invoice extends Resource {
   /** Invoice state */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.InvoiceState state;
 
   /** If the invoice is charging or refunding for one or more subscriptions, these are their IDs. */
   @SerializedName("subscription_ids")
@@ -198,7 +199,7 @@ public class Invoice extends Resource {
   /** Invoices are either charge, credit, or legacy invoices. */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.InvoiceType type;
 
   /** Last updated at */
   @SerializedName("updated_at")
@@ -290,7 +291,7 @@ public class Invoice extends Resource {
    * customer pay the invoice with an automatic method, like credit card, PayPal, Amazon, or ACH
    * bank payment.
    */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
@@ -301,7 +302,7 @@ public class Invoice extends Resource {
    *     transaction or have the customer pay the invoice with an automatic method, like credit
    *     card, PayPal, Amazon, or ACH bank payment.
    */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -439,12 +440,12 @@ public class Invoice extends Resource {
   }
 
   /** The event that created the invoice. */
-  public String getOrigin() {
+  public Constants.Origin getOrigin() {
     return this.origin;
   }
 
   /** @param origin The event that created the invoice. */
-  public void setOrigin(final String origin) {
+  public void setOrigin(final Constants.Origin origin) {
     this.origin = origin;
   }
 
@@ -510,12 +511,12 @@ public class Invoice extends Resource {
   }
 
   /** Invoice state */
-  public String getState() {
+  public Constants.InvoiceState getState() {
     return this.state;
   }
 
   /** @param state Invoice state */
-  public void setState(final String state) {
+  public void setState(final Constants.InvoiceState state) {
     this.state = state;
   }
 
@@ -605,12 +606,12 @@ public class Invoice extends Resource {
   }
 
   /** Invoices are either charge, credit, or legacy invoices. */
-  public String getType() {
+  public Constants.InvoiceType getType() {
     return this.type;
   }
 
   /** @param type Invoices are either charge, credit, or legacy invoices. */
-  public void setType(final String type) {
+  public void setType(final Constants.InvoiceType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/recurly/v3/resources/InvoiceMini.java
+++ b/src/main/java/com/recurly/v3/resources/InvoiceMini.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class InvoiceMini extends Resource {
@@ -29,12 +30,12 @@ public class InvoiceMini extends Resource {
   /** Invoice state */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.InvoiceState state;
 
   /** Invoice type */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.InvoiceType type;
 
   /** Invoice ID */
   public String getId() {
@@ -67,22 +68,22 @@ public class InvoiceMini extends Resource {
   }
 
   /** Invoice state */
-  public String getState() {
+  public Constants.InvoiceState getState() {
     return this.state;
   }
 
   /** @param state Invoice state */
-  public void setState(final String state) {
+  public void setState(final Constants.InvoiceState state) {
     this.state = state;
   }
 
   /** Invoice type */
-  public String getType() {
+  public Constants.InvoiceType getType() {
     return this.type;
   }
 
   /** @param type Invoice type */
-  public void setType(final String type) {
+  public void setType(final Constants.InvoiceType type) {
     this.type = type;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/Item.java
+++ b/src/main/java/com/recurly/v3/resources/Item.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -98,12 +99,12 @@ public class Item extends Resource {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** The current state of the item. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
@@ -291,22 +292,22 @@ public class Item extends Resource {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
   /** The current state of the item. */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state The current state of the item. */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 

--- a/src/main/java/com/recurly/v3/resources/ItemMini.java
+++ b/src/main/java/com/recurly/v3/resources/ItemMini.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class ItemMini extends Resource {
@@ -42,7 +43,7 @@ public class ItemMini extends Resource {
   /** The current state of the item. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /** Unique code to identify the item. */
   public String getCode() {
@@ -101,12 +102,12 @@ public class ItemMini extends Resource {
   }
 
   /** The current state of the item. */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state The current state of the item. */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -75,7 +76,7 @@ public class LineItem extends Resource {
   /** The reason the credit was given when line item is `type=credit`. */
   @SerializedName("credit_reason_code")
   @Expose
-  private String creditReasonCode;
+  private Constants.FullCreditReasonCode creditReasonCode;
 
   /** 3-letter ISO 4217 currency code. */
   @SerializedName("currency")
@@ -154,7 +155,7 @@ public class LineItem extends Resource {
    */
   @SerializedName("legacy_category")
   @Expose
-  private String legacyCategory;
+  private Constants.LegacyCategory legacyCategory;
 
   /** Object type */
   @SerializedName("object")
@@ -164,7 +165,7 @@ public class LineItem extends Resource {
   /** A credit created from an original charge will have the value of the charge's origin. */
   @SerializedName("origin")
   @Expose
-  private String origin;
+  private Constants.LineItemOrigin origin;
 
   /**
    * The invoice where the credit originated. Will only have a value if the line item is a credit
@@ -233,7 +234,7 @@ public class LineItem extends Resource {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.LineItemRevenueScheduleType revenueScheduleType;
 
   @SerializedName("shipping_address")
   @Expose
@@ -253,7 +254,7 @@ public class LineItem extends Resource {
    */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.LineItemState state;
 
   /** If the line item is a charge or credit for a subscription, this is its ID. */
   @SerializedName("subscription_id")
@@ -304,7 +305,7 @@ public class LineItem extends Resource {
    */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.LineItemType type;
 
   /** Positive amount for a charge, negative amount for a credit. */
   @SerializedName("unit_amount")
@@ -446,12 +447,12 @@ public class LineItem extends Resource {
   }
 
   /** The reason the credit was given when line item is `type=credit`. */
-  public String getCreditReasonCode() {
+  public Constants.FullCreditReasonCode getCreditReasonCode() {
     return this.creditReasonCode;
   }
 
   /** @param creditReasonCode The reason the credit was given when line item is `type=credit`. */
-  public void setCreditReasonCode(final String creditReasonCode) {
+  public void setCreditReasonCode(final Constants.FullCreditReasonCode creditReasonCode) {
     this.creditReasonCode = creditReasonCode;
   }
 
@@ -597,7 +598,7 @@ public class LineItem extends Resource {
    * first originated. - "carryforwards" can be ignored. They exist to consume any remaining credit
    * balance. A new credit with the same amount will be created and placed back on the account.
    */
-  public String getLegacyCategory() {
+  public Constants.LegacyCategory getLegacyCategory() {
     return this.legacyCategory;
   }
 
@@ -610,7 +611,7 @@ public class LineItem extends Resource {
    *     be ignored. They exist to consume any remaining credit balance. A new credit with the same
    *     amount will be created and placed back on the account.
    */
-  public void setLegacyCategory(final String legacyCategory) {
+  public void setLegacyCategory(final Constants.LegacyCategory legacyCategory) {
     this.legacyCategory = legacyCategory;
   }
 
@@ -625,7 +626,7 @@ public class LineItem extends Resource {
   }
 
   /** A credit created from an original charge will have the value of the charge's origin. */
-  public String getOrigin() {
+  public Constants.LineItemOrigin getOrigin() {
     return this.origin;
   }
 
@@ -633,7 +634,7 @@ public class LineItem extends Resource {
    * @param origin A credit created from an original charge will have the value of the charge's
    *     origin.
    */
-  public void setOrigin(final String origin) {
+  public void setOrigin(final Constants.LineItemOrigin origin) {
     this.origin = origin;
   }
 
@@ -775,12 +776,13 @@ public class LineItem extends Resource {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.LineItemRevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(
+      final Constants.LineItemRevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -813,7 +815,7 @@ public class LineItem extends Resource {
    * Pending line items are charges or credits on an account that have not been applied to an
    * invoice yet. Invoiced line items will always have an `invoice_id` value.
    */
-  public String getState() {
+  public Constants.LineItemState getState() {
     return this.state;
   }
 
@@ -821,7 +823,7 @@ public class LineItem extends Resource {
    * @param state Pending line items are charges or credits on an account that have not been applied
    *     to an invoice yet. Invoiced line items will always have an `invoice_id` value.
    */
-  public void setState(final String state) {
+  public void setState(final Constants.LineItemState state) {
     this.state = state;
   }
 
@@ -919,7 +921,7 @@ public class LineItem extends Resource {
    * Charges are positive line items that debit the account. Credits are negative line items that
    * credit the account.
    */
-  public String getType() {
+  public Constants.LineItemType getType() {
     return this.type;
   }
 
@@ -927,7 +929,7 @@ public class LineItem extends Resource {
    * @param type Charges are positive line items that debit the account. Credits are negative line
    *     items that credit the account.
    */
-  public void setType(final String type) {
+  public void setType(final Constants.LineItemType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -305,7 +305,7 @@ public class LineItem extends Resource {
    */
   @SerializedName("type")
   @Expose
-  private Constants.LineItemType type;
+  private Constants.LintItemType type;
 
   /** Positive amount for a charge, negative amount for a credit. */
   @SerializedName("unit_amount")
@@ -921,7 +921,7 @@ public class LineItem extends Resource {
    * Charges are positive line items that debit the account. Credits are negative line items that
    * credit the account.
    */
-  public Constants.LineItemType getType() {
+  public Constants.LintItemType getType() {
     return this.type;
   }
 
@@ -929,7 +929,7 @@ public class LineItem extends Resource {
    * @param type Charges are positive line items that debit the account. Credits are negative line
    *     items that credit the account.
    */
-  public void setType(final Constants.LineItemType type) {
+  public void setType(final Constants.LintItemType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/recurly/v3/resources/MeasuredUnit.java
+++ b/src/main/java/com/recurly/v3/resources/MeasuredUnit.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -53,7 +54,7 @@ public class MeasuredUnit extends Resource {
   /** The current state of the measured unit. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /** Last updated at */
   @SerializedName("updated_at")
@@ -137,12 +138,12 @@ public class MeasuredUnit extends Resource {
   }
 
   /** The current state of the measured unit. */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state The current state of the measured unit. */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 

--- a/src/main/java/com/recurly/v3/resources/PaymentMethod.java
+++ b/src/main/java/com/recurly/v3/resources/PaymentMethod.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class PaymentMethod extends Resource {
@@ -14,7 +15,7 @@ public class PaymentMethod extends Resource {
   /** The bank account type. Only present for ACH payment methods. */
   @SerializedName("account_type")
   @Expose
-  private String accountType;
+  private Constants.AccountType accountType;
 
   /** Billing Agreement identifier. Only present for Amazon or Paypal payment methods. */
   @SerializedName("billing_agreement_id")
@@ -24,7 +25,7 @@ public class PaymentMethod extends Resource {
   /** Visa, MasterCard, American Express, Discover, JCB, etc. */
   @SerializedName("card_type")
   @Expose
-  private String cardType;
+  private Constants.CardType cardType;
 
   /** Expiration month. */
   @SerializedName("exp_month")
@@ -68,7 +69,7 @@ public class PaymentMethod extends Resource {
 
   @SerializedName("object")
   @Expose
-  private String object;
+  private Constants.PaymentMethod object;
 
   /** The bank account's routing number. Only present for ACH payment methods. */
   @SerializedName("routing_number")
@@ -81,12 +82,12 @@ public class PaymentMethod extends Resource {
   private String routingNumberBank;
 
   /** The bank account type. Only present for ACH payment methods. */
-  public String getAccountType() {
+  public Constants.AccountType getAccountType() {
     return this.accountType;
   }
 
   /** @param accountType The bank account type. Only present for ACH payment methods. */
-  public void setAccountType(final String accountType) {
+  public void setAccountType(final Constants.AccountType accountType) {
     this.accountType = accountType;
   }
 
@@ -104,12 +105,12 @@ public class PaymentMethod extends Resource {
   }
 
   /** Visa, MasterCard, American Express, Discover, JCB, etc. */
-  public String getCardType() {
+  public Constants.CardType getCardType() {
     return this.cardType;
   }
 
   /** @param cardType Visa, MasterCard, American Express, Discover, JCB, etc. */
-  public void setCardType(final String cardType) {
+  public void setCardType(final Constants.CardType cardType) {
     this.cardType = cardType;
   }
 
@@ -198,12 +199,12 @@ public class PaymentMethod extends Resource {
     this.nameOnAccount = nameOnAccount;
   }
 
-  public String getObject() {
+  public Constants.PaymentMethod getObject() {
     return this.object;
   }
 
   /** @param object */
-  public void setObject(final String object) {
+  public void setObject(final Constants.PaymentMethod object) {
     this.object = object;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Plan.java
+++ b/src/main/java/com/recurly/v3/resources/Plan.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -106,7 +107,7 @@ public class Plan extends Resource {
   /** Unit for the plan's billing interval. */
   @SerializedName("interval_unit")
   @Expose
-  private String intervalUnit;
+  private Constants.IntervalUnit intervalUnit;
 
   /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's
@@ -124,7 +125,7 @@ public class Plan extends Resource {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
    * Accounting code for invoice line items for the plan's setup fee. If no value is provided, it
@@ -137,12 +138,12 @@ public class Plan extends Resource {
   /** Setup fee revenue schedule type */
   @SerializedName("setup_fee_revenue_schedule_type")
   @Expose
-  private String setupFeeRevenueScheduleType;
+  private Constants.RevenueScheduleType setupFeeRevenueScheduleType;
 
   /** The current state of the plan. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.ActiveState state;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
@@ -183,7 +184,7 @@ public class Plan extends Resource {
   /** Units for the plan's trial period. */
   @SerializedName("trial_unit")
   @Expose
-  private String trialUnit;
+  private Constants.IntervalUnit trialUnit;
 
   /** Last updated at */
   @SerializedName("updated_at")
@@ -371,12 +372,12 @@ public class Plan extends Resource {
   }
 
   /** Unit for the plan's billing interval. */
-  public String getIntervalUnit() {
+  public Constants.IntervalUnit getIntervalUnit() {
     return this.intervalUnit;
   }
 
   /** @param intervalUnit Unit for the plan's billing interval. */
-  public void setIntervalUnit(final String intervalUnit) {
+  public void setIntervalUnit(final Constants.IntervalUnit intervalUnit) {
     this.intervalUnit = intervalUnit;
   }
 
@@ -407,12 +408,12 @@ public class Plan extends Resource {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -433,22 +434,23 @@ public class Plan extends Resource {
   }
 
   /** Setup fee revenue schedule type */
-  public String getSetupFeeRevenueScheduleType() {
+  public Constants.RevenueScheduleType getSetupFeeRevenueScheduleType() {
     return this.setupFeeRevenueScheduleType;
   }
 
   /** @param setupFeeRevenueScheduleType Setup fee revenue schedule type */
-  public void setSetupFeeRevenueScheduleType(final String setupFeeRevenueScheduleType) {
+  public void setSetupFeeRevenueScheduleType(
+      final Constants.RevenueScheduleType setupFeeRevenueScheduleType) {
     this.setupFeeRevenueScheduleType = setupFeeRevenueScheduleType;
   }
 
   /** The current state of the plan. */
-  public String getState() {
+  public Constants.ActiveState getState() {
     return this.state;
   }
 
   /** @param state The current state of the plan. */
-  public void setState(final String state) {
+  public void setState(final Constants.ActiveState state) {
     this.state = state;
   }
 
@@ -526,12 +528,12 @@ public class Plan extends Resource {
   }
 
   /** Units for the plan's trial period. */
-  public String getTrialUnit() {
+  public Constants.IntervalUnit getTrialUnit() {
     return this.trialUnit;
   }
 
   /** @param trialUnit Units for the plan's trial period. */
-  public void setTrialUnit(final String trialUnit) {
+  public void setTrialUnit(final Constants.IntervalUnit trialUnit) {
     this.trialUnit = trialUnit;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Settings.java
+++ b/src/main/java/com/recurly/v3/resources/Settings.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 
@@ -22,7 +23,7 @@ public class Settings extends Resource {
    */
   @SerializedName("billing_address_requirement")
   @Expose
-  private String billingAddressRequirement;
+  private Constants.AddressRequirement billingAddressRequirement;
 
   /** The default 3-letter ISO 4217 currency code. */
   @SerializedName("default_currency")
@@ -42,7 +43,7 @@ public class Settings extends Resource {
    * - full: Full Address (Street, City, State, Postal Code and Country) - streetzip: Street and
    * Postal Code only - zip: Postal Code only - none: No Address
    */
-  public String getBillingAddressRequirement() {
+  public Constants.AddressRequirement getBillingAddressRequirement() {
     return this.billingAddressRequirement;
   }
 
@@ -51,7 +52,8 @@ public class Settings extends Resource {
    *     Country) - streetzip: Street and Postal Code only - zip: Postal Code only - none: No
    *     Address
    */
-  public void setBillingAddressRequirement(final String billingAddressRequirement) {
+  public void setBillingAddressRequirement(
+      final Constants.AddressRequirement billingAddressRequirement) {
     this.billingAddressRequirement = billingAddressRequirement;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Site.java
+++ b/src/main/java/com/recurly/v3/resources/Site.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -30,7 +31,7 @@ public class Site extends Resource {
   /** A list of features enabled for the site. */
   @SerializedName("features")
   @Expose
-  private List<String> features;
+  private List<Constants.Features> features;
 
   /** Site ID */
   @SerializedName("id")
@@ -40,7 +41,7 @@ public class Site extends Resource {
   /** Mode */
   @SerializedName("mode")
   @Expose
-  private String mode;
+  private Constants.SiteMode mode;
 
   /** Object type */
   @SerializedName("object")
@@ -95,12 +96,12 @@ public class Site extends Resource {
   }
 
   /** A list of features enabled for the site. */
-  public List<String> getFeatures() {
+  public List<Constants.Features> getFeatures() {
     return this.features;
   }
 
   /** @param features A list of features enabled for the site. */
-  public void setFeatures(final List<String> features) {
+  public void setFeatures(final List<Constants.Features> features) {
     this.features = features;
   }
 
@@ -115,12 +116,12 @@ public class Site extends Resource {
   }
 
   /** Mode */
-  public String getMode() {
+  public Constants.SiteMode getMode() {
     return this.mode;
   }
 
   /** @param mode Mode */
-  public void setMode(final String mode) {
+  public void setMode(final Constants.SiteMode mode) {
     this.mode = mode;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -60,7 +61,7 @@ public class Subscription extends Resource {
   /** Collection method */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /** Returns subscription level coupon redemptions that are tied to this subscription. */
   @SerializedName("coupon_redemptions")
@@ -194,7 +195,7 @@ public class Subscription extends Resource {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Subscription shipping details */
   @SerializedName("shipping")
@@ -204,7 +205,7 @@ public class Subscription extends Resource {
   /** State */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.SubscriptionState state;
 
   /** Estimated total, before tax. */
   @SerializedName("subtotal")
@@ -342,12 +343,12 @@ public class Subscription extends Resource {
   }
 
   /** Collection method */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
   /** @param collectionMethod Collection method */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -624,12 +625,12 @@ public class Subscription extends Resource {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -644,12 +645,12 @@ public class Subscription extends Resource {
   }
 
   /** State */
-  public String getState() {
+  public Constants.SubscriptionState getState() {
     return this.state;
   }
 
   /** @param state State */
-  public void setState(final String state) {
+  public void setState(final Constants.SubscriptionState state) {
     this.state = state;
   }
 

--- a/src/main/java/com/recurly/v3/resources/SubscriptionAddOn.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionAddOn.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -26,7 +27,7 @@ public class SubscriptionAddOn extends Resource {
    */
   @SerializedName("add_on_source")
   @Expose
-  private String addOnSource;
+  private Constants.AddOnSource addOnSource;
 
   /** Created at */
   @SerializedName("created_at")
@@ -56,7 +57,7 @@ public class SubscriptionAddOn extends Resource {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Subscription ID */
   @SerializedName("subscription_id")
@@ -71,7 +72,7 @@ public class SubscriptionAddOn extends Resource {
    */
   @SerializedName("tier_type")
   @Expose
-  private String tierType;
+  private Constants.TierType tierType;
 
   /**
    * If tiers are provided in the request, all existing tiers on the Subscription Add-on will be
@@ -116,7 +117,7 @@ public class SubscriptionAddOn extends Resource {
    * associated `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to
    * `item`, then the associated add-on data will be pulled from the site's item catalog.
    */
-  public String getAddOnSource() {
+  public Constants.AddOnSource getAddOnSource() {
     return this.addOnSource;
   }
 
@@ -127,7 +128,7 @@ public class SubscriptionAddOn extends Resource {
    *     `true` and this field is set to `item`, then the associated add-on data will be pulled from
    *     the site's item catalog.
    */
-  public void setAddOnSource(final String addOnSource) {
+  public void setAddOnSource(final Constants.AddOnSource addOnSource) {
     this.addOnSource = addOnSource;
   }
 
@@ -182,12 +183,12 @@ public class SubscriptionAddOn extends Resource {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 
@@ -207,7 +208,7 @@ public class SubscriptionAddOn extends Resource {
    * [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to
    * configure quantity-based pricing models.
    */
-  public String getTierType() {
+  public Constants.TierType getTierType() {
     return this.tierType;
   }
 
@@ -217,7 +218,7 @@ public class SubscriptionAddOn extends Resource {
    *     [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
    *     to configure quantity-based pricing models.
    */
-  public void setTierType(final String tierType) {
+  public void setTierType(final Constants.TierType tierType) {
     this.tierType = tierType;
   }
 

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -75,7 +76,7 @@ public class SubscriptionChange extends Resource {
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
-  private String revenueScheduleType;
+  private Constants.RevenueScheduleType revenueScheduleType;
 
   /** Subscription shipping details */
   @SerializedName("shipping")
@@ -216,12 +217,12 @@ public class SubscriptionChange extends Resource {
   }
 
   /** Revenue schedule type */
-  public String getRevenueScheduleType() {
+  public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
   }
 
   /** @param revenueScheduleType Revenue schedule type */
-  public void setRevenueScheduleType(final String revenueScheduleType) {
+  public void setRevenueScheduleType(final Constants.RevenueScheduleType revenueScheduleType) {
     this.revenueScheduleType = revenueScheduleType;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Tier.java
+++ b/src/main/java/com/recurly/v3/resources/Tier.java
@@ -15,7 +15,7 @@ public class Tier extends Resource {
   /** Tier pricing */
   @SerializedName("currencies")
   @Expose
-  private List<Pricing> currencies;
+  private List<TierPricing> currencies;
 
   /** Ending quantity */
   @SerializedName("ending_quantity")
@@ -23,12 +23,12 @@ public class Tier extends Resource {
   private Integer endingQuantity;
 
   /** Tier pricing */
-  public List<Pricing> getCurrencies() {
+  public List<TierPricing> getCurrencies() {
     return this.currencies;
   }
 
   /** @param currencies Tier pricing */
-  public void setCurrencies(final List<Pricing> currencies) {
+  public void setCurrencies(final List<TierPricing> currencies) {
     this.currencies = currencies;
   }
 

--- a/src/main/java/com/recurly/v3/resources/TierPricing.java
+++ b/src/main/java/com/recurly/v3/resources/TierPricing.java
@@ -1,0 +1,43 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+
+public class TierPricing extends Resource {
+
+  /** 3-letter ISO 4217 currency code. */
+  @SerializedName("currency")
+  @Expose
+  private String currency;
+
+  /** Unit price */
+  @SerializedName("unit_amount")
+  @Expose
+  private Float unitAmount;
+
+  /** 3-letter ISO 4217 currency code. */
+  public String getCurrency() {
+    return this.currency;
+  }
+
+  /** @param currency 3-letter ISO 4217 currency code. */
+  public void setCurrency(final String currency) {
+    this.currency = currency;
+  }
+
+  /** Unit price */
+  public Float getUnitAmount() {
+    return this.unitAmount;
+  }
+
+  /** @param unitAmount Unit price */
+  public void setUnitAmount(final Float unitAmount) {
+    this.unitAmount = unitAmount;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/Transaction.java
+++ b/src/main/java/com/recurly/v3/resources/Transaction.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class Transaction extends Resource {
   /** When processed, result from checking the overall AVS on the transaction. */
   @SerializedName("avs_check")
   @Expose
-  private String avsCheck;
+  private Constants.AvsCheck avsCheck;
 
   @SerializedName("billing_address")
   @Expose
@@ -41,7 +42,7 @@ public class Transaction extends Resource {
   /** The method by which the payment was collected. */
   @SerializedName("collection_method")
   @Expose
-  private String collectionMethod;
+  private Constants.CollectionMethod collectionMethod;
 
   /** Created at */
   @SerializedName("created_at")
@@ -66,7 +67,7 @@ public class Transaction extends Resource {
   /** When processed, result from checking the CVV/CVC value on the transaction. */
   @SerializedName("cvv_check")
   @Expose
-  private String cvvCheck;
+  private Constants.CvvCheck cvvCheck;
 
   /** Transaction approval code from the payment gateway. */
   @SerializedName("gateway_approval_code")
@@ -133,7 +134,7 @@ public class Transaction extends Resource {
   /** Describes how the transaction was triggered. */
   @SerializedName("origin")
   @Expose
-  private String origin;
+  private Constants.TransactionOrigin origin;
 
   /**
    * If this transaction is a refund (`type=refund`), this will be the ID of the original
@@ -162,7 +163,7 @@ public class Transaction extends Resource {
    */
   @SerializedName("status")
   @Expose
-  private String status;
+  private Constants.TransactionStatus status;
 
   /** Status code */
   @SerializedName("status_code")
@@ -195,7 +196,7 @@ public class Transaction extends Resource {
    */
   @SerializedName("type")
   @Expose
-  private String type;
+  private Constants.TransactionType type;
 
   /** Updated at */
   @SerializedName("updated_at")
@@ -240,12 +241,12 @@ public class Transaction extends Resource {
   }
 
   /** When processed, result from checking the overall AVS on the transaction. */
-  public String getAvsCheck() {
+  public Constants.AvsCheck getAvsCheck() {
     return this.avsCheck;
   }
 
   /** @param avsCheck When processed, result from checking the overall AVS on the transaction. */
-  public void setAvsCheck(final String avsCheck) {
+  public void setAvsCheck(final Constants.AvsCheck avsCheck) {
     this.avsCheck = avsCheck;
   }
 
@@ -271,12 +272,12 @@ public class Transaction extends Resource {
   }
 
   /** The method by which the payment was collected. */
-  public String getCollectionMethod() {
+  public Constants.CollectionMethod getCollectionMethod() {
     return this.collectionMethod;
   }
 
   /** @param collectionMethod The method by which the payment was collected. */
-  public void setCollectionMethod(final String collectionMethod) {
+  public void setCollectionMethod(final Constants.CollectionMethod collectionMethod) {
     this.collectionMethod = collectionMethod;
   }
 
@@ -324,12 +325,12 @@ public class Transaction extends Resource {
   }
 
   /** When processed, result from checking the CVV/CVC value on the transaction. */
-  public String getCvvCheck() {
+  public Constants.CvvCheck getCvvCheck() {
     return this.cvvCheck;
   }
 
   /** @param cvvCheck When processed, result from checking the CVV/CVC value on the transaction. */
-  public void setCvvCheck(final String cvvCheck) {
+  public void setCvvCheck(final Constants.CvvCheck cvvCheck) {
     this.cvvCheck = cvvCheck;
   }
 
@@ -460,12 +461,12 @@ public class Transaction extends Resource {
   }
 
   /** Describes how the transaction was triggered. */
-  public String getOrigin() {
+  public Constants.TransactionOrigin getOrigin() {
     return this.origin;
   }
 
   /** @param origin Describes how the transaction was triggered. */
-  public void setOrigin(final String origin) {
+  public void setOrigin(final Constants.TransactionOrigin origin) {
     this.origin = origin;
   }
 
@@ -517,7 +518,7 @@ public class Transaction extends Resource {
    * The current transaction status. Note that the status may change, e.g. a `pending` transaction
    * may become `declined` or `success` may later become `void`.
    */
-  public String getStatus() {
+  public Constants.TransactionStatus getStatus() {
     return this.status;
   }
 
@@ -525,7 +526,7 @@ public class Transaction extends Resource {
    * @param status The current transaction status. Note that the status may change, e.g. a `pending`
    *     transaction may become `declined` or `success` may later become `void`.
    */
-  public void setStatus(final String status) {
+  public void setStatus(final Constants.TransactionStatus status) {
     this.status = status;
   }
 
@@ -584,7 +585,7 @@ public class Transaction extends Resource {
    * all or a portion of the money collected in a previous transaction to the customer. - `verify` –
    * a $0 or $1 transaction used to verify billing information which is immediately voided.
    */
-  public String getType() {
+  public Constants.TransactionType getType() {
     return this.type;
   }
 
@@ -596,7 +597,7 @@ public class Transaction extends Resource {
    *     customer. - `verify` – a $0 or $1 transaction used to verify billing information which is
    *     immediately voided.
    */
-  public void setType(final String type) {
+  public void setType(final Constants.TransactionType type) {
     this.type = type;
   }
 

--- a/src/main/java/com/recurly/v3/resources/TransactionError.java
+++ b/src/main/java/com/recurly/v3/resources/TransactionError.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class TransactionError extends Resource {
@@ -14,12 +15,12 @@ public class TransactionError extends Resource {
   /** Category */
   @SerializedName("category")
   @Expose
-  private String category;
+  private Constants.ErrorCategory category;
 
   /** Code */
   @SerializedName("code")
   @Expose
-  private String code;
+  private Constants.ErrorCode code;
 
   /** Merchant message */
   @SerializedName("merchant_advice")
@@ -50,22 +51,22 @@ public class TransactionError extends Resource {
   private String transactionId;
 
   /** Category */
-  public String getCategory() {
+  public Constants.ErrorCategory getCategory() {
     return this.category;
   }
 
   /** @param category Category */
-  public void setCategory(final String category) {
+  public void setCategory(final Constants.ErrorCategory category) {
     this.category = category;
   }
 
   /** Code */
-  public String getCode() {
+  public Constants.ErrorCode getCode() {
     return this.code;
   }
 
   /** @param code Code */
-  public void setCode(final String code) {
+  public void setCode(final Constants.ErrorCode code) {
     this.code = code;
   }
 

--- a/src/main/java/com/recurly/v3/resources/UniqueCouponCode.java
+++ b/src/main/java/com/recurly/v3/resources/UniqueCouponCode.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import org.joda.time.DateTime;
 
@@ -55,7 +56,7 @@ public class UniqueCouponCode extends Resource {
   /** Indicates if the unique coupon code is redeemable or why not. */
   @SerializedName("state")
   @Expose
-  private String state;
+  private Constants.CouponCodeState state;
 
   /** Updated at */
   @SerializedName("updated_at")
@@ -146,12 +147,12 @@ public class UniqueCouponCode extends Resource {
   }
 
   /** Indicates if the unique coupon code is redeemable or why not. */
-  public String getState() {
+  public Constants.CouponCodeState getState() {
     return this.state;
   }
 
   /** @param state Indicates if the unique coupon code is redeemable or why not. */
-  public void setState(final String state) {
+  public void setState(final Constants.CouponCodeState state) {
     this.state = state;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Usage.java
+++ b/src/main/java/com/recurly/v3/resources/Usage.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -67,7 +68,7 @@ public class Usage extends Resource {
    */
   @SerializedName("tier_type")
   @Expose
-  private String tierType;
+  private Constants.TierType tierType;
 
   /**
    * The tiers and prices of the subscription based on the usage_timestamp. If tier_type = flat,
@@ -106,7 +107,7 @@ public class Usage extends Resource {
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
   @SerializedName("usage_type")
   @Expose
-  private String usageType;
+  private Constants.UsageType usageType;
 
   /**
    * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
@@ -211,7 +212,7 @@ public class Usage extends Resource {
    * [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how to
    * configure quantity-based pricing models.
    */
-  public String getTierType() {
+  public Constants.TierType getTierType() {
     return this.tierType;
   }
 
@@ -221,7 +222,7 @@ public class Usage extends Resource {
    *     [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
    *     to configure quantity-based pricing models.
    */
-  public void setTierType(final String tierType) {
+  public void setTierType(final Constants.TierType tierType) {
     this.tierType = tierType;
   }
 
@@ -294,12 +295,12 @@ public class Usage extends Resource {
   }
 
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
-  public String getUsageType() {
+  public Constants.UsageType getUsageType() {
     return this.usageType;
   }
 
   /** @param usageType Type of usage, returns usage type if `add_on_type` is `usage`. */
-  public void setUsageType(final String usageType) {
+  public void setUsageType(final Constants.UsageType usageType) {
     this.usageType = usageType;
   }
 }

--- a/src/test/java/com/recurly/v3/JsonSerializerTest.java
+++ b/src/test/java/com/recurly/v3/JsonSerializerTest.java
@@ -22,6 +22,14 @@ public class JsonSerializerTest {
   }
 
   @Test
+  public void testDeserializeUnknownEnum() {
+    final JsonSerializer jsonSerializer = new JsonSerializer();
+    final MyResource mockResource =
+        jsonSerializer.deserialize("{\"my_constant\":\"not-defined\"}", MyResource.class);
+    assertEquals(FixtureConstants.ConstantType.UNDEFINED, mockResource.getMyConstant());
+  }
+
+  @Test
   public void testDeserializeError() {
     final JsonSerializer jsonSerializer = new JsonSerializer();
     final ApiException error = jsonSerializer.deserialize(getMockErrorJson(), ApiException.class);

--- a/src/test/java/com/recurly/v3/JsonSerializerTest.java
+++ b/src/test/java/com/recurly/v3/JsonSerializerTest.java
@@ -3,8 +3,10 @@ package com.recurly.v3;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.recurly.v3.fixtures.DateTimeTestClass;
+import com.recurly.v3.fixtures.FixtureConstants;
 import com.recurly.v3.fixtures.MyRequest;
 import com.recurly.v3.fixtures.MyResource;
+import com.recurly.v3.Constants;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
@@ -16,13 +18,14 @@ public class JsonSerializerTest {
     final MyResource mockResource =
         jsonSerializer.deserialize(getMockResourceJson(), MyResource.class);
     assertEquals("My String", mockResource.getMyString());
+    assertEquals(FixtureConstants.ConstantType.TWENTY_THREE, mockResource.getMyConstant());
   }
 
   @Test
   public void testDeserializeError() {
     final JsonSerializer jsonSerializer = new JsonSerializer();
     final ApiException error = jsonSerializer.deserialize(getMockErrorJson(), ApiException.class);
-    assertEquals("not_found", error.getError().getType());
+    assertEquals(Constants.ErrorType.NOT_FOUND, error.getError().getType());
     assertEquals("Couldn't find resource", error.getError().getMessage());
     assertEquals("some_param", error.getError().getParams().get(0).get("param"));
   }
@@ -32,8 +35,9 @@ public class JsonSerializerTest {
     final JsonSerializer jsonSerializer = new JsonSerializer();
     final MyRequest mockRequest = new MyRequest();
     mockRequest.setMyString("aaron");
+    mockRequest.setMyConstant(FixtureConstants.ConstantType.TWENTY_THREE);
     final String serialized = jsonSerializer.serialize(mockRequest);
-    assertEquals("{\"my_string\":\"aaron\"}", serialized);
+    assertEquals("{\"my_string\":\"aaron\",\"my_constant\":\"twenty-three\"}", serialized);
   }
 
   @Test
@@ -75,7 +79,8 @@ public class JsonSerializerTest {
         + "          \"object\": \"nested_resource\",\n"
         + "          \"my_string\": \"Nested String\"\n"
         + "       }\n"
-        + "    ]\n"
+        + "    ],\n"
+        + "    \"my_constant\": \"twenty-three\"\n"
         + "}";
   }
 

--- a/src/test/java/com/recurly/v3/fixtures/FixtureConstants.java
+++ b/src/test/java/com/recurly/v3/fixtures/FixtureConstants.java
@@ -1,0 +1,21 @@
+package com.recurly.v3.fixtures;
+
+import com.google.gson.annotations.SerializedName;
+
+public class FixtureConstants {
+  
+    public enum ConstantType {
+      UNDEFINED,
+    
+      @SerializedName("one")
+      ONE,
+    
+      @SerializedName("two")
+      TWO,
+    
+      @SerializedName("twenty-three")
+      TWENTY_THREE,
+    
+    };
+    
+}

--- a/src/test/java/com/recurly/v3/fixtures/MyRequest.java
+++ b/src/test/java/com/recurly/v3/fixtures/MyRequest.java
@@ -39,6 +39,10 @@ public class MyRequest extends Request {
   @Expose
   private List<NestedRequest> myNestedRequestList;
 
+  @SerializedName("my_constant")
+  @Expose
+  private FixtureConstants.ConstantType myConstant;
+
   public String getMyString() {
     return this.myString;
   }
@@ -101,5 +105,13 @@ public class MyRequest extends Request {
 
   public void setMyNestedRequestList(final List<NestedRequest> myNestedRequestList) {
     this.myNestedRequestList = myNestedRequestList;
+  }
+
+  public FixtureConstants.ConstantType getMyConstant() {
+    return this.myConstant;
+  }
+
+  public void setMyConstant(FixtureConstants.ConstantType myConstant) {
+    this.myConstant = myConstant;
   }
 }

--- a/src/test/java/com/recurly/v3/fixtures/MyResource.java
+++ b/src/test/java/com/recurly/v3/fixtures/MyResource.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
+import com.recurly.v3.fixtures.FixtureConstants;
 
 public class MyResource extends Resource {
   @SerializedName("my_string")
@@ -38,6 +39,10 @@ public class MyResource extends Resource {
   @SerializedName("my_nested_resource_list")
   @Expose
   private List<NestedResource> myNestedResourceList;
+
+  @SerializedName("my_constant")
+  @Expose
+  private FixtureConstants.ConstantType myConstant;
 
   public String getMyString() {
     return this.myString;
@@ -101,5 +106,13 @@ public class MyResource extends Resource {
 
   public void setMyNestedResourceList(final List<NestedResource> myNestedResourceList) {
     this.myNestedResourceList = myNestedResourceList;
+  }
+
+  public FixtureConstants.ConstantType getMyConstant() {
+    return this.myConstant;
+  }
+
+  public void setMyConstant(FixtureConstants.ConstantType myConstant) {
+    this.myConstant = myConstant;
   }
 }


### PR DESCRIPTION
Adds support for Enums where they are defined in the openapi specification.

If Recurly API returns an unknown value for an enumerated field, then the client will populate the field with the default `UNDEFINED` constant.