### PR TITLE
Ignoring 'internal' tags in changelog generation

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,6 +1,6 @@
 user=recurly
 project=recurly-client-java
 unreleased=false
-exclude-labels=question,bug?,duplicate
+exclude-labels=internal,question,bug?,duplicate
 issues-wo-labels=false
 verbose=false


### PR DESCRIPTION
Internal only update to ignore issues and pull requests with the `internal` label from changelog generation.