### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -525,6 +525,28 @@ public class Constants {
     
     };
   
+    public enum UsageTimeframe {
+      UNDEFINED,
+    
+      @SerializedName("billing_period")
+      BILLING_PERIOD,
+    
+      @SerializedName("subscription_term")
+      SUBSCRIPTION_TERM,
+    
+    };
+  
+    public enum UsageTimeframeCreate {
+      UNDEFINED,
+    
+      @SerializedName("billing_period")
+      BILLING_PERIOD,
+    
+      @SerializedName("subscription_term")
+      SUBSCRIPTION_TERM,
+    
+    };
+  
     public enum CreditPaymentAction {
       UNDEFINED,
     

--- a/src/main/java/com/recurly/v3/requests/AddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnCreate.java
@@ -196,6 +196,14 @@ public class AddOnCreate extends Request {
   private BigDecimal usagePercentage;
 
   /**
+   * The time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to
+   * accumulate usage over the course of multiple billing periods.
+   */
+  @SerializedName("usage_timeframe")
+  @Expose
+  private Constants.UsageTimeframeCreate usageTimeframe;
+
+  /**
    * Type of usage, required if `add_on_type` is `usage`. See our
    * [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview
    * of how to configure usage add-ons.
@@ -571,6 +579,22 @@ public class AddOnCreate extends Request {
    */
   public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
+  }
+
+  /**
+   * The time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to
+   * accumulate usage over the course of multiple billing periods.
+   */
+  public Constants.UsageTimeframeCreate getUsageTimeframe() {
+    return this.usageTimeframe;
+  }
+
+  /**
+   * @param usageTimeframe The time at which usage totals are reset for billing purposes. Allows for
+   *     `tiered` add-ons to accumulate usage over the course of multiple billing periods.
+   */
+  public void setUsageTimeframe(final Constants.UsageTimeframeCreate usageTimeframe) {
+    this.usageTimeframe = usageTimeframe;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/AddOn.java
+++ b/src/main/java/com/recurly/v3/resources/AddOn.java
@@ -179,6 +179,11 @@ public class AddOn extends Resource {
   @Expose
   private BigDecimal usagePercentage;
 
+  /** The time at which usage totals are reset for billing purposes. */
+  @SerializedName("usage_timeframe")
+  @Expose
+  private Constants.UsageTimeframe usageTimeframe;
+
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */
   @SerializedName("usage_type")
   @Expose
@@ -518,6 +523,16 @@ public class AddOn extends Resource {
    */
   public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
+  }
+
+  /** The time at which usage totals are reset for billing purposes. */
+  public Constants.UsageTimeframe getUsageTimeframe() {
+    return this.usageTimeframe;
+  }
+
+  /** @param usageTimeframe The time at which usage totals are reset for billing purposes. */
+  public void setUsageTimeframe(final Constants.UsageTimeframe usageTimeframe) {
+    this.usageTimeframe = usageTimeframe;
   }
 
   /** Type of usage, returns usage type if `add_on_type` is `usage`. */

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -25,6 +25,11 @@ public class Subscription extends Resource {
   @Expose
   private DateTime activatedAt;
 
+  /** The invoice ID of the latest invoice created for an active subscription. */
+  @SerializedName("active_invoice_id")
+  @Expose
+  private String activeInvoiceId;
+
   /** Add-ons */
   @SerializedName("add_ons")
   @Expose
@@ -292,6 +297,18 @@ public class Subscription extends Resource {
   /** @param activatedAt Activated at */
   public void setActivatedAt(final DateTime activatedAt) {
     this.activatedAt = activatedAt;
+  }
+
+  /** The invoice ID of the latest invoice created for an active subscription. */
+  public String getActiveInvoiceId() {
+    return this.activeInvoiceId;
+  }
+
+  /**
+   * @param activeInvoiceId The invoice ID of the latest invoice created for an active subscription.
+   */
+  public void setActiveInvoiceId(final String activeInvoiceId) {
+    this.activeInvoiceId = activeInvoiceId;
   }
 
   /** Add-ons */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionAddOn.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionAddOn.java
@@ -119,6 +119,11 @@ public class SubscriptionAddOn extends Resource {
   @Expose
   private BigDecimal usagePercentage;
 
+  /** The time at which usage totals are reset for billing purposes. */
+  @SerializedName("usage_timeframe")
+  @Expose
+  private Constants.UsageTimeframe usageTimeframe;
+
   /** Just the important parts. */
   public AddOnMini getAddOn() {
     return this.addOn;
@@ -327,5 +332,15 @@ public class SubscriptionAddOn extends Resource {
    */
   public void setUsagePercentage(final BigDecimal usagePercentage) {
     this.usagePercentage = usagePercentage;
+  }
+
+  /** The time at which usage totals are reset for billing purposes. */
+  public Constants.UsageTimeframe getUsageTimeframe() {
+    return this.usageTimeframe;
+  }
+
+  /** @param usageTimeframe The time at which usage totals are reset for billing purposes. */
+  public void setUsageTimeframe(final Constants.UsageTimeframe usageTimeframe) {
+    this.usageTimeframe = usageTimeframe;
   }
 }


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.