### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15426,11 +15426,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15556,11 +15558,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15714,6 +15718,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19127,9 +19137,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19294,9 +19303,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -19318,9 +19326,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20289,9 +20296,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20401,9 +20407,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20862,9 +20867,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"

--- a/src/main/java/com/recurly/v3/requests/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnPricing.java
@@ -17,10 +17,7 @@ public class AddOnPricing extends Request {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -40,19 +37,12 @@ public class AddOnPricing extends Request {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanPricing.java
@@ -26,10 +26,7 @@ public class PlanPricing extends Request {
   @Expose
   private Float setupFee;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -68,19 +65,12 @@ public class PlanPricing extends Request {
     this.setupFee = setupFee;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/Pricing.java
+++ b/src/main/java/com/recurly/v3/requests/Pricing.java
@@ -17,10 +17,7 @@ public class Pricing extends Request {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -40,19 +37,12 @@ public class Pricing extends Request {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -104,10 +104,7 @@ public class SubscriptionChangeCreate extends Request {
   @Expose
   private SubscriptionChangeShippingCreate shipping;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -328,19 +325,12 @@ public class SubscriptionChangeCreate extends Request {
     this.shipping = shipping;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -100,10 +100,7 @@ public class SubscriptionUpdate extends Request {
   @Expose
   private SubscriptionShippingUpdate shipping;
 
-  /**
-   * This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use
-   * the POST subscription change route instead.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -292,18 +289,12 @@ public class SubscriptionUpdate extends Request {
     this.shipping = shipping;
   }
 
-  /**
-   * This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use
-   * the POST subscription change route instead.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive This field is deprecated. Do not use it anymore to update a subscription's
-   *     tax inclusivity. Use the POST subscription change route instead.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/AccountBalanceAmount.java
+++ b/src/main/java/com/recurly/v3/resources/AccountBalanceAmount.java
@@ -21,6 +21,11 @@ public class AccountBalanceAmount extends Resource {
   @Expose
   private String currency;
 
+  /** Total amount for the prepayment credit invoices in a `processing` state on the account. */
+  @SerializedName("processing_prepayment_amount")
+  @Expose
+  private Float processingPrepaymentAmount;
+
   /** Total amount the account is past due. */
   public Float getAmount() {
     return this.amount;
@@ -39,5 +44,18 @@ public class AccountBalanceAmount extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /** Total amount for the prepayment credit invoices in a `processing` state on the account. */
+  public Float getProcessingPrepaymentAmount() {
+    return this.processingPrepaymentAmount;
+  }
+
+  /**
+   * @param processingPrepaymentAmount Total amount for the prepayment credit invoices in a
+   *     `processing` state on the account.
+   */
+  public void setProcessingPrepaymentAmount(final Float processingPrepaymentAmount) {
+    this.processingPrepaymentAmount = processingPrepaymentAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnPricing.java
@@ -16,10 +16,7 @@ public class AddOnPricing extends Resource {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -39,19 +36,12 @@ public class AddOnPricing extends Resource {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanPricing.java
@@ -25,10 +25,7 @@ public class PlanPricing extends Resource {
   @Expose
   private Float setupFee;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -67,19 +64,12 @@ public class PlanPricing extends Resource {
     this.setupFee = setupFee;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/Pricing.java
+++ b/src/main/java/com/recurly/v3/resources/Pricing.java
@@ -16,10 +16,7 @@ public class Pricing extends Resource {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -39,19 +36,12 @@ public class Pricing extends Resource {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -97,10 +97,7 @@ public class SubscriptionChange extends Resource {
   @Expose
   private String subscriptionId;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -283,19 +280,12 @@ public class SubscriptionChange extends Resource {
     this.subscriptionId = subscriptionId;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChangePreview.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChangePreview.java
@@ -97,10 +97,7 @@ public class SubscriptionChangePreview extends Resource {
   @Expose
   private String subscriptionId;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -283,19 +280,12 @@ public class SubscriptionChangePreview extends Resource {
     this.subscriptionId = subscriptionId;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.