### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -232,7 +232,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices and Subscription Billing Terms features to be enabled.
+    Recurly's item catalog requires the Credit Invoices features to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -15540,6 +15540,8 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        invoice_template:
+          "$ref": "#/components/schemas/AccountInvoiceTemplate"
     AccountNote:
       type: object
       required:
@@ -15636,6 +15638,20 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+    AccountInvoiceTemplate:
+      type: object
+      title: Invoice Template
+      description: Invoice template associated to the account. Available when invoice
+        customization flag is enabled.
+      properties:
+        id:
+          type: string
+          title: ID
+          description: Unique ID to identify the invoice template.
+        name:
+          type: string
+          title: Name
+          description: Template name
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -15900,16 +15916,16 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` and `Subscription Billing Terms` features are enabled. If `item_id`
-            and `item_code` are both present, `item_id` will be used.
+            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the `Credit Invoices` and `Subscription Billing Terms` features are enabled.
-            If `item_id` and `item_code` are both present, `item_id` will be used.
+            the `Credit Invoices` feature is enabled. If `item_id` and `item_code`
+            are both present, `item_id` will be used.
           maxLength: 13
         code:
           type: string
@@ -17888,20 +17904,20 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         external_sku:
           type: string
           title: External SKU
           description: Optional Stock Keeping Unit assigned to an item. Available
-            when the Credit Invoices and Subscription Billing Terms features are enabled.
+            when the Credit Invoices feature is enabled.
           maxLength: 50
         revenue_schedule_type:
           title: Revenue schedule type
@@ -18204,14 +18220,14 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
@@ -22160,9 +22176,10 @@ components:
     AchTypeEnum:
       type: string
       description: The payment method type for a non-credit card based billing info.
-        The value of `bacs` is the only accepted value (Bacs only)
+        `bacs` and `becs` are the only accepted values.
       enum:
       - bacs
+      - becs
     AchAccountTypeEnum:
       type: string
       description: The bank account type. (ACH only)

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -1916,6 +1916,9 @@ public class Constants {
       @SerializedName("bacs")
       BACS,
     
+      @SerializedName("becs")
+      BECS,
+    
     };
   
     public enum AchAccountType {

--- a/src/main/java/com/recurly/v3/requests/AddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnCreate.java
@@ -81,18 +81,16 @@ public class AddOnCreate extends Request {
   private Boolean displayQuantity;
 
   /**
-   * Unique code to identify an item. Available when the `Credit Invoices` and `Subscription Billing
-   * Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be
-   * used.
+   * Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If
+   * `item_id` and `item_code` are both present, `item_id` will be used.
    */
   @SerializedName("item_code")
   @Expose
   private String itemCode;
 
   /**
-   * System-generated unique identifier for an item. Available when the `Credit Invoices` and
-   * `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both
-   * present, `item_id` will be used.
+   * System-generated unique identifier for an item. Available when the `Credit Invoices` feature is
+   * enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
    */
   @SerializedName("item_id")
   @Expose
