### PR TITLE
Generated Latest Changes for v2021-02-25 (Support to new subscription fields and response)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12611,7 +12611,16 @@ paths:
       - subscription_change
       operationId: create_subscription_change
       summary: Create a new subscription change
-      description: Calling this will overwrite an existing, pending subscription change.
+      description: |
+        Calling this will overwrite an existing, pending subscription change.
+
+        If a subscription has a pending change, and a change is submitted which matches
+        the subscription as it currently exists, the pending change will be deleted,
+        and you will receive a 204 No Content response.
+
+        If a subscription has no pending
+        change, and a change is submitted which matches the subscription as it currently
+        exists, a 422 Unprocessable Entity validation error will be returned.
       parameters:
       - "$ref": "#/components/parameters/subscription_id"
       requestBody:
@@ -12627,6 +12636,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SubscriptionChange"
+        '204':
+          description: The previous pending change was reverted.
         '404':
           description: Incorrect site ID.
           content:
@@ -19443,6 +19454,16 @@ components:
           format: float
           title: Estimated total, before tax.
           minimum: 0
+        tax:
+          type: number
+          format: float
+          title: Estimated tax
+        tax_info:
+          "$ref": "#/components/schemas/TaxInfo"
+        total:
+          type: number
+          format: float
+          title: Estimated total
         collection_method:
           title: Collection method
           default: automatic
@@ -19502,6 +19523,12 @@ components:
             set. This timestamp is used for alerting customers to reauthorize in 3
             years in accordance with NACHA rules. If a subscription becomes inactive
             or the billing info is no longer a bank account, this timestamp is cleared.
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         billing_info_id:
           type: string
           title: Billing Info ID
@@ -19956,6 +19983,13 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+        address_id:
+          type: string
+          titpe: Shipping address ID
+          description: Assign a shipping address from the account's existing shipping
+            addresses. If this and address are both present, address will take precedence.
+        address:
+          "$ref": "#/components/schemas/ShippingAddressCreate"
     SubscriptionCreate:
       type: object
       properties:
