### PR TITLE
Generated Latest Changes for v2021-02-25 (Tax Inclusive Pricing)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14579,7 +14579,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17377,7 +17378,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17634,7 +17636,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18178,6 +18181,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the
             `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -18691,6 +18701,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -18849,6 +18866,13 @@ components:
           description: |
             Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
     TierPricing:
@@ -18891,6 +18915,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19828,6 +19859,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -19915,6 +19953,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20043,7 +20088,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20067,6 +20113,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20198,6 +20251,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20334,6 +20394,13 @@ components:
           description: If present, this subscription's transactions will use the payment
             gateway with this code.
           maxLength: 13
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20342,7 +20409,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -20940,7 +21008,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           title: Collection method
           description: Must be set to manual in order to preview a purchase for an
@@ -22017,6 +22086,7 @@ components:
       - three_d_secure_action_result_token_mismatch
       - three_d_secure_authentication
       - three_d_secure_connection_error
+      - three_d_secure_credential_error
       - three_d_secure_not_supported
       - too_many_attempts
       - total_credit_exceeds_capture

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -337,7 +337,7 @@ public class Client extends BaseClient {
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_a_billing_info">get_a_billing_info api documentation</a>
    * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId Billing Info ID.
+   * @param billingInfoId Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
      * @return A billing info.
    */
   public BillingInfo getABillingInfo(String accountId, String billingInfoId) {
@@ -355,7 +355,7 @@ public class Client extends BaseClient {
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/update_a_billing_info">update_a_billing_info api documentation</a>
    * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId Billing Info ID.
+   * @param billingInfoId Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
    * @param body The body of the request.
      * @return Updated billing information.
    */
@@ -374,7 +374,7 @@ public class Client extends BaseClient {
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/remove_a_billing_info">remove_a_billing_info api documentation</a>
    * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-   * @param billingInfoId Billing Info ID.
+   * @param billingInfoId Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
    */
   public void removeABillingInfo(String accountId, String billingInfoId) {
     final String url = "/accounts/{account_id}/billing_infos/{billing_info_id}";

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -1820,6 +1820,9 @@ public class Constants {
       @SerializedName("three_d_secure_connection_error")
       THREE_D_SECURE_CONNECTION_ERROR,
     
+      @SerializedName("three_d_secure_credential_error")
+      THREE_D_SECURE_CREDENTIAL_ERROR,
+    
       @SerializedName("three_d_secure_not_supported")
       THREE_D_SECURE_NOT_SUPPORTED,
     

--- a/src/main/java/com/recurly/v3/requests/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnPricing.java
@@ -18,6 +18,14 @@ public class AddOnPricing extends Request {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
   @SerializedName("unit_amount")
   @Expose
@@ -39,6 +47,23 @@ public class AddOnPricing extends Request {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */

--- a/src/main/java/com/recurly/v3/requests/InvoiceCollect.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceCollect.java
@@ -16,7 +16,8 @@ public class InvoiceCollect extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -41,7 +42,8 @@ public class InvoiceCollect extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -51,7 +53,7 @@ public class InvoiceCollect extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -156,6 +156,14 @@ public class LineItemCreate extends Request {
   private Boolean taxExempt;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * Line item type. If `item_code`/`item_id` is present then `type` should not be present. If
    * `item_code`/`item_id` is not present then `type` is required.
    */
@@ -454,6 +462,23 @@ public class LineItemCreate extends Request {
    */
   public void setTaxExempt(final Boolean taxExempt) {
     this.taxExempt = taxExempt;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanPricing.java
@@ -27,6 +27,14 @@ public class PlanPricing extends Request {
   @Expose
   private BigDecimal setupFee;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -59,6 +67,23 @@ public class PlanPricing extends Request {
    */
   public void setSetupFee(final BigDecimal setupFee) {
     this.setupFee = setupFee;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/requests/Pricing.java
+++ b/src/main/java/com/recurly/v3/requests/Pricing.java
@@ -18,6 +18,14 @@ public class Pricing extends Request {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -31,6 +39,23 @@ public class Pricing extends Request {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
@@ -21,7 +21,8 @@ public class PurchaseCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -127,7 +128,8 @@ public class PurchaseCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -137,7 +139,7 @@ public class PurchaseCreate extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -112,6 +112,14 @@ public class SubscriptionChangeCreate extends Request {
   private SubscriptionChangeShippingCreate shipping;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * The timeframe parameter controls when the upgrade or downgrade takes place. The subscription
    * change can occur now, when the subscription is next billed, or when the subscription term ends.
    * Generally, if you're performing an upgrade, you will want the change to occur immediately
@@ -332,6 +340,23 @@ public class SubscriptionChangeCreate extends Request {
    */
   public void setShipping(final SubscriptionChangeShippingCreate shipping) {
     this.shipping = shipping;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -33,7 +33,8 @@ public class SubscriptionCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -155,6 +156,14 @@ public class SubscriptionCreate extends Request {
   private DateTime startsAt;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * This will default to the Terms and Conditions text specified on the Invoice Settings page in
    * your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes
    * will stay with a subscription on all renewals.
@@ -230,7 +239,8 @@ public class SubscriptionCreate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -240,7 +250,7 @@ public class SubscriptionCreate extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;
@@ -482,6 +492,23 @@ public class SubscriptionCreate extends Request {
    */
   public void setStartsAt(final DateTime startsAt) {
     this.startsAt = startsAt;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
@@ -89,6 +89,14 @@ public class SubscriptionPurchase extends Request {
   private DateTime startsAt;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if
    * `auto_renew=true` the subscription will renew and a new term will begin, otherwise the
    * subscription will expire.
@@ -258,6 +266,23 @@ public class SubscriptionPurchase extends Request {
    */
   public void setStartsAt(final DateTime startsAt) {
     this.startsAt = startsAt;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -23,7 +23,8 @@ public class SubscriptionUpdate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -106,6 +107,14 @@ public class SubscriptionUpdate extends Request {
   private SubscriptionShippingUpdate shipping;
 
   /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
+  /**
    * Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a
    * subscription on all renewals.
    */
@@ -126,7 +135,8 @@ public class SubscriptionUpdate extends Request {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -136,7 +146,7 @@ public class SubscriptionUpdate extends Request {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;
@@ -299,6 +309,23 @@ public class SubscriptionUpdate extends Request {
   /** @param shipping Subscription shipping details */
   public void setShipping(final SubscriptionShippingUpdate shipping) {
     this.shipping = shipping;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnPricing.java
@@ -17,6 +17,14 @@ public class AddOnPricing extends Resource {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */
   @SerializedName("unit_amount")
   @Expose
@@ -38,6 +46,23 @@ public class AddOnPricing extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided. */

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -32,7 +32,8 @@ public class Invoice extends Resource {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   @SerializedName("billing_info_id")
   @Expose
@@ -278,7 +279,8 @@ public class Invoice extends Resource {
   /**
    * The `billing_info_id` is the value that represents a specific billing info for an end customer.
    * When `billing_info_id` is used to assign billing info to the subscription, all future billing
-   * events for the subscription will bill to the specified billing info.
+   * events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY
+   * be used for sites utilizing the Wallet feature.
    */
   public String getBillingInfoId() {
     return this.billingInfoId;
@@ -288,7 +290,7 @@ public class Invoice extends Resource {
    * @param billingInfoId The `billing_info_id` is the value that represents a specific billing info
    *     for an end customer. When `billing_info_id` is used to assign billing info to the
    *     subscription, all future billing events for the subscription will bill to the specified
-   *     billing info.
+   *     billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
    */
   public void setBillingInfoId(final String billingInfoId) {
     this.billingInfoId = billingInfoId;

--- a/src/main/java/com/recurly/v3/resources/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanPricing.java
@@ -26,6 +26,14 @@ public class PlanPricing extends Resource {
   @Expose
   private BigDecimal setupFee;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -58,6 +66,23 @@ public class PlanPricing extends Resource {
    */
   public void setSetupFee(final BigDecimal setupFee) {
     this.setupFee = setupFee;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/resources/Pricing.java
+++ b/src/main/java/com/recurly/v3/resources/Pricing.java
@@ -17,6 +17,14 @@ public class Pricing extends Resource {
   @Expose
   private String currency;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit price */
   @SerializedName("unit_amount")
   @Expose
@@ -30,6 +38,23 @@ public class Pricing extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit price */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -94,6 +94,14 @@ public class SubscriptionChange extends Resource {
   @Expose
   private String subscriptionId;
 
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  @SerializedName("tax_inclusive")
+  @Expose
+  private Boolean taxInclusive;
+
   /** Unit amount */
   @SerializedName("unit_amount")
   @Expose
@@ -260,6 +268,23 @@ public class SubscriptionChange extends Resource {
   /** @param subscriptionId The ID of the subscription that is going to be changed. */
   public void setSubscriptionId(final String subscriptionId) {
     this.subscriptionId = subscriptionId;
+  }
+
+  /**
+   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
+   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+   */
+  public Boolean getTaxInclusive() {
+    return this.taxInclusive;
+  }
+
+  /**
+   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
+   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
+   *     use this flag.
+   */
+  public void setTaxInclusive(final Boolean taxInclusive) {
+    this.taxInclusive = taxInclusive;
   }
 
   /** Unit amount */


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds Boolean `taxInclusive`, getTaxInclusive, and setTaxInclusive  to the following requests:
- AddOnPricing
- LineItemCreate
- PlanPricing
- Pricing
- SubscriptionChangeCreate
- SubscriptionCreate
- SubscriptionPurchase
- SubscriptionUpdate

Adds `tax_inclusive` attribute to the following resources:
- AddOnPricing
- PlanPricing
- Pricing
- SubscriptionChange