### PR TITLE
Release 4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.17.0
+current_version = 4.0.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ As a Maven dependency:
 <dependency>
   <groupId>com.recurly.v3</groupId>
   <artifactId>api-client</artifactId>
-  <version>3.17.0</version>
+  <version>4.0.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation 'com.recurly.v3:api-client:3.17.0'
+implementation 'com.recurly.v3:api-client:4.0.0'
 ```
 
 You can find further release and distribution details on

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.recurly.v3</groupId>
     <artifactId>api-client</artifactId>
-    <version>3.17.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <name>Recurly API V3 Java Client</name>
     <description>The official Java client for Recurly's V3 API.</description>

--- a/src/test/java/com/recurly/v3/HeaderInterceptorTest.java
+++ b/src/test/java/com/recurly/v3/HeaderInterceptorTest.java
@@ -34,7 +34,7 @@ public class HeaderInterceptorTest {
     // TODO this regex will change on GA
     // BETA semver sequence is forced until then
     final String agentFormat =
-        "Recurly/3\\.\\d+\\.\\d+(-SNAPSHOT)?;\\s+java\\s+\\d+.*";
+        "Recurly/\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?;\\s+java\\s+\\d+.*";
     assertEquals(request.getHeader("User-Agent").matches(agentFormat), true);
 
     mockWebServer.shutdown();


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-java/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-java/compare/3.18.0...HEAD)

# Major Version Release

The 4.x major version of the client pairs with the `v2021-02-25` API version. This version of the client and the API contain breaking changes that should be considered before upgrading your integration.

## Breaking Changes in the API
All changes to the core API are documented in the [Developer Portal changelog](https://developers.recurly.com/api/changelog.html#v2021-02-25---current-ga-version)

## Breaking Changes in Client

- Add enum support where they are defined in the OpenApi specification. [[#127](https://github.com/recurly/recurly-client-java/pull/127)]
- Convert `Float` to `BigDecimal`. [#133]

**Fixed bugs:**

- Interpolate path pattern has capture parens in wrong place [\#125](https://github.com/recurly/recurly-client-java/pull/125) ([douglasmiller](https://github.com/douglasmiller))

**Merged pull requests:**

- Convert Float To BigDecimal [\#133](https://github.com/recurly/recurly-client-java/pull/133) ([jguidry-recurly](https://github.com/jguidry-recurly))
- Convert query string enums to their SerializedName [\#132](https://github.com/recurly/recurly-client-java/pull/132) ([douglasmiller](https://github.com/douglasmiller))
- Updating changelog script and changelog generator config for 4.x release [\#131](https://github.com/recurly/recurly-client-java/pull/131) ([douglasmiller](https://github.com/douglasmiller))
- Adds support for Enums where applicable [\#127](https://github.com/recurly/recurly-client-java/pull/127) ([douglasmiller](https://github.com/douglasmiller))