### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16345,6 +16345,28 @@ components:
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
             routing information
+        name_on_account:
+          type: string
+          maxLength: 255
+          description: The name associated with the bank account (ACH, SEPA, Bacs
+            only)
+        account_number:
+          type: string
+          maxLength: 255
+          description: The bank account number. (ACH, Bacs only)
+        routing_number:
+          type: string
+          maxLength: 15
+          description: The bank's rounting number. (ACH only)
+        sort_code:
+          type: string
+          maxLength: 15
+          description: Bank identifier code for UK based banks. Required for Bacs
+            based billing infos. (Bacs only)
+        type:
+          "$ref": "#/components/schemas/AchTypeEnum"
+        account_type:
+          "$ref": "#/components/schemas/AchAccountTypeEnum"
         tax_identifier:
           type: string
           description: Tax identifier is required if adding a billing info that is
@@ -17898,6 +17920,12 @@ components:
           "$ref": "#/components/schemas/LegacyCategoryEnum"
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21885,6 +21913,7 @@ components:
       - billing_agreement_already_accepted
       - billing_agreement_not_accepted
       - billing_agreement_not_found
+      - billing_agreement_replaced
       - call_issuer
       - call_issuer_update_cardholder_data
       - cancelled
@@ -22058,3 +22087,15 @@ components:
       - automatic
       - manual
       - trial
