### PR TITLE
Generated Latest Changes for v2019-10-10 (Account Hierarchy Invoice Rollup)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18279,6 +18279,12 @@ components:
           - carryforward
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21916,6 +21922,8 @@ components:
                 - batch_processing_error
                 - billing_agreement_already_accepted
                 - billing_agreement_not_accepted
+                - billing_agreement_not_found
+                - billing_agreement_replaced
                 - call_issuer
                 - call_issuer_update_cardholder_data
                 - cannot_refund_unsettled_transactions

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -62,6 +62,11 @@ public class LineItem extends Resource {
   @Expose
   private Integer avalaraTransactionType;
 
+  /** The UUID of the account responsible for originating the line item. */
+  @SerializedName("bill_for_account_id")
+  @Expose
+  private String billForAccountId;
+
   /** When the line item was created. */
   @SerializedName("created_at")
   @Expose
@@ -421,6 +426,16 @@ public class LineItem extends Resource {
    */
   public void setAvalaraTransactionType(final Integer avalaraTransactionType) {
     this.avalaraTransactionType = avalaraTransactionType;
+  }
+
+  /** The UUID of the account responsible for originating the line item. */
+  public String getBillForAccountId() {
+    return this.billForAccountId;
+  }
+
+  /** @param billForAccountId The UUID of the account responsible for originating the line item. */
+  public void setBillForAccountId(final String billForAccountId) {
+    this.billForAccountId = billForAccountId;
   }
 
   /** When the line item was created. */


### PR DESCRIPTION
Add `getBillForAccountId`/`setBillForAccountId` methods to the `LineItem` class. This exposes the UUID of the account responsible for originating the line item.

