### PR TITLE
Convert Float To BigDecimal

### DIFF
--- a/src/main/java/com/recurly/v3/BaseClient.java
+++ b/src/main/java/com/recurly/v3/BaseClient.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;

--- a/src/main/java/com/recurly/v3/requests/AccountAcquisitionCost.java
+++ b/src/main/java/com/recurly/v3/requests/AccountAcquisitionCost.java
@@ -9,13 +9,14 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class AccountAcquisitionCost extends Request {
 
   /** The amount of the corresponding currency used to acquire the account. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** 3-letter ISO 4217 currency code. */
   @SerializedName("currency")
@@ -23,12 +24,12 @@ public class AccountAcquisitionCost extends Request {
   private String currency;
 
   /** The amount of the corresponding currency used to acquire the account. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount The amount of the corresponding currency used to acquire the account. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnCreate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class AddOnCreate extends Request {
@@ -185,7 +186,7 @@ public class AddOnCreate extends Request {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /**
    * Type of usage, required if `add_on_type` is `usage`. See our
@@ -536,7 +537,7 @@ public class AddOnCreate extends Request {
    * places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is
    * percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -546,7 +547,7 @@ public class AddOnCreate extends Request {
    *     usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does
    *     not support tiers.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnPricing.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class AddOnPricing extends Request {
 
@@ -20,7 +21,7 @@ public class AddOnPricing extends Request {
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`. If
@@ -41,7 +42,7 @@ public class AddOnPricing extends Request {
   }
 
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -49,7 +50,7 @@ public class AddOnPricing extends Request {
    * @param unitAmount Allows up to 2 decimal places. Required unless `unit_amount_decimal` is
    *     provided.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class AddOnUpdate extends Request {
@@ -147,7 +148,7 @@ public class AddOnUpdate extends Request {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /**
    * Accounting code for invoice line items for this add-on. If no value is provided, it defaults to
@@ -414,7 +415,7 @@ public class AddOnUpdate extends Request {
    * places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is
    * percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -424,7 +425,7 @@ public class AddOnUpdate extends Request {
    *     usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does
    *     not support tiers.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/CouponPricing.java
+++ b/src/main/java/com/recurly/v3/requests/CouponPricing.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class CouponPricing extends Request {
 
@@ -20,7 +21,7 @@ public class CouponPricing extends Request {
   /** The fixed discount (in dollars) for the corresponding currency. */
   @SerializedName("discount")
   @Expose
-  private Float discount;
+  private BigDecimal discount;
 
   /** 3-letter ISO 4217 currency code. */
   public String getCurrency() {
@@ -33,12 +34,12 @@ public class CouponPricing extends Request {
   }
 
   /** The fixed discount (in dollars) for the corresponding currency. */
-  public Float getDiscount() {
+  public BigDecimal getDiscount() {
     return this.discount;
   }
 
   /** @param discount The fixed discount (in dollars) for the corresponding currency. */
-  public void setDiscount(final Float discount) {
+  public void setDiscount(final BigDecimal discount) {
     this.discount = discount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/ExternalTransaction.java
+++ b/src/main/java/com/recurly/v3/requests/ExternalTransaction.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class ExternalTransaction extends Request {
@@ -17,7 +18,7 @@ public class ExternalTransaction extends Request {
   /** The total amount of the transcaction. Cannot excceed the invoice total. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** Datetime that the external payment was collected. Defaults to current datetime. */
   @SerializedName("collected_at")
@@ -35,12 +36,12 @@ public class ExternalTransaction extends Request {
   private Constants.ExternalPaymentMethod paymentMethod;
 
   /** The total amount of the transcaction. Cannot excceed the invoice total. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount The total amount of the transcaction. Cannot excceed the invoice total. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/InvoiceRefund.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceRefund.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class InvoiceRefund extends Request {
@@ -20,7 +21,7 @@ public class InvoiceRefund extends Request {
    */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * Used as the Customer Notes on the credit invoice.
@@ -74,7 +75,7 @@ public class InvoiceRefund extends Request {
    * The amount to be refunded. The amount will be split between the line items. If no amount is
    * specified, it will default to refunding the total refundable amount on the invoice.
    */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
@@ -83,7 +84,7 @@ public class InvoiceRefund extends Request {
    *     amount is specified, it will default to refunding the total refundable amount on the
    *     invoice.
    */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class LineItemCreate extends Request {
@@ -170,7 +171,7 @@ public class LineItemCreate extends Request {
    */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Accounting Code for the `LineItem`. If `item_code`/`item_id` is part of the request then
@@ -477,7 +478,7 @@ public class LineItemCreate extends Request {
    * `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s
    * `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
    */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -488,7 +489,7 @@ public class LineItemCreate extends Request {
    *     override the `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then
    *     `unit_amount` is required.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanPricing.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class PlanPricing extends Request {
 
@@ -24,12 +25,12 @@ public class PlanPricing extends Request {
    */
   @SerializedName("setup_fee")
   @Expose
-  private Float setupFee;
+  private BigDecimal setupFee;
 
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** 3-letter ISO 4217 currency code. */
   public String getCurrency() {
@@ -46,7 +47,7 @@ public class PlanPricing extends Request {
    * cycle. For subscription plans with a trial, the setup fee will be charged at the time of
    * signup. Setup fees do not increase with the quantity of a subscription plan.
    */
-  public Float getSetupFee() {
+  public BigDecimal getSetupFee() {
     return this.setupFee;
   }
 
@@ -56,17 +57,17 @@ public class PlanPricing extends Request {
    *     charged at the time of signup. Setup fees do not increase with the quantity of a
    *     subscription plan.
    */
-  public void setSetupFee(final Float setupFee) {
+  public void setSetupFee(final BigDecimal setupFee) {
     this.setupFee = setupFee;
   }
 
   /** Unit price */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Unit price */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/Pricing.java
+++ b/src/main/java/com/recurly/v3/requests/Pricing.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class Pricing extends Request {
 
@@ -20,7 +21,7 @@ public class Pricing extends Request {
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** 3-letter ISO 4217 currency code. */
   public String getCurrency() {
@@ -33,12 +34,12 @@ public class Pricing extends Request {
   }
 
   /** Unit price */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Unit price */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/ShippingFeeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/ShippingFeeCreate.java
@@ -9,13 +9,14 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class ShippingFeeCreate extends Request {
 
   /** This is priced in the purchase's currency. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * The code of the shipping method used to deliver the purchase. If `method_id` and `method_code`
@@ -34,12 +35,12 @@ public class ShippingFeeCreate extends Request {
   private String methodId;
 
   /** This is priced in the purchase's currency. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount This is priced in the purchase's currency. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionAddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionAddOnCreate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class SubscriptionAddOnCreate extends Request {
@@ -61,7 +62,7 @@ public class SubscriptionAddOnCreate extends Request {
    */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Optionally, override the add-on's default unit amount. If the
@@ -82,7 +83,7 @@ public class SubscriptionAddOnCreate extends Request {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /**
    * Used to determine where the associated add-on data is pulled from. If this value is set to
@@ -170,7 +171,7 @@ public class SubscriptionAddOnCreate extends Request {
    * plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `unit_amount` cannot be
    * provided.
    */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -179,7 +180,7 @@ public class SubscriptionAddOnCreate extends Request {
    *     amount. If the plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then
    *     `unit_amount` cannot be provided.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 
@@ -211,7 +212,7 @@ public class SubscriptionAddOnCreate extends Request {
    * [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview
    * of how to configure usage add-ons.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -223,7 +224,7 @@ public class SubscriptionAddOnCreate extends Request {
    *     [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an
    *     overview of how to configure usage add-ons.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionAddOnTier.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionAddOnTier.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class SubscriptionAddOnTier extends Request {
 
@@ -20,7 +21,7 @@ public class SubscriptionAddOnTier extends Request {
   /** Allows up to 2 decimal places. Optionally, override the tiers' default unit amount. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Optionally, override tiers' default unit amount. If
@@ -41,7 +42,7 @@ public class SubscriptionAddOnTier extends Request {
   }
 
   /** Allows up to 2 decimal places. Optionally, override the tiers' default unit amount. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -49,7 +50,7 @@ public class SubscriptionAddOnTier extends Request {
    * @param unitAmount Allows up to 2 decimal places. Optionally, override the tiers' default unit
    *     amount.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionAddOnUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionAddOnUpdate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class SubscriptionAddOnUpdate extends Request {
@@ -69,7 +70,7 @@ public class SubscriptionAddOnUpdate extends Request {
    */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Optionally, override the add-on's default unit amount. If the
@@ -88,7 +89,7 @@ public class SubscriptionAddOnUpdate extends Request {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /**
    * Used to determine where the associated add-on data is pulled from. If this value is set to
@@ -193,7 +194,7 @@ public class SubscriptionAddOnUpdate extends Request {
    * plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `unit_amount` cannot be
    * provided.
    */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -202,7 +203,7 @@ public class SubscriptionAddOnUpdate extends Request {
    *     amount. If the plan add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then
    *     `unit_amount` cannot be provided.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 
@@ -232,7 +233,7 @@ public class SubscriptionAddOnUpdate extends Request {
    * places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is
    * percentage.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -241,7 +242,7 @@ public class SubscriptionAddOnUpdate extends Request {
    *     be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage
    *     and usage_type is percentage.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class SubscriptionChangeCreate extends Request {
@@ -128,7 +129,7 @@ public class SubscriptionChangeCreate extends Request {
    */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * If you provide a value for this field it will replace any existing add-ons. So, when adding or
@@ -356,7 +357,7 @@ public class SubscriptionChangeCreate extends Request {
    * Optionally, sets custom pricing for the subscription, overriding the plan's default unit
    * amount. The subscription's current currency will be used.
    */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -364,7 +365,7 @@ public class SubscriptionChangeCreate extends Request {
    * @param unitAmount Optionally, sets custom pricing for the subscription, overriding the plan's
    *     default unit amount. The subscription's current currency will be used.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeShippingCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeShippingCreate.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class SubscriptionChangeShippingCreate extends Request {
 
@@ -18,7 +19,7 @@ public class SubscriptionChangeShippingCreate extends Request {
    */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * The code of the shipping method used to deliver the subscription. To remove shipping set this
@@ -42,7 +43,7 @@ public class SubscriptionChangeShippingCreate extends Request {
    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or
    * `method_code` is required.
    */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
@@ -50,7 +51,7 @@ public class SubscriptionChangeShippingCreate extends Request {
    * @param amount Assigns the subscription's shipping cost. If this is greater than zero then a
    *     `method_id` or `method_code` is required.
    */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -193,7 +194,7 @@ public class SubscriptionCreate extends Request {
    */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   public AccountCreate getAccount() {
     return this.account;
@@ -554,7 +555,7 @@ public class SubscriptionCreate extends Request {
    * Override the unit amount of the subscription plan by setting this value. If not provided, the
    * subscription will inherit the price from the subscription plan for the provided currency.
    */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -563,7 +564,7 @@ public class SubscriptionCreate extends Request {
    *     not provided, the subscription will inherit the price from the subscription plan for the
    *     provided currency.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
@@ -10,6 +10,7 @@ import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -111,7 +112,7 @@ public class SubscriptionPurchase extends Request {
    */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** Add-ons */
   public List<SubscriptionAddOnCreate> getAddOns() {
@@ -297,7 +298,7 @@ public class SubscriptionPurchase extends Request {
    * provided, the subscription will inherit the price from the subscription plan for the provided
    * currency.
    */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -306,7 +307,7 @@ public class SubscriptionPurchase extends Request {
    *     cents. If not provided, the subscription will inherit the price from the subscription plan
    *     for the provided currency.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionShippingCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionShippingCreate.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class SubscriptionShippingCreate extends Request {
 
@@ -30,7 +31,7 @@ public class SubscriptionShippingCreate extends Request {
    */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * The code of the shipping method used to deliver the subscription. If `method_id` and
@@ -77,7 +78,7 @@ public class SubscriptionShippingCreate extends Request {
    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or
    * `method_code` is required.
    */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
@@ -85,7 +86,7 @@ public class SubscriptionShippingCreate extends Request {
    * @param amount Assigns the subscription's shipping cost. If this is greater than zero then a
    *     `method_id` or `method_code` is required.
    */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/SubscriptionShippingPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionShippingPurchase.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class SubscriptionShippingPurchase extends Request {
 
@@ -18,7 +19,7 @@ public class SubscriptionShippingPurchase extends Request {
    */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * The code of the shipping method used to deliver the subscription. If `method_id` and
@@ -40,7 +41,7 @@ public class SubscriptionShippingPurchase extends Request {
    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or
    * `method_code` is required.
    */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
@@ -48,7 +49,7 @@ public class SubscriptionShippingPurchase extends Request {
    * @param amount Assigns the subscription's shipping cost. If this is greater than zero then a
    *     `method_id` or `method_code` is required.
    */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/TierPricing.java
+++ b/src/main/java/com/recurly/v3/requests/TierPricing.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class TierPricing extends Request {
 
@@ -20,7 +21,7 @@ public class TierPricing extends Request {
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`. If
@@ -41,7 +42,7 @@ public class TierPricing extends Request {
   }
 
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -49,7 +50,7 @@ public class TierPricing extends Request {
    * @param unitAmount Allows up to 2 decimal places. Required unless `unit_amount_decimal` is
    *     provided.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/requests/UsageCreate.java
+++ b/src/main/java/com/recurly/v3/requests/UsageCreate.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class UsageCreate extends Request {
@@ -20,7 +21,7 @@ public class UsageCreate extends Request {
    */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * Custom field for recording the id in your own system associated with the usage, so you can
@@ -48,7 +49,7 @@ public class UsageCreate extends Request {
    * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
    * will want to format in cents. (e.g., $5.00 is "500").
    */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
@@ -57,7 +58,7 @@ public class UsageCreate extends Request {
    *     will strip them. If the usage-based add-on is billed with a percentage, your usage will be
    *     a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
    */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AccountAcquisitionCost.java
+++ b/src/main/java/com/recurly/v3/resources/AccountAcquisitionCost.java
@@ -8,13 +8,14 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class AccountAcquisitionCost extends Resource {
 
   /** The amount of the corresponding currency used to acquire the account. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** 3-letter ISO 4217 currency code. */
   @SerializedName("currency")
@@ -22,12 +23,12 @@ public class AccountAcquisitionCost extends Resource {
   private String currency;
 
   /** The amount of the corresponding currency used to acquire the account. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount The amount of the corresponding currency used to acquire the account. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AccountBalanceAmount.java
+++ b/src/main/java/com/recurly/v3/resources/AccountBalanceAmount.java
@@ -8,13 +8,14 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class AccountBalanceAmount extends Resource {
 
   /** Total amount the account is past due. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** 3-letter ISO 4217 currency code. */
   @SerializedName("currency")
@@ -22,12 +23,12 @@ public class AccountBalanceAmount extends Resource {
   private String currency;
 
   /** Total amount the account is past due. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount Total amount the account is past due. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AddOn.java
+++ b/src/main/java/com/recurly/v3/resources/AddOn.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -171,7 +172,7 @@ public class AddOn extends Resource {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
   @SerializedName("usage_type")
@@ -492,7 +493,7 @@ public class AddOn extends Resource {
    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal
    * places. A value between 0.0 and 100.0.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -500,7 +501,7 @@ public class AddOn extends Resource {
    * @param usagePercentage The percentage taken of the monetary amount of usage tracked. This can
    *     be up to 4 decimal places. A value between 0.0 and 100.0.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AddOnMini.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnMini.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class AddOnMini extends Resource {
 
@@ -66,7 +67,7 @@ public class AddOnMini extends Resource {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
   @SerializedName("usage_type")
@@ -178,7 +179,7 @@ public class AddOnMini extends Resource {
    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal
    * places. A value between 0.0 and 100.0.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -186,7 +187,7 @@ public class AddOnMini extends Resource {
    * @param usagePercentage The percentage taken of the monetary amount of usage tracked. This can
    *     be up to 4 decimal places. A value between 0.0 and 100.0.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 

--- a/src/main/java/com/recurly/v3/resources/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnPricing.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class AddOnPricing extends Resource {
 
@@ -19,7 +20,7 @@ public class AddOnPricing extends Resource {
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`. If
@@ -40,7 +41,7 @@ public class AddOnPricing extends Resource {
   }
 
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -48,7 +49,7 @@ public class AddOnPricing extends Resource {
    * @param unitAmount Allows up to 2 decimal places. Required unless `unit_amount_decimal` is
    *     provided.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CouponDiscountPricing.java
+++ b/src/main/java/com/recurly/v3/resources/CouponDiscountPricing.java
@@ -8,13 +8,14 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class CouponDiscountPricing extends Resource {
 
   /** Value of the fixed discount that this coupon applies. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** 3-letter ISO 4217 currency code. */
   @SerializedName("currency")
@@ -22,12 +23,12 @@ public class CouponDiscountPricing extends Resource {
   private String currency;
 
   /** Value of the fixed discount that this coupon applies. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount Value of the fixed discount that this coupon applies. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CouponRedemption.java
+++ b/src/main/java/com/recurly/v3/resources/CouponRedemption.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class CouponRedemption extends Resource {
@@ -37,7 +38,7 @@ public class CouponRedemption extends Resource {
    */
   @SerializedName("discounted")
   @Expose
-  private Float discounted;
+  private BigDecimal discounted;
 
   /** Coupon Redemption ID */
   @SerializedName("id")
@@ -111,7 +112,7 @@ public class CouponRedemption extends Resource {
   /**
    * The amount that was discounted upon the application of the coupon, formatted with the currency.
    */
-  public Float getDiscounted() {
+  public BigDecimal getDiscounted() {
     return this.discounted;
   }
 
@@ -119,7 +120,7 @@ public class CouponRedemption extends Resource {
    * @param discounted The amount that was discounted upon the application of the coupon, formatted
    *     with the currency.
    */
-  public void setDiscounted(final Float discounted) {
+  public void setDiscounted(final BigDecimal discounted) {
     this.discounted = discounted;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CouponRedemptionMini.java
+++ b/src/main/java/com/recurly/v3/resources/CouponRedemptionMini.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class CouponRedemptionMini extends Resource {
@@ -27,7 +28,7 @@ public class CouponRedemptionMini extends Resource {
    */
   @SerializedName("discounted")
   @Expose
-  private Float discounted;
+  private BigDecimal discounted;
 
   /** Coupon Redemption ID */
   @SerializedName("id")
@@ -66,7 +67,7 @@ public class CouponRedemptionMini extends Resource {
   /**
    * The amount that was discounted upon the application of the coupon, formatted with the currency.
    */
-  public Float getDiscounted() {
+  public BigDecimal getDiscounted() {
     return this.discounted;
   }
 
@@ -74,7 +75,7 @@ public class CouponRedemptionMini extends Resource {
    * @param discounted The amount that was discounted upon the application of the coupon, formatted
    *     with the currency.
    */
-  public void setDiscounted(final Float discounted) {
+  public void setDiscounted(final BigDecimal discounted) {
     this.discounted = discounted;
   }
 

--- a/src/main/java/com/recurly/v3/resources/CreditPayment.java
+++ b/src/main/java/com/recurly/v3/resources/CreditPayment.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class CreditPayment extends Resource {
@@ -26,7 +27,7 @@ public class CreditPayment extends Resource {
   /** Total credit payment amount applied to the charge invoice. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** Invoice mini details */
   @SerializedName("applied_to_invoice")
@@ -105,12 +106,12 @@ public class CreditPayment extends Resource {
   }
 
   /** Total credit payment amount applied to the charge invoice. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount Total credit payment amount applied to the charge invoice. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -26,7 +27,7 @@ public class Invoice extends Resource {
   /** The outstanding balance remaining on this invoice. */
   @SerializedName("balance")
   @Expose
-  private Float balance;
+  private BigDecimal balance;
 
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
@@ -79,7 +80,7 @@ public class Invoice extends Resource {
   /** Total discounts applied to this invoice. */
   @SerializedName("discount")
   @Expose
-  private Float discount;
+  private BigDecimal discount;
 
   /** Date invoice is due. This is the date the net terms are reached. */
   @SerializedName("due_at")
@@ -137,7 +138,7 @@ public class Invoice extends Resource {
   /** The total amount of successful payments transaction on this invoice. */
   @SerializedName("paid")
   @Expose
-  private Float paid;
+  private BigDecimal paid;
 
   /** For manual invoicing, this identifies the PO number associated with the subscription. */
   @SerializedName("po_number")
@@ -155,7 +156,7 @@ public class Invoice extends Resource {
   /** The refundable amount on a charge invoice. It will be null for all other invoices. */
   @SerializedName("refundable_amount")
   @Expose
-  private Float refundableAmount;
+  private BigDecimal refundableAmount;
 
   @SerializedName("shipping_address")
   @Expose
@@ -174,12 +175,12 @@ public class Invoice extends Resource {
   /** The summation of charges, discounts, and credits, before tax. */
   @SerializedName("subtotal")
   @Expose
-  private Float subtotal;
+  private BigDecimal subtotal;
 
   /** The total tax on this invoice. */
   @SerializedName("tax")
   @Expose
-  private Float tax;
+  private BigDecimal tax;
 
   /** Tax info */
   @SerializedName("tax_info")
@@ -199,7 +200,7 @@ public class Invoice extends Resource {
    */
   @SerializedName("total")
   @Expose
-  private Float total;
+  private BigDecimal total;
 
   /** Transactions */
   @SerializedName("transactions")
@@ -256,12 +257,12 @@ public class Invoice extends Resource {
   }
 
   /** The outstanding balance remaining on this invoice. */
-  public Float getBalance() {
+  public BigDecimal getBalance() {
     return this.balance;
   }
 
   /** @param balance The outstanding balance remaining on this invoice. */
-  public void setBalance(final Float balance) {
+  public void setBalance(final BigDecimal balance) {
     this.balance = balance;
   }
 
@@ -363,12 +364,12 @@ public class Invoice extends Resource {
   }
 
   /** Total discounts applied to this invoice. */
-  public Float getDiscount() {
+  public BigDecimal getDiscount() {
     return this.discount;
   }
 
   /** @param discount Total discounts applied to this invoice. */
-  public void setDiscount(final Float discount) {
+  public void setDiscount(final BigDecimal discount) {
     this.discount = discount;
   }
 
@@ -479,12 +480,12 @@ public class Invoice extends Resource {
   }
 
   /** The total amount of successful payments transaction on this invoice. */
-  public Float getPaid() {
+  public BigDecimal getPaid() {
     return this.paid;
   }
 
   /** @param paid The total amount of successful payments transaction on this invoice. */
-  public void setPaid(final Float paid) {
+  public void setPaid(final BigDecimal paid) {
     this.paid = paid;
   }
 
@@ -518,7 +519,7 @@ public class Invoice extends Resource {
   }
 
   /** The refundable amount on a charge invoice. It will be null for all other invoices. */
-  public Float getRefundableAmount() {
+  public BigDecimal getRefundableAmount() {
     return this.refundableAmount;
   }
 
@@ -526,7 +527,7 @@ public class Invoice extends Resource {
    * @param refundableAmount The refundable amount on a charge invoice. It will be null for all
    *     other invoices.
    */
-  public void setRefundableAmount(final Float refundableAmount) {
+  public void setRefundableAmount(final BigDecimal refundableAmount) {
     this.refundableAmount = refundableAmount;
   }
 
@@ -563,22 +564,22 @@ public class Invoice extends Resource {
   }
 
   /** The summation of charges, discounts, and credits, before tax. */
-  public Float getSubtotal() {
+  public BigDecimal getSubtotal() {
     return this.subtotal;
   }
 
   /** @param subtotal The summation of charges, discounts, and credits, before tax. */
-  public void setSubtotal(final Float subtotal) {
+  public void setSubtotal(final BigDecimal subtotal) {
     this.subtotal = subtotal;
   }
 
   /** The total tax on this invoice. */
-  public Float getTax() {
+  public BigDecimal getTax() {
     return this.tax;
   }
 
   /** @param tax The total tax on this invoice. */
-  public void setTax(final Float tax) {
+  public void setTax(final BigDecimal tax) {
     this.tax = tax;
   }
 
@@ -612,7 +613,7 @@ public class Invoice extends Resource {
   /**
    * The final total on this invoice. The summation of invoice charges, discounts, credits, and tax.
    */
-  public Float getTotal() {
+  public BigDecimal getTotal() {
     return this.total;
   }
 
@@ -620,7 +621,7 @@ public class Invoice extends Resource {
    * @param total The final total on this invoice. The summation of invoice charges, discounts,
    *     credits, and tax.
    */
-  public void setTotal(final Float total) {
+  public void setTotal(final BigDecimal total) {
     this.total = total;
   }
 

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 public class LineItem extends Resource {
@@ -41,7 +42,7 @@ public class LineItem extends Resource {
   /** `(quantity * unit_amount) - (discount + tax)` */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /**
    * Used by Avalara for Communications taxes. The transaction type in combination with the service
@@ -71,7 +72,7 @@ public class LineItem extends Resource {
   /** The amount of credit from this line item that was applied to the invoice. */
   @SerializedName("credit_applied")
   @Expose
-  private Float creditApplied;
+  private BigDecimal creditApplied;
 
   /** The reason the credit was given when line item is `type=credit`. */
   @SerializedName("credit_reason_code")
@@ -94,7 +95,7 @@ public class LineItem extends Resource {
   /** The discount applied to the line item. */
   @SerializedName("discount")
   @Expose
-  private Float discount;
+  private BigDecimal discount;
 
   /** If this date is provided, it indicates the end of a time range. */
   @SerializedName("end_date")
@@ -208,7 +209,7 @@ public class LineItem extends Resource {
    */
   @SerializedName("proration_rate")
   @Expose
-  private Float prorationRate;
+  private BigDecimal prorationRate;
 
   /**
    * This number will be multiplied by the unit amount to compute the subtotal before any discounts
@@ -264,12 +265,12 @@ public class LineItem extends Resource {
   /** `quantity * unit_amount` */
   @SerializedName("subtotal")
   @Expose
-  private Float subtotal;
+  private BigDecimal subtotal;
 
   /** The tax amount for the line item. */
   @SerializedName("tax")
   @Expose
-  private Float tax;
+  private BigDecimal tax;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
@@ -310,7 +311,7 @@ public class LineItem extends Resource {
   /** Positive amount for a charge, negative amount for a credit. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** Positive amount for a charge, negative amount for a credit. */
   @SerializedName("unit_amount_decimal")
@@ -380,12 +381,12 @@ public class LineItem extends Resource {
   }
 
   /** `(quantity * unit_amount) - (discount + tax)` */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount `(quantity * unit_amount) - (discount + tax)` */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 
@@ -440,14 +441,14 @@ public class LineItem extends Resource {
   }
 
   /** The amount of credit from this line item that was applied to the invoice. */
-  public Float getCreditApplied() {
+  public BigDecimal getCreditApplied() {
     return this.creditApplied;
   }
 
   /**
    * @param creditApplied The amount of credit from this line item that was applied to the invoice.
    */
-  public void setCreditApplied(final Float creditApplied) {
+  public void setCreditApplied(final BigDecimal creditApplied) {
     this.creditApplied = creditApplied;
   }
 
@@ -488,12 +489,12 @@ public class LineItem extends Resource {
   }
 
   /** The discount applied to the line item. */
-  public Float getDiscount() {
+  public BigDecimal getDiscount() {
     return this.discount;
   }
 
   /** @param discount The discount applied to the line item. */
-  public void setDiscount(final Float discount) {
+  public void setDiscount(final BigDecimal discount) {
     this.discount = discount;
   }
 
@@ -724,7 +725,7 @@ public class LineItem extends Resource {
    * made available for line items created after March 30, 2017. For line items created prior to
    * that date, the proration rate will be `null`, even if the line item was prorated.
    */
-  public Float getProrationRate() {
+  public BigDecimal getProrationRate() {
     return this.prorationRate;
   }
 
@@ -734,7 +735,7 @@ public class LineItem extends Resource {
    *     items created prior to that date, the proration rate will be `null`, even if the line item
    *     was prorated.
    */
-  public void setProrationRate(final Float prorationRate) {
+  public void setProrationRate(final BigDecimal prorationRate) {
     this.prorationRate = prorationRate;
   }
 
@@ -846,22 +847,22 @@ public class LineItem extends Resource {
   }
 
   /** `quantity * unit_amount` */
-  public Float getSubtotal() {
+  public BigDecimal getSubtotal() {
     return this.subtotal;
   }
 
   /** @param subtotal `quantity * unit_amount` */
-  public void setSubtotal(final Float subtotal) {
+  public void setSubtotal(final BigDecimal subtotal) {
     this.subtotal = subtotal;
   }
 
   /** The tax amount for the line item. */
-  public Float getTax() {
+  public BigDecimal getTax() {
     return this.tax;
   }
 
   /** @param tax The tax amount for the line item. */
-  public void setTax(final Float tax) {
+  public void setTax(final BigDecimal tax) {
     this.tax = tax;
   }
 
@@ -939,12 +940,12 @@ public class LineItem extends Resource {
   }
 
   /** Positive amount for a charge, negative amount for a credit. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Positive amount for a charge, negative amount for a credit. */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanPricing.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class PlanPricing extends Resource {
 
@@ -23,12 +24,12 @@ public class PlanPricing extends Resource {
    */
   @SerializedName("setup_fee")
   @Expose
-  private Float setupFee;
+  private BigDecimal setupFee;
 
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** 3-letter ISO 4217 currency code. */
   public String getCurrency() {
@@ -45,7 +46,7 @@ public class PlanPricing extends Resource {
    * cycle. For subscription plans with a trial, the setup fee will be charged at the time of
    * signup. Setup fees do not increase with the quantity of a subscription plan.
    */
-  public Float getSetupFee() {
+  public BigDecimal getSetupFee() {
     return this.setupFee;
   }
 
@@ -55,17 +56,17 @@ public class PlanPricing extends Resource {
    *     charged at the time of signup. Setup fees do not increase with the quantity of a
    *     subscription plan.
    */
-  public void setSetupFee(final Float setupFee) {
+  public void setSetupFee(final BigDecimal setupFee) {
     this.setupFee = setupFee;
   }
 
   /** Unit price */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Unit price */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/Pricing.java
+++ b/src/main/java/com/recurly/v3/resources/Pricing.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class Pricing extends Resource {
 
@@ -19,7 +20,7 @@ public class Pricing extends Resource {
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** 3-letter ISO 4217 currency code. */
   public String getCurrency() {
@@ -32,12 +33,12 @@ public class Pricing extends Resource {
   }
 
   /** Unit price */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Unit price */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -32,7 +33,7 @@ public class Subscription extends Resource {
   /** Total price of add-ons */
   @SerializedName("add_ons_total")
   @Expose
-  private Float addOnsTotal;
+  private BigDecimal addOnsTotal;
 
   /** Whether the subscription renews at the end of its term. */
   @SerializedName("auto_renew")
@@ -210,7 +211,7 @@ public class Subscription extends Resource {
   /** Estimated total, before tax. */
   @SerializedName("subtotal")
   @Expose
-  private Float subtotal;
+  private BigDecimal subtotal;
 
   /** Terms and conditions */
   @SerializedName("terms_and_conditions")
@@ -239,7 +240,7 @@ public class Subscription extends Resource {
   /** Subscription unit price */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** Last updated at */
   @SerializedName("updated_at")
@@ -284,12 +285,12 @@ public class Subscription extends Resource {
   }
 
   /** Total price of add-ons */
-  public Float getAddOnsTotal() {
+  public BigDecimal getAddOnsTotal() {
     return this.addOnsTotal;
   }
 
   /** @param addOnsTotal Total price of add-ons */
-  public void setAddOnsTotal(final Float addOnsTotal) {
+  public void setAddOnsTotal(final BigDecimal addOnsTotal) {
     this.addOnsTotal = addOnsTotal;
   }
 
@@ -655,12 +656,12 @@ public class Subscription extends Resource {
   }
 
   /** Estimated total, before tax. */
-  public Float getSubtotal() {
+  public BigDecimal getSubtotal() {
     return this.subtotal;
   }
 
   /** @param subtotal Estimated total, before tax. */
-  public void setSubtotal(final Float subtotal) {
+  public void setSubtotal(final BigDecimal subtotal) {
     this.subtotal = subtotal;
   }
 
@@ -713,12 +714,12 @@ public class Subscription extends Resource {
   }
 
   /** Subscription unit price */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Subscription unit price */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/SubscriptionAddOn.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionAddOn.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -85,7 +86,7 @@ public class SubscriptionAddOn extends Resource {
   /** Supports up to 2 decimal places. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** Supports up to 9 decimal places. */
   @SerializedName("unit_amount_decimal")
@@ -104,7 +105,7 @@ public class SubscriptionAddOn extends Resource {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /** Just the important parts. */
   public AddOnMini getAddOn() {
@@ -244,12 +245,12 @@ public class SubscriptionAddOn extends Resource {
   }
 
   /** Supports up to 2 decimal places. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Supports up to 2 decimal places. */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 
@@ -278,7 +279,7 @@ public class SubscriptionAddOn extends Resource {
    * places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is
    * percentage.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -287,7 +288,7 @@ public class SubscriptionAddOn extends Resource {
    *     be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage
    *     and usage_type is percentage.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/SubscriptionAddOnTier.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionAddOnTier.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class SubscriptionAddOnTier extends Resource {
 
@@ -19,7 +20,7 @@ public class SubscriptionAddOnTier extends Resource {
   /** Allows up to 2 decimal places. Optionally, override the tiers' default unit amount. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Optionally, override tiers' default unit amount. If
@@ -40,7 +41,7 @@ public class SubscriptionAddOnTier extends Resource {
   }
 
   /** Allows up to 2 decimal places. Optionally, override the tiers' default unit amount. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -48,7 +49,7 @@ public class SubscriptionAddOnTier extends Resource {
    * @param unitAmount Allows up to 2 decimal places. Optionally, override the tiers' default unit
    *     amount.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -91,7 +92,7 @@ public class SubscriptionChange extends Resource {
   /** Unit amount */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** Updated at */
   @SerializedName("updated_at")
@@ -247,12 +248,12 @@ public class SubscriptionChange extends Resource {
   }
 
   /** Unit amount */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Unit amount */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/SubscriptionShipping.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionShipping.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class SubscriptionShipping extends Resource {
 
@@ -18,7 +19,7 @@ public class SubscriptionShipping extends Resource {
   /** Subscription's shipping cost */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   @SerializedName("method")
   @Expose
@@ -39,12 +40,12 @@ public class SubscriptionShipping extends Resource {
   }
 
   /** Subscription's shipping cost */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount Subscription's shipping cost */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/TaxInfo.java
+++ b/src/main/java/com/recurly/v3/resources/TaxInfo.java
@@ -8,13 +8,14 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class TaxInfo extends Resource {
 
   /** Rate */
   @SerializedName("rate")
   @Expose
-  private Float rate;
+  private BigDecimal rate;
 
   /**
    * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter
@@ -35,12 +36,12 @@ public class TaxInfo extends Resource {
   private String type;
 
   /** Rate */
-  public Float getRate() {
+  public BigDecimal getRate() {
     return this.rate;
   }
 
   /** @param rate Rate */
-  public void setRate(final Float rate) {
+  public void setRate(final BigDecimal rate) {
     this.rate = rate;
   }
 

--- a/src/main/java/com/recurly/v3/resources/TierPricing.java
+++ b/src/main/java/com/recurly/v3/resources/TierPricing.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 
 public class TierPricing extends Resource {
 
@@ -19,7 +20,7 @@ public class TierPricing extends Resource {
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /**
    * Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`. If
@@ -40,7 +41,7 @@ public class TierPricing extends Resource {
   }
 
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
@@ -48,7 +49,7 @@ public class TierPricing extends Resource {
    * @param unitAmount Allows up to 2 decimal places. Required unless `unit_amount_decimal` is
    *     provided.
    */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Transaction.java
+++ b/src/main/java/com/recurly/v3/resources/Transaction.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.joda.time.DateTime;
@@ -23,7 +24,7 @@ public class Transaction extends Resource {
   /** Total transaction amount sent to the payment gateway. */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** When processed, result from checking the overall AVS on the transaction. */
   @SerializedName("avs_check")
@@ -92,7 +93,7 @@ public class Transaction extends Resource {
   /** Time, in seconds, for gateway to process the transaction. */
   @SerializedName("gateway_response_time")
   @Expose
-  private Float gatewayResponseTime;
+  private BigDecimal gatewayResponseTime;
 
   /** The values in this field will vary from gateway to gateway. */
   @SerializedName("gateway_response_values")
@@ -231,12 +232,12 @@ public class Transaction extends Resource {
   }
 
   /** Total transaction amount sent to the payment gateway. */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
   /** @param amount Total transaction amount sent to the payment gateway. */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 
@@ -378,12 +379,12 @@ public class Transaction extends Resource {
   }
 
   /** Time, in seconds, for gateway to process the transaction. */
-  public Float getGatewayResponseTime() {
+  public BigDecimal getGatewayResponseTime() {
     return this.gatewayResponseTime;
   }
 
   /** @param gatewayResponseTime Time, in seconds, for gateway to process the transaction. */
-  public void setGatewayResponseTime(final Float gatewayResponseTime) {
+  public void setGatewayResponseTime(final BigDecimal gatewayResponseTime) {
     this.gatewayResponseTime = gatewayResponseTime;
   }
 

--- a/src/main/java/com/recurly/v3/resources/Usage.java
+++ b/src/main/java/com/recurly/v3/resources/Usage.java
@@ -9,6 +9,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -21,7 +22,7 @@ public class Usage extends Resource {
    */
   @SerializedName("amount")
   @Expose
-  private Float amount;
+  private BigDecimal amount;
 
   /** When the usage record was billed on an invoice. */
   @SerializedName("billed_at")
@@ -81,7 +82,7 @@ public class Usage extends Resource {
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
-  private Float unitAmount;
+  private BigDecimal unitAmount;
 
   /** Unit price that can optionally support a sub-cent value. */
   @SerializedName("unit_amount_decimal")
@@ -99,7 +100,7 @@ public class Usage extends Resource {
    */
   @SerializedName("usage_percentage")
   @Expose
-  private Float usagePercentage;
+  private BigDecimal usagePercentage;
 
   /**
    * When the usage actually happened. This will define the line item dates this usage is billed
@@ -119,7 +120,7 @@ public class Usage extends Resource {
    * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
    * will want to format in cents. (e.g., $5.00 is "500").
    */
-  public Float getAmount() {
+  public BigDecimal getAmount() {
     return this.amount;
   }
 
@@ -128,7 +129,7 @@ public class Usage extends Resource {
    *     will strip them. If the usage-based add-on is billed with a percentage, your usage will be
    *     a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
    */
-  public void setAmount(final Float amount) {
+  public void setAmount(final BigDecimal amount) {
     this.amount = amount;
   }
 
@@ -248,12 +249,12 @@ public class Usage extends Resource {
   }
 
   /** Unit price */
-  public Float getUnitAmount() {
+  public BigDecimal getUnitAmount() {
     return this.unitAmount;
   }
 
   /** @param unitAmount Unit price */
-  public void setUnitAmount(final Float unitAmount) {
+  public void setUnitAmount(final BigDecimal unitAmount) {
     this.unitAmount = unitAmount;
   }
 
@@ -281,7 +282,7 @@ public class Usage extends Resource {
    * The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal
    * places. A value between 0.0 and 100.0.
    */
-  public Float getUsagePercentage() {
+  public BigDecimal getUsagePercentage() {
     return this.usagePercentage;
   }
 
@@ -289,7 +290,7 @@ public class Usage extends Resource {
    * @param usagePercentage The percentage taken of the monetary amount of usage tracked. This can
    *     be up to 4 decimal places. A value between 0.0 and 100.0.
    */
-  public void setUsagePercentage(final Float usagePercentage) {
+  public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
   }
 

--- a/src/test/java/com/recurly/v3/fixtures/MyRequest.java
+++ b/src/test/java/com/recurly/v3/fixtures/MyRequest.java
@@ -3,6 +3,7 @@ package com.recurly.v3.fixtures;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 
@@ -11,9 +12,9 @@ public class MyRequest extends Request {
   @Expose
   private String myString;
 
-  @SerializedName("my_float")
+  @SerializedName("my_big_decimal")
   @Expose
-  private Float myFloat;
+  private BigDecimal myBigDecimal;
 
   @SerializedName("my_int")
   @Expose
@@ -51,12 +52,12 @@ public class MyRequest extends Request {
     this.myString = myString;
   }
 
-  public Float getMyFloat() {
-    return this.myFloat;
+  public BigDecimal getMyBigDecimal() {
+    return this.myBigDecimal;
   }
 
-  public void setMyFloat(final Float myFloat) {
-    this.myFloat = myFloat;
+  public void setMyBigDecimal(final BigDecimal myBigDecimal) {
+    this.myBigDecimal = myBigDecimal;
   }
 
   public Integer getMyInt() {

--- a/src/test/java/com/recurly/v3/fixtures/MyResource.java
+++ b/src/test/java/com/recurly/v3/fixtures/MyResource.java
@@ -3,6 +3,7 @@ package com.recurly.v3.fixtures;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.math.BigDecimal;
 import java.util.List;
 import org.joda.time.DateTime;
 import com.recurly.v3.fixtures.FixtureConstants;
@@ -12,9 +13,9 @@ public class MyResource extends Resource {
   @Expose
   private String myString;
 
-  @SerializedName("my_float")
+  @SerializedName("my_big_decimal")
   @Expose
-  private Float myFloat;
+  private BigDecimal myBigDecimal;
 
   @SerializedName("my_int")
   @Expose
@@ -52,12 +53,12 @@ public class MyResource extends Resource {
     this.myString = myString;
   }
 
-  public Float getMyFloat() {
-    return this.myFloat;
+  public BigDecimal getMyBigDecimal() {
+    return this.myBigDecimal;
   }
 
-  public void setMyFloat(final Float myFloat) {
-    this.myFloat = myFloat;
+  public void setMyBigDecimal(final BigDecimal myBigDecimal) {
+    this.myBigDecimal = myBigDecimal;
   }
 
   public Integer getMyInt() {


### PR DESCRIPTION
I will update the v4.0.0 release summary as this is a breaking change.

Address #116. Wholesale convert API float types to `BigDecimal` within client. I believe this is the most reasonable compromise we can reach without changing the spec. As discussed with @douglasmiller , I don't see a route to offer an opt-in/opt-out choice at runtime.

I did not update query params -- ran into some test failures. Looks like it was not done for the dotnet client either though. From what I can see, there are no float types used there currently, so the type mapping is unused.