### PR TITLE
Convert query string enums to their SerializedName

### DIFF
--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -5,6 +5,7 @@ import com.recurly.v3.exception.InvalidApiKeyException;
 import com.recurly.v3.exception.NotFoundException;
 import com.recurly.v3.exception.TransactionException;
 import com.recurly.v3.exception.ValidationException;
+import com.recurly.v3.fixtures.FixtureConstants;
 import com.recurly.v3.fixtures.MockClient;
 import com.recurly.v3.fixtures.MockQueryParams;
 import com.recurly.v3.fixtures.MyRequest;
@@ -137,6 +138,7 @@ public class BaseClientTest {
       assertEquals("2.3", url.queryParameter("my_float"));
       assertEquals("4.5", url.queryParameter("my_double"));
       assertEquals("6", url.queryParameter("my_long"));
+      assertEquals("twenty-three", url.queryParameter("my_enum"));
       assertEquals(null, url.queryParameter("my_random"));
       assertEquals("[]", url.queryParameter("unsupported"));
       return mCall;
@@ -153,6 +155,7 @@ public class BaseClientTest {
     qp.setMyFloat(2.3f);
     qp.setMyDouble(4.5);
     qp.setMyLong(6L);
+    qp.setMyEnum(FixtureConstants.ConstantType.TWENTY_THREE);
     qp.setMyRandom(null);
     qp.setUnsupported(new ArrayList<>());
     final Pager<MyResource> pager = client.listResources(qp);

--- a/src/test/java/com/recurly/v3/fixtures/MockQueryParams.java
+++ b/src/test/java/com/recurly/v3/fixtures/MockQueryParams.java
@@ -29,6 +29,10 @@ public class MockQueryParams extends QueryParams {
     this.add("my_long", myLong);
   }
 
+  public void setMyEnum(FixtureConstants.ConstantType myEnum) {
+    this.add("my_enum", myEnum);
+  }
+
   public void setMyRandom(String myString) {
     this.add("my_random", myString);
   }


### PR DESCRIPTION
An extension of https://github.com/recurly/recurly-client-java/pull/127 which added `Enum` support. Query string parameters were not properly using the `SerializedName` annotation when generating the request.