### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21720,6 +21720,7 @@ components:
           - gateway_token
           - iban_bank_account
           - other
+          - braintree_v_zero
         card_type:
           type: string
           description: Visa, MasterCard, American Express, Discover, JCB, etc.


### PR DESCRIPTION
Adds `braintreee_v_zero` to the `PaymentMethodEnum`.