### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21380,20 +21380,26 @@ components:
       - en-AU
       - en-CA
       - en-GB
+      - en-IE
       - en-NZ
       - en-US
       - es-ES
       - es-MX
       - es-US
+      - fi-FI
       - fr-CA
       - fr-FR
       - hi-IN
+      - it-IT
       - ja-JP
+      - ko-KR
       - nl-BE
       - nl-NL
       - pt-BR
       - pt-PT
+      - ro-RO
       - ru-RU
+      - sk-SK
       - tr-TR
       - zh-CN
     BillToEnum:
@@ -21533,16 +21539,22 @@ components:
     OriginEnum:
       type: string
       enum:
+      - carryforward_credit
+      - carryforward_gift_credit
       - credit
+      - external_refund
       - gift_card
       - immediate_change
+      - import
       - line_item_refund
       - open_amount_refund
+      - prepayment
       - purchase
+      - refund
       - renewal
       - termination
+      - usage_correction
       - write_off
-      - prepayment
     InvoiceStateEnum:
       type: string
       enum:

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -265,6 +265,9 @@ public class Constants {
       @SerializedName("en-GB")
       EN_GB,
     
+      @SerializedName("en-IE")
+      EN_IE,
+    
       @SerializedName("en-NZ")
       EN_NZ,
     
@@ -280,6 +283,9 @@ public class Constants {
       @SerializedName("es-US")
       ES_US,
     
+      @SerializedName("fi-FI")
+      FI_FI,
+    
       @SerializedName("fr-CA")
       FR_CA,
     
@@ -289,8 +295,14 @@ public class Constants {
       @SerializedName("hi-IN")
       HI_IN,
     
+      @SerializedName("it-IT")
+      IT_IT,
+    
       @SerializedName("ja-JP")
       JA_JP,
+    
+      @SerializedName("ko-KR")
+      KO_KR,
     
       @SerializedName("nl-BE")
       NL_BE,
@@ -304,8 +316,14 @@ public class Constants {
       @SerializedName("pt-PT")
       PT_PT,
     
+      @SerializedName("ro-RO")
+      RO_RO,
+    
       @SerializedName("ru-RU")
       RU_RU,
+    
+      @SerializedName("sk-SK")
+      SK_SK,
     
       @SerializedName("tr-TR")
       TR_TR,
@@ -572,8 +590,17 @@ public class Constants {
     public enum Origin {
       UNDEFINED,
     
+      @SerializedName("carryforward_credit")
+      CARRYFORWARD_CREDIT,
+    
+      @SerializedName("carryforward_gift_credit")
+      CARRYFORWARD_GIFT_CREDIT,
+    
       @SerializedName("credit")
       CREDIT,
+    
+      @SerializedName("external_refund")
+      EXTERNAL_REFUND,
     
       @SerializedName("gift_card")
       GIFT_CARD,
@@ -581,14 +608,23 @@ public class Constants {
       @SerializedName("immediate_change")
       IMMEDIATE_CHANGE,
     
+      @SerializedName("import")
+      IMPORT,
+    
       @SerializedName("line_item_refund")
       LINE_ITEM_REFUND,
     
       @SerializedName("open_amount_refund")
       OPEN_AMOUNT_REFUND,
     
+      @SerializedName("prepayment")
+      PREPAYMENT,
+    
       @SerializedName("purchase")
       PURCHASE,
+    
+      @SerializedName("refund")
+      REFUND,
     
       @SerializedName("renewal")
       RENEWAL,
@@ -596,11 +632,11 @@ public class Constants {
       @SerializedName("termination")
       TERMINATION,
     
+      @SerializedName("usage_correction")
+      USAGE_CORRECTION,
+    
       @SerializedName("write_off")
       WRITE_OFF,
-    
-      @SerializedName("prepayment")
-      PREPAYMENT,
     
     };
   


### PR DESCRIPTION
- Added additional enum values for `Invoice` `origin`:
  - `refund`
  - `external_refund`
  - `carryforward_credit`
  - `carryforward_gift_credit`
  - `usage_correction`
  - `import`

- Added additional enum values for `Account` `preferred_locale`:
  - `en-IE`
  - `fi-FI`
  - `it-IT`
  - `ko-KR`
  - `ro-RO`
  - `sk-SK`
