### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19999,6 +19999,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -23,6 +23,11 @@ public class Subscription extends Resource {
   @Expose
   private DateTime activatedAt;
 
+  /** The invoice ID of the latest invoice created for an active subscription. */
+  @SerializedName("active_invoice_id")
+  @Expose
+  private String activeInvoiceId;
+
   /** Add-ons */
   @SerializedName("add_ons")
   @Expose
@@ -270,6 +275,18 @@ public class Subscription extends Resource {
   /** @param activatedAt Activated at */
   public void setActivatedAt(final DateTime activatedAt) {
     this.activatedAt = activatedAt;
+  }
+
+  /** The invoice ID of the latest invoice created for an active subscription. */
+  public String getActiveInvoiceId() {
+    return this.activeInvoiceId;
+  }
+
+  /**
+   * @param activeInvoiceId The invoice ID of the latest invoice created for an active subscription.
+   */
+  public void setActiveInvoiceId(final String activeInvoiceId) {
+    this.activeInvoiceId = activeInvoiceId;
   }
 
   /** Add-ons */


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.