### PR TITLE
Specify javadoc executable path in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
               <version>2.9.1</version>
               <configuration>
                 <source>${java.version}</source>
+                <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
               </configuration>
               <executions>
                 <execution>


### PR DESCRIPTION
Per https://issues.apache.org/jira/browse/MJAVADOC-595, the `JAVA_HOME` environment variable is not sufficient for the `maven-javadoc-plugin`