+    AchTypeEnum:
+      type: string
+      description: The payment method type for a non-credit card based billing info.
+        The value of `bacs` is the only accepted value (Bacs only)
+      enum:
+      - bacs
+    AchAccountTypeEnum:
+      type: string
+      description: The bank account type. (ACH only)
+      enum:
+      - checking
+      - savings

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -1508,6 +1508,9 @@ public class Constants {
       @SerializedName("billing_agreement_not_found")
       BILLING_AGREEMENT_NOT_FOUND,
     
+      @SerializedName("billing_agreement_replaced")
+      BILLING_AGREEMENT_REPLACED,
+    
       @SerializedName("call_issuer")
       CALL_ISSUER,
     
@@ -1901,6 +1904,25 @@ public class Constants {
     
       @SerializedName("trial")
       TRIAL,
+    
+    };
+  
+    public enum AchType {
+      UNDEFINED,
+    
+      @SerializedName("bacs")
+      BACS,
+    
+    };
+  
+    public enum AchAccountType {
+      UNDEFINED,
+    
+      @SerializedName("checking")
+      CHECKING,
+    
+      @SerializedName("savings")
+      SAVINGS,
     
     };
   

--- a/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
@@ -13,6 +13,16 @@ import com.recurly.v3.resources.*;
 
 public class BillingInfoCreate extends Request {
 
+  /** The bank account number. (ACH, Bacs only) */
+  @SerializedName("account_number")
+  @Expose
+  private String accountNumber;
+
+  /** The bank account type. (ACH only) */
+  @SerializedName("account_type")
+  @Expose
+  private Constants.AchAccountType accountType;
+
   @SerializedName("address")
   @Expose
   private Address address;
@@ -92,6 +102,11 @@ public class BillingInfoCreate extends Request {
   @Expose
   private String month;
 
+  /** The name associated with the bank account (ACH, SEPA, Bacs only) */
+  @SerializedName("name_on_account")
+  @Expose
+  private String nameOnAccount;
+
   /** Credit card number, spaces and dashes are accepted. */
   @SerializedName("number")
   @Expose
@@ -113,6 +128,16 @@ public class BillingInfoCreate extends Request {
   @SerializedName("primary_payment_method")
   @Expose
   private Boolean primaryPaymentMethod;
+
+  /** The bank's rounting number. (ACH only) */
+  @SerializedName("routing_number")
+  @Expose
+  private String routingNumber;
+
+  /** Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only) */
+  @SerializedName("sort_code")
+  @Expose
+  private String sortCode;
 
   /**
    * Tax identifier is required if adding a billing info that is a consumer card in Brazil or in
@@ -155,6 +180,14 @@ public class BillingInfoCreate extends Request {
   @Expose
   private Constants.GatewayTransactionType transactionType;
 
+  /**
+   * The payment method type for a non-credit card based billing info. The value of `bacs` is the
+   * only accepted value (Bacs only)
+   */
+  @SerializedName("type")
+  @Expose
+  private Constants.AchType type;
+
   /** VAT number */
   @SerializedName("vat_number")
   @Expose
@@ -164,6 +197,26 @@ public class BillingInfoCreate extends Request {
   @SerializedName("year")
   @Expose
   private String year;
+
+  /** The bank account number. (ACH, Bacs only) */
+  public String getAccountNumber() {
+    return this.accountNumber;
+  }
+
+  /** @param accountNumber The bank account number. (ACH, Bacs only) */
+  public void setAccountNumber(final String accountNumber) {
+    this.accountNumber = accountNumber;
+  }
+
+  /** The bank account type. (ACH only) */
+  public Constants.AchAccountType getAccountType() {
+    return this.accountType;
+  }
+
+  /** @param accountType The bank account type. (ACH only) */
+  public void setAccountType(final Constants.AchAccountType accountType) {
+    this.accountType = accountType;
+  }
 
   public Address getAddress() {
     return this.address;
@@ -329,6 +382,16 @@ public class BillingInfoCreate extends Request {
     this.month = month;
   }
 
+  /** The name associated with the bank account (ACH, SEPA, Bacs only) */
+  public String getNameOnAccount() {
+    return this.nameOnAccount;
+  }
+
+  /** @param nameOnAccount The name associated with the bank account (ACH, SEPA, Bacs only) */
+  public void setNameOnAccount(final String nameOnAccount) {
+    this.nameOnAccount = nameOnAccount;
+  }
+
   /** Credit card number, spaces and dashes are accepted. */
   public String getNumber() {
     return this.number;
@@ -372,6 +435,29 @@ public class BillingInfoCreate extends Request {
    */
   public void setPrimaryPaymentMethod(final Boolean primaryPaymentMethod) {
     this.primaryPaymentMethod = primaryPaymentMethod;
+  }
+
+  /** The bank's rounting number. (ACH only) */
+  public String getRoutingNumber() {
+    return this.routingNumber;
+  }
+
+  /** @param routingNumber The bank's rounting number. (ACH only) */
+  public void setRoutingNumber(final String routingNumber) {
+    this.routingNumber = routingNumber;
+  }
+
+  /** Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only) */
+  public String getSortCode() {
+    return this.sortCode;
+  }
+
+  /**
+   * @param sortCode Bank identifier code for UK based banks. Required for Bacs based billing infos.
+   *     (Bacs only)
+   */
+  public void setSortCode(final String sortCode) {
+    this.sortCode = sortCode;
   }
 
   /**
@@ -456,6 +542,22 @@ public class BillingInfoCreate extends Request {
    */
   public void setTransactionType(final Constants.GatewayTransactionType transactionType) {
     this.transactionType = transactionType;
+  }
+
+  /**
+   * The payment method type for a non-credit card based billing info. The value of `bacs` is the
+   * only accepted value (Bacs only)
+   */
+  public Constants.AchType getType() {
+    return this.type;
+  }
+
+  /**
+   * @param type The payment method type for a non-credit card based billing info. The value of
+   *     `bacs` is the only accepted value (Bacs only)
+   */
+  public void setType(final Constants.AchType type) {
+    this.type = type;
   }
 
   /** VAT number */

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -64,6 +64,11 @@ public class LineItem extends Resource {
   @Expose
   private Integer avalaraTransactionType;
 
+  /** The UUID of the account responsible for originating the line item. */
+  @SerializedName("bill_for_account_id")
+  @Expose
+  private String billForAccountId;
+
   /** When the line item was created. */
   @SerializedName("created_at")
   @Expose
@@ -428,6 +433,16 @@ public class LineItem extends Resource {
    */
   public void setAvalaraTransactionType(final Integer avalaraTransactionType) {
     this.avalaraTransactionType = avalaraTransactionType;
+  }
+
+  /** The UUID of the account responsible for originating the line item. */
+  public String getBillForAccountId() {
+    return this.billForAccountId;
+  }
+
+  /** @param billForAccountId The UUID of the account responsible for originating the line item. */
+  public void setBillForAccountId(final String billForAccountId) {
+    this.billForAccountId = billForAccountId;
   }
 
   /** When the line item was created. */


### PR DESCRIPTION
Support for Account Hierarchy Invoice Rollup:
- Add `getBillForAccountId`/`setBillForAccountId` methods to the `LineItem` class. This exposes the UUID of the account responsible for originating the line item.

BillingInfoCreate request format has changed:
- Added `setNameOnAccount`
- Added `setAccountNumber`
- Added `setRoutingNumber`
- Added `setSortCode`
- Added `setType`
- Added `setAccountType`