@@ -333,27 +331,24 @@ public class AddOnCreate extends Request {
   }
 
   /**
-   * Unique code to identify an item. Available when the `Credit Invoices` and `Subscription Billing
-   * Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be
-   * used.
+   * Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If
+   * `item_id` and `item_code` are both present, `item_id` will be used.
    */
   public String getItemCode() {
     return this.itemCode;
   }
 
   /**
-   * @param itemCode Unique code to identify an item. Available when the `Credit Invoices` and
-   *     `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both
-   *     present, `item_id` will be used.
+   * @param itemCode Unique code to identify an item. Available when the `Credit Invoices` feature
+   *     are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
    */
   public void setItemCode(final String itemCode) {
     this.itemCode = itemCode;
   }
 
   /**
-   * System-generated unique identifier for an item. Available when the `Credit Invoices` and
-   * `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both
-   * present, `item_id` will be used.
+   * System-generated unique identifier for an item. Available when the `Credit Invoices` feature is
+   * enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
    */
   public String getItemId() {
     return this.itemId;
@@ -361,8 +356,8 @@ public class AddOnCreate extends Request {
 
   /**
    * @param itemId System-generated unique identifier for an item. Available when the `Credit
-   *     Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and
-   *     `item_code` are both present, `item_id` will be used.
+   *     Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will
+   *     be used.
    */
   public void setItemId(final String itemId) {
     this.itemId = itemId;

--- a/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
@@ -181,8 +181,8 @@ public class BillingInfoCreate extends Request {
   private Constants.GatewayTransactionType transactionType;
 
   /**
-   * The payment method type for a non-credit card based billing info. The value of `bacs` is the
-   * only accepted value (Bacs only)
+   * The payment method type for a non-credit card based billing info. `bacs` and `becs` are the
+   * only accepted values.
    */
   @SerializedName("type")
   @Expose
@@ -545,16 +545,16 @@ public class BillingInfoCreate extends Request {
   }
 
   /**
-   * The payment method type for a non-credit card based billing info. The value of `bacs` is the
-   * only accepted value (Bacs only)
+   * The payment method type for a non-credit card based billing info. `bacs` and `becs` are the
+   * only accepted values.
    */
   public Constants.AchType getType() {
     return this.type;
   }
 
   /**
-   * @param type The payment method type for a non-credit card based billing info. The value of
-   *     `bacs` is the only accepted value (Bacs only)
+   * @param type The payment method type for a non-credit card based billing info. `bacs` and `becs`
+   *     are the only accepted values.
    */
   public void setType(final Constants.AchType type) {
     this.type = type;

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -77,17 +77,14 @@ public class LineItemCreate extends Request {
   @Expose
   private DateTime endDate;
 
-  /**
-   * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing
-   * Terms features are enabled.
-   */
+  /** Unique code to identify an item. Available when the Credit Invoices feature is enabled. */
   @SerializedName("item_code")
   @Expose
   private String itemCode;
 
   /**
-   * System-generated unique identifier for an item. Available when the Credit Invoices and
-   * Subscription Billing Terms features are enabled.
+   * System-generated unique identifier for an item. Available when the Credit Invoices feature is
+   * enabled.
    */
   @SerializedName("item_id")
   @Expose
@@ -305,25 +302,22 @@ public class LineItemCreate extends Request {
     this.endDate = endDate;
   }
 
-  /**
-   * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing
-   * Terms features are enabled.
-   */
+  /** Unique code to identify an item. Available when the Credit Invoices feature is enabled. */
   public String getItemCode() {
     return this.itemCode;
   }
 
   /**
-   * @param itemCode Unique code to identify an item. Available when the Credit Invoices and
-   *     Subscription Billing Terms features are enabled.
+   * @param itemCode Unique code to identify an item. Available when the Credit Invoices feature is
+   *     enabled.
    */
   public void setItemCode(final String itemCode) {
     this.itemCode = itemCode;
   }
 
   /**
-   * System-generated unique identifier for an item. Available when the Credit Invoices and
-   * Subscription Billing Terms features are enabled.
+   * System-generated unique identifier for an item. Available when the Credit Invoices feature is
+   * enabled.
    */
   public String getItemId() {
     return this.itemId;
@@ -331,7 +325,7 @@ public class LineItemCreate extends Request {
 
   /**
    * @param itemId System-generated unique identifier for an item. Available when the Credit
-   *     Invoices and Subscription Billing Terms features are enabled.
+   *     Invoices feature is enabled.
    */
   public void setItemId(final String itemId) {
     this.itemId = itemId;

--- a/src/main/java/com/recurly/v3/resources/Account.java
+++ b/src/main/java/com/recurly/v3/resources/Account.java
@@ -143,6 +143,14 @@ public class Account extends Resource {
   @Expose
   private String id;
 
+  /**
+   * Invoice template associated to the account. Available when invoice customization flag is
+   * enabled.
+   */
+  @SerializedName("invoice_template")
+  @Expose
+  private AccountInvoiceTemplate invoiceTemplate;
+
   @SerializedName("last_name")
   @Expose
   private String lastName;
@@ -467,6 +475,22 @@ public class Account extends Resource {
   /** @param id */
   public void setId(final String id) {
     this.id = id;
+  }
+
+  /**
+   * Invoice template associated to the account. Available when invoice customization flag is
+   * enabled.
+   */
+  public AccountInvoiceTemplate getInvoiceTemplate() {
+    return this.invoiceTemplate;
+  }
+
+  /**
+   * @param invoiceTemplate Invoice template associated to the account. Available when invoice
+   *     customization flag is enabled.
+   */
+  public void setInvoiceTemplate(final AccountInvoiceTemplate invoiceTemplate) {
+    this.invoiceTemplate = invoiceTemplate;
   }
 
   public String getLastName() {

--- a/src/main/java/com/recurly/v3/resources/AccountInvoiceTemplate.java
+++ b/src/main/java/com/recurly/v3/resources/AccountInvoiceTemplate.java
@@ -1,0 +1,43 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+
+public class AccountInvoiceTemplate extends Resource {
+
+  /** Unique ID to identify the invoice template. */
+  @SerializedName("id")
+  @Expose
+  private String id;
+
+  /** Template name */
+  @SerializedName("name")
+  @Expose
+  private String name;
+
+  /** Unique ID to identify the invoice template. */
+  public String getId() {
+    return this.id;
+  }
+
+  /** @param id Unique ID to identify the invoice template. */
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  /** Template name */
+  public String getName() {
+    return this.name;
+  }
+
+  /** @param name Template name */
+  public void setName(final String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -108,8 +108,8 @@ public class LineItem extends Resource {
   private DateTime endDate;
 
   /**
-   * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and
-   * Subscription Billing Terms features are enabled.
+   * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is
+   * enabled.
    */
   @SerializedName("external_sku")
   @Expose
@@ -135,17 +135,14 @@ public class LineItem extends Resource {
   @Expose
   private String invoiceNumber;
 
-  /**
-   * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing
-   * Terms features are enabled.
-   */
+  /** Unique code to identify an item. Available when the Credit Invoices feature is enabled. */
   @SerializedName("item_code")
   @Expose
   private String itemCode;
 
   /**
-   * System-generated unique identifier for an item. Available when the Credit Invoices and
-   * Subscription Billing Terms features are enabled.
+   * System-generated unique identifier for an item. Available when the Credit Invoices feature is
+   * enabled.
    */
   @SerializedName("item_id")
   @Expose
@@ -524,8 +521,8 @@ public class LineItem extends Resource {
   }
 
   /**
-   * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and
-   * Subscription Billing Terms features are enabled.
+   * Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is
+   * enabled.
    */
   public String getExternalSku() {
     return this.externalSku;
@@ -533,7 +530,7 @@ public class LineItem extends Resource {
 
   /**
    * @param externalSku Optional Stock Keeping Unit assigned to an item. Available when the Credit
-   *     Invoices and Subscription Billing Terms features are enabled.
+   *     Invoices feature is enabled.
    */
   public void setExternalSku(final String externalSku) {
     this.externalSku = externalSku;
@@ -579,25 +576,22 @@ public class LineItem extends Resource {
     this.invoiceNumber = invoiceNumber;
   }
 
-  /**
-   * Unique code to identify an item. Available when the Credit Invoices and Subscription Billing
-   * Terms features are enabled.
-   */
+  /** Unique code to identify an item. Available when the Credit Invoices feature is enabled. */
   public String getItemCode() {
     return this.itemCode;
   }
 
   /**
-   * @param itemCode Unique code to identify an item. Available when the Credit Invoices and
-   *     Subscription Billing Terms features are enabled.
+   * @param itemCode Unique code to identify an item. Available when the Credit Invoices feature is
+   *     enabled.
    */
   public void setItemCode(final String itemCode) {
     this.itemCode = itemCode;
   }
 
   /**
-   * System-generated unique identifier for an item. Available when the Credit Invoices and
-   * Subscription Billing Terms features are enabled.
+   * System-generated unique identifier for an item. Available when the Credit Invoices feature is
+   * enabled.
    */
   public String getItemId() {
     return this.itemId;
@@ -605,7 +599,7 @@ public class LineItem extends Resource {
 
   /**
    * @param itemId System-generated unique identifier for an item. Available when the Credit
-   *     Invoices and Subscription Billing Terms features are enabled.
+   *     Invoices feature is enabled.
    */
   public void setItemId(final String itemId) {
     this.itemId = itemId;


### PR DESCRIPTION
Support `Becs` as a payment method type for non-credit card based billing info.
- Added `Becs` as a valid non-credit card payment method type.

Support `InvoiceTemplate` in account when invoice customization feature is enabled.
- added `setInvoiceTemplate` and `getInvoiceTemplate` methods to Account

Updated documentation for the removal of the `Subscription Billing Terms` feature flag as the feature is now fully accessible on all sites.