### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19961,8 +19961,10 @@ components:
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
-      description: The shipping address can currently only be changed immediately,
-        using SubscriptionUpdate.
+      description: Shipping addresses are tied to a customer's account. Each account
+        can have up to 20 different shipping addresses, and if you have enabled multiple
+        subscriptions per account, you can associate different shipping addresses
+        to each subscription.
       properties:
         method_id:
           type: string
@@ -21777,6 +21779,7 @@ components:
       - roku
       - sepadirectdebit
       - wire_transfer
+      - braintree_v_zero
     CardTypeEnum:
       type: string
       enum:

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -1210,6 +1210,9 @@ public class Constants {
       @SerializedName("wire_transfer")
       WIRE_TRANSFER,
     
+      @SerializedName("braintree_v_zero")
+      BRAINTREE_V_ZERO,
+    
     };
   
     public enum CardType {

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -102,7 +102,11 @@ public class SubscriptionChangeCreate extends Request {
   @Expose
   private Constants.RevenueScheduleType revenueScheduleType;
 
-  /** The shipping address can currently only be changed immediately, using SubscriptionUpdate. */
+  /**
+   * Shipping addresses are tied to a customer's account. Each account can have up to 20 different
+   * shipping addresses, and if you have enabled multiple subscriptions per account, you can
+   * associate different shipping addresses to each subscription.
+   */
   @SerializedName("shipping")
   @Expose
   private SubscriptionChangeShippingCreate shipping;
@@ -312,14 +316,19 @@ public class SubscriptionChangeCreate extends Request {
     this.revenueScheduleType = revenueScheduleType;
   }
 
-  /** The shipping address can currently only be changed immediately, using SubscriptionUpdate. */
+  /**
+   * Shipping addresses are tied to a customer's account. Each account can have up to 20 different
+   * shipping addresses, and if you have enabled multiple subscriptions per account, you can
+   * associate different shipping addresses to each subscription.
+   */
   public SubscriptionChangeShippingCreate getShipping() {
     return this.shipping;
   }
 
   /**
-   * @param shipping The shipping address can currently only be changed immediately, using
-   *     SubscriptionUpdate.
+   * @param shipping Shipping addresses are tied to a customer's account. Each account can have up
+   *     to 20 different shipping addresses, and if you have enabled multiple subscriptions per
+   *     account, you can associate different shipping addresses to each subscription.
    */
   public void setShipping(final SubscriptionChangeShippingCreate shipping) {
     this.shipping = shipping;


### PR DESCRIPTION
- Adds `braintree_v_zero` to the `PaymentMethodEnum` and sets it as a constant in `Constants.java`.
- Updates the `SubscriptionChangeShippingCreate` description to include the number of shipping addresses allowed per account as well as specifying specific shipping addresses to individual subscriptions.