### PR TITLE
Generated Latest Changes for v2019-10-10 (Tax Inclusive Pricing)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14525,7 +14525,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17683,7 +17684,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17939,7 +17941,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18551,6 +18554,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s
             `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -19113,6 +19123,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -19274,6 +19291,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19291,6 +19315,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -20248,6 +20279,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -20353,6 +20391,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20485,7 +20530,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20512,6 +20558,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20649,6 +20702,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20792,6 +20852,13 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20800,7 +20867,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -21469,7 +21537,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           type: string
           title: Collection method

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -337,7 +337,7 @@ public class Client extends BaseClient {
    *
    * @see <a href="https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info">get_a_billing_info api documentation</a>
    * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId Billing Info ID.
+   * @param billingInfoId Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
      * @return A billing info.
    */
   public BillingInfo getABillingInfo(String accountId, String billingInfoId) {
@@ -355,7 +355,7 @@ public class Client extends BaseClient {
    *
    * @see <a href="https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info">update_a_billing_info api documentation</a>
    * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId Billing Info ID.
+   * @param billingInfoId Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
    * @param body The body of the request.
      * @return Updated billing information.
    */
@@ -374,7 +374,7 @@ public class Client extends BaseClient {
    *
    * @see <a href="https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info">remove_a_billing_info api documentation</a>
    * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId Billing Info ID.
+   * @param billingInfoId Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
    */
   public void removeABillingInfo(String accountId, String billingInfoId) {
     final String url = "/accounts/{account_id}/billing_infos/{billing_info_id}";

--- a/src/main/java/com/recurly/v3/requests/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnPricing.java
@@ -17,6 +17,14 @@ public class AddOnPricing extends Request {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -30,6 +38,23 @@ public class AddOnPricing extends Request {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/requests/InvoiceCollect.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceCollect.java
@@ -15,7 +15,8 @@ public class InvoiceCollect extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -40,7 +41,8 @@ public class InvoiceCollect extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -50,7 +52,7 @@ public class InvoiceCollect extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -154,6 +154,14 @@ public class LineItemCreate extends Request {
   private Boolean taxExempt;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If
    * `item_code`/`item_id` is not present then `type` is required.
    */
@@ -451,6 +459,23 @@ public class LineItemCreate extends Request {
    */
   public void setTaxExempt(final Boolean taxExempt) {
     this.taxExempt = taxExempt;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanPricing.java
@@ -26,6 +26,14 @@ public class PlanPricing extends Request {
   @Expose
   private Float setupFee;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -58,6 +66,23 @@ public class PlanPricing extends Request {
    */
   public void setSetupFee(final Float setupFee) {
     this.setupFee = setupFee;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/requests/Pricing.java
+++ b/src/main/java/com/recurly/v3/requests/Pricing.java
@@ -17,6 +17,14 @@ public class Pricing extends Request {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -30,6 +38,23 @@ public class Pricing extends Request {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
@@ -20,7 +20,8 @@ public class PurchaseCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -126,7 +127,8 @@ public class PurchaseCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -136,7 +138,7 @@ public class PurchaseCreate extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -105,6 +105,14 @@ public class SubscriptionChangeCreate extends Request {
   private SubscriptionChangeShippingCreate shipping;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * The timeframe parameter controls when the upgrade or downgrade takes place. The subscription
    * change can occur now, when the subscription is next billed, or when the subscription term ends.
    * Generally, if you're performing an upgrade, you will want the change to occur immediately
@@ -318,6 +326,23 @@ public class SubscriptionChangeCreate extends Request {
    */
   public void setShipping(final SubscriptionChangeShippingCreate shipping) {
     this.shipping = shipping;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -31,7 +31,8 @@ public class SubscriptionCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -156,6 +157,14 @@ public class SubscriptionCreate extends Request {
   private DateTime startsAt;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * This will default to the Terms and Conditions text specified on the Invoice Settings page in
    * your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes
    * will stay with a subscription on all renewals.
@@ -231,7 +240,8 @@ public class SubscriptionCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -241,7 +251,7 @@ public class SubscriptionCreate extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;
@@ -486,6 +496,23 @@ public class SubscriptionCreate extends Request {
    */
   public void setStartsAt(final DateTime startsAt) {
     this.startsAt = startsAt;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
@@ -87,6 +87,14 @@ public class SubscriptionPurchase extends Request {
   private DateTime startsAt;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if
    * `auto_renew=true` the subscription will renew and a new term will begin, otherwise the
    * subscription will expire.
@@ -256,6 +264,23 @@ public class SubscriptionPurchase extends Request {
    */
   public void setStartsAt(final DateTime startsAt) {
     this.startsAt = startsAt;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -22,7 +22,8 @@ public class SubscriptionUpdate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -100,6 +101,14 @@ public class SubscriptionUpdate extends Request {
   private SubscriptionShippingUpdate shipping;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a
    * subscription on all renewals.
    */
@@ -120,7 +129,8 @@ public class SubscriptionUpdate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -130,7 +140,7 @@ public class SubscriptionUpdate extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;
@@ -280,6 +290,23 @@ public class SubscriptionUpdate extends Request {
   /** @param shipping Subscription shipping details */
   public void setShipping(final SubscriptionShippingUpdate shipping) {
     this.shipping = shipping;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnPricing.java
@@ -16,6 +16,14 @@ public class AddOnPricing extends Resource {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -29,6 +37,23 @@ public class AddOnPricing extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -30,7 +30,8 @@ public class Invoice extends Resource {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -266,7 +267,8 @@ public class Invoice extends Resource {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -276,7 +278,7 @@ public class Invoice extends Resource {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;

--- a/src/main/java/com/recurly/v3/resources/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanPricing.java
@@ -25,6 +25,14 @@ public class PlanPricing extends Resource {
   @Expose
   private Float setupFee;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -57,6 +65,23 @@ public class PlanPricing extends Resource {
    */
   public void setSetupFee(final Float setupFee) {
     this.setupFee = setupFee;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/resources/Pricing.java
+++ b/src/main/java/com/recurly/v3/resources/Pricing.java
@@ -16,6 +16,14 @@ public class Pricing extends Resource {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -29,6 +37,23 @@ public class Pricing extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -97,6 +97,14 @@ public class SubscriptionChange extends Resource {
   @Expose
   private String subscriptionId;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit amount */
   @SerializedName("unit_amount")
   @Expose
@@ -273,6 +281,23 @@ public class SubscriptionChange extends Resource {
   /** @param subscriptionId The ID of the subscription that is going to be changed. */
   public void setSubscriptionId(final String subscriptionId) {
     this.subscriptionId = subscriptionId;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit amount */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChangePreview.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChangePreview.java
@@ -97,6 +97,14 @@ public class SubscriptionChangePreview extends Resource {
   @Expose
   private String subscriptionId;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit amount */
   @SerializedName("unit_amount")
   @Expose
@@ -273,6 +281,23 @@ public class SubscriptionChangePreview extends Resource {
   /** @param subscriptionId The ID of the subscription that is going to be changed. */
   public void setSubscriptionId(final String subscriptionId) {
     this.subscriptionId = subscriptionId;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit amount */


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds Boolean `taxInclusive`, getTaxInclusive, and setTaxInclusive  to the following requests:
- AddOnPricing
- LineItemCreate
- PlanPricing
- Pricing
- SubscriptionChangeCreate
- SubscriptionCreate
- SubscriptionPurchase
- SubscriptionUpdate

Adds `tax_inclusive` attribute to the following resources:
- AddOnPricing
- PlanPricing
- Pricing
- SubscriptionChange
- SubscriptionChangePreview