@@ -20264,6 +20298,12 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeShippingCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeShippingCreate.java
@@ -13,6 +13,18 @@ import java.math.BigDecimal;
 
 public class SubscriptionChangeShippingCreate extends Request {
 
+  @SerializedName("address")
+  @Expose
+  private ShippingAddressCreate address;
+
+  /**
+   * Assign a shipping address from the account's existing shipping addresses. If this and address
+   * are both present, address will take precedence.
+   */
+  @SerializedName("address_id")
+  @Expose
+  private String addressId;
+
   /**
    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or
    * `method_code` is required.
@@ -38,6 +50,31 @@ public class SubscriptionChangeShippingCreate extends Request {
   @SerializedName("method_id")
   @Expose
   private String methodId;
+
+  public ShippingAddressCreate getAddress() {
+    return this.address;
+  }
+
+  /** @param address */
+  public void setAddress(final ShippingAddressCreate address) {
+    this.address = address;
+  }
+
+  /**
+   * Assign a shipping address from the account's existing shipping addresses. If this and address
+   * are both present, address will take precedence.
+   */
+  public String getAddressId() {
+    return this.addressId;
+  }
+
+  /**
+   * @param addressId Assign a shipping address from the account's existing shipping addresses. If
+   *     this and address are both present, address will take precedence.
+   */
+  public void setAddressId(final String addressId) {
+    this.addressId = addressId;
+  }
 
   /**
    * Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -51,6 +51,11 @@ public class SubscriptionUpdate extends Request {
   @Expose
   private String customerNotes;
 
+  /** If present, this subscription's transactions will use the payment gateway with this code. */
+  @SerializedName("gateway_code")
+  @Expose
+  private String gatewayCode;
+
   /**
    * Integer representing the number of days after an invoice's creation that the invoice will
    * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
@@ -179,6 +184,19 @@ public class SubscriptionUpdate extends Request {
    */
   public void setCustomerNotes(final String customerNotes) {
     this.customerNotes = customerNotes;
+  }
+
+  /** If present, this subscription's transactions will use the payment gateway with this code. */
+  public String getGatewayCode() {
+    return this.gatewayCode;
+  }
+
+  /**
+   * @param gatewayCode If present, this subscription's transactions will use the payment gateway
+   *     with this code.
+   */
+  public void setGatewayCode(final String gatewayCode) {
+    this.gatewayCode = gatewayCode;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -130,6 +130,11 @@ public class Subscription extends Resource {
   @Expose
   private DateTime expiresAt;
 
+  /** If present, this subscription's transactions will use the payment gateway with this code. */
+  @SerializedName("gateway_code")
+  @Expose
+  private String gatewayCode;
+
   /** Subscription ID */
   @SerializedName("id")
   @Expose
@@ -213,10 +218,25 @@ public class Subscription extends Resource {
   @Expose
   private BigDecimal subtotal;
 
+  /** Estimated tax */
+  @SerializedName("tax")
+  @Expose
+  private BigDecimal tax;
+
+  /** Tax info */
+  @SerializedName("tax_info")
+  @Expose
+  private TaxInfo taxInfo;
+
   /** Terms and conditions */
   @SerializedName("terms_and_conditions")
   @Expose
   private String termsAndConditions;
+
+  /** Estimated total */
+  @SerializedName("total")
+  @Expose
+  private BigDecimal total;
 
   /**
    * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if
@@ -489,6 +509,19 @@ public class Subscription extends Resource {
     this.expiresAt = expiresAt;
   }
 
+  /** If present, this subscription's transactions will use the payment gateway with this code. */
+  public String getGatewayCode() {
+    return this.gatewayCode;
+  }
+
+  /**
+   * @param gatewayCode If present, this subscription's transactions will use the payment gateway
+   *     with this code.
+   */
+  public void setGatewayCode(final String gatewayCode) {
+    this.gatewayCode = gatewayCode;
+  }
+
   /** Subscription ID */
   public String getId() {
     return this.id;
@@ -665,6 +698,26 @@ public class Subscription extends Resource {
     this.subtotal = subtotal;
   }
 
+  /** Estimated tax */
+  public BigDecimal getTax() {
+    return this.tax;
+  }
+
+  /** @param tax Estimated tax */
+  public void setTax(final BigDecimal tax) {
+    this.tax = tax;
+  }
+
+  /** Tax info */
+  public TaxInfo getTaxInfo() {
+    return this.taxInfo;
+  }
+
+  /** @param taxInfo Tax info */
+  public void setTaxInfo(final TaxInfo taxInfo) {
+    this.taxInfo = taxInfo;
+  }
+
   /** Terms and conditions */
   public String getTermsAndConditions() {
     return this.termsAndConditions;
@@ -673,6 +726,16 @@ public class Subscription extends Resource {
   /** @param termsAndConditions Terms and conditions */
   public void setTermsAndConditions(final String termsAndConditions) {
     this.termsAndConditions = termsAndConditions;
+  }
+
+  /** Estimated total */
+  public BigDecimal getTotal() {
+    return this.total;
+  }
+
+  /** @param total Estimated total */
+  public void setTotal(final BigDecimal total) {
+    this.total = total;
   }
 
   /**


### PR DESCRIPTION
Generated Latest Changes for v2021-02-25

SubscriptionCreate request format has changed:
* Added `setGatewayCode`.

SubscriptionUpdate request format has changed:
* Added `setGatewayCode`.

Subscription response format has changed:
* Added `getGatewayCode`.

SubscriptionChangeShippingCreate request format has changed:
* Added `setAddress`.
* Added `setAddressId`.

Added tax information to `Subscription` response
* Added the fields `getTax`, `getTaxInfo` and `getTotal`.

Updated the response for `POST /subscriptions/{subscription_id}/change`.
* Responding with `204 No Content` when the subscription has a pending change, and a change is submitted which matches the subscription as it currently exists.


