### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12519,7 +12519,97 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-      x-code-samples: []
+      x-code-samples:
+      - lang: Node.js
+        source: |
+          try {
+            const invoiceCollection = await client.getPreviewRenewal(subscriptionId)
+            console.log('Fetched Renewal Preview with total: ', invoiceCollection.chargeInvoice.total)
+          } catch (err) {
+            if (err instanceof recurly.errors.NotFoundError) {
+              // If the request was not found, you may want to alert the user or
+              // just return null
+              console.log('Resource Not Found')
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              invoice_collection = client.get_preview_renewal(subscription_id)
+              print("Fetched Renewal Preview with total: %s" % invoice_collection.charge_invoice.total)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+        source: |
+          try
+          {
+              InvoiceCollection invoiceCollection = client.GetPreviewRenewal(subscriptionId);
+              Console.WriteLine($"Fetched Renewal Preview with total {invoiceCollection.ChargeInvoice.Total}");
+          }
+          catch (Recurly.Errors.NotFound ex)
+          {
+              // If the resource was not found
+              // we may want to alert the user or just return null
+              Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+          }
+          catch (Recurly.Errors.ApiError ex)
+          {
+              // Use ApiError to catch a generic error from the API
+              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+          }
+      - lang: Ruby
+        source: |
+          begin
+            invoice_collection = @client.get_preview_renewal(
+              subscription_id: subscription_id
+            )
+            puts "Fetched Renewal Preview with total: #{invoice_collection.charge_invoice.total}"
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+        source: |
+          try {
+              final InvoiceCollection invoiceCollection = client.getPreviewRenewal(subscriptionId);
+              System.out.println("Fetched Renewal Preview with total: " + invoiceCollection.getChargeInvoice().getTotal());
+          } catch (ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+      - lang: PHP
+        source: |
+          try {
+              $invoiceCollection = $client->getPreviewRenewal($subscription_id);
+
+              echo 'Fetched Renewal Preview with total: ' . $invoiceCollection->getChargeInvoice()->getTotal() . PHP_EOL;
+              var_dump($invoiceCollection);
+          } catch (\Recurly\Errors\NotFound $e) {
+              // Could not find the resource, you may want to inform the user
+              // or just return a NULL
+              echo 'Could not find resource.' . PHP_EOL;
+              var_dump($e);
+          } catch (\Recurly\RecurlyError $e) {
+              // Something bad happened... tell the user so that they can fix it?
+              echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+          }
+      - lang: Go
+        source: "invoiceCollection, err := client.GetPreviewRenewal(subID)\nif e,
+          ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+          {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+          Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Renewal
+          Preview with total: %f\", invoiceCollection.ChargeInvoice.Total)"
   "/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -15852,7 +15942,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template.  Available when
-            the Invoice Customization feature is enabled.  Used to specify which invoice
+            the site is on a Pro or Enterprise plan.  Used to specify which invoice
             template, if any, should be used to generate invoices for the account.
         address:
           "$ref": "#/components/schemas/Address"
@@ -15935,7 +16025,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template. Available when the
-            Invoice Customization feature is enabled. Used to specify if a non-default
+            site is on a Pro or Enterprise plan. Used to specify if a non-default
             invoice template will be used to generate invoices for the account. For
             sites without multiple invoice templates enabled, the default template
             will always be used.
@@ -16040,6 +16130,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -16805,11 +16901,12 @@ components:
           type: string
           description: Tax identifier is required if adding a billing info that is
             a consumer card in Brazil or in Argentina. This would be the customer's
-            CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for
-            all residents who pay taxes in Brazil and Argentina respectively.
+            CPF/CNPJ (Brazil) and CUIT (Argentina). CPF, CNPJ and CUIT are tax identifiers
+            for all residents who pay taxes in Brazil and Argentina respectively.
         tax_identifier_type:
-          description: This field and a value of `cpf` or `cuit` are required if adding
-            a billing info that is an elo or hipercard type in Brazil or in Argentina.
+          description: This field and a value of `cpf`, `cnpj` or `cuit` are required
+            if adding a billing info that is an elo or hipercard type in Brazil or
+            in Argentina.
           "$ref": "#/components/schemas/TaxIdentifierTypeEnum"
         primary_payment_method:
           type: boolean
@@ -19143,9 +19240,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19307,9 +19403,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
     TierPricing:
@@ -19356,9 +19451,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20397,9 +20491,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20491,9 +20584,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20932,9 +21024,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
@@ -22074,11 +22164,13 @@ components:
       - ko-KR
       - nl-BE
       - nl-NL
+      - pl-PL
       - pt-BR
       - pt-PT
       - ro-RO
       - ru-RU
       - sk-SK
+      - sv-SE
       - tr-TR
       - zh-CN
     BillToEnum:
@@ -22752,6 +22844,7 @@ components:
       type: string
       enum:
       - cpf
+      - cnpj
       - cuit
     DunningCycleTypeEnum:
       type: string

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -310,6 +310,9 @@ public class Constants {
       @SerializedName("nl-NL")
       NL_NL,
     
+      @SerializedName("pl-PL")
+      PL_PL,
+    
       @SerializedName("pt-BR")
       PT_BR,
     
@@ -324,6 +327,9 @@ public class Constants {
     
       @SerializedName("sk-SK")
       SK_SK,
+    
+      @SerializedName("sv-SE")
+      SV_SE,
     
       @SerializedName("tr-TR")
       TR_TR,
@@ -1918,6 +1924,9 @@ public class Constants {
     
       @SerializedName("cpf")
       CPF,
+    
+      @SerializedName("cnpj")
+      CNPJ,
     
       @SerializedName("cuit")
       CUIT,

--- a/src/main/java/com/recurly/v3/requests/AccountCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AccountCreate.java
@@ -92,9 +92,9 @@ public class AccountCreate extends Request {
   private String firstName;
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify which invoice template, if any, should be used to generate invoices
-   * for the account.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify which invoice template, if any, should be used to generate invoices for
+   * the account.
    */
   @SerializedName("invoice_template_id")
   @Expose
@@ -331,18 +331,18 @@ public class AccountCreate extends Request {
   }
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify which invoice template, if any, should be used to generate invoices
-   * for the account.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify which invoice template, if any, should be used to generate invoices for
+   * the account.
    */
   public String getInvoiceTemplateId() {
     return this.invoiceTemplateId;
   }
 
   /**
-   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the Invoice
-   *     Customization feature is enabled. Used to specify which invoice template, if any, should be
-   *     used to generate invoices for the account.
+   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the site is
+   *     on a Pro or Enterprise plan. Used to specify which invoice template, if any, should be used
+   *     to generate invoices for the account.
    */
   public void setInvoiceTemplateId(final String invoiceTemplateId) {
     this.invoiceTemplateId = invoiceTemplateId;

--- a/src/main/java/com/recurly/v3/requests/AccountPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/AccountPurchase.java
@@ -100,9 +100,9 @@ public class AccountPurchase extends Request {
   private String id;
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify which invoice template, if any, should be used to generate invoices
-   * for the account.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify which invoice template, if any, should be used to generate invoices for
+   * the account.
    */
   @SerializedName("invoice_template_id")
   @Expose
@@ -351,18 +351,18 @@ public class AccountPurchase extends Request {
   }
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify which invoice template, if any, should be used to generate invoices
-   * for the account.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify which invoice template, if any, should be used to generate invoices for
+   * the account.
    */
   public String getInvoiceTemplateId() {
     return this.invoiceTemplateId;
   }
 
   /**
-   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the Invoice
-   *     Customization feature is enabled. Used to specify which invoice template, if any, should be
-   *     used to generate invoices for the account.
+   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the site is
+   *     on a Pro or Enterprise plan. Used to specify which invoice template, if any, should be used
+   *     to generate invoices for the account.
    */
   public void setInvoiceTemplateId(final String invoiceTemplateId) {
     this.invoiceTemplateId = invoiceTemplateId;

--- a/src/main/java/com/recurly/v3/requests/AccountUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/AccountUpdate.java
@@ -83,9 +83,9 @@ public class AccountUpdate extends Request {
   private String firstName;
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify which invoice template, if any, should be used to generate invoices
-   * for the account.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify which invoice template, if any, should be used to generate invoices for
+   * the account.
    */
   @SerializedName("invoice_template_id")
   @Expose
@@ -296,18 +296,18 @@ public class AccountUpdate extends Request {
   }
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify which invoice template, if any, should be used to generate invoices
-   * for the account.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify which invoice template, if any, should be used to generate invoices for
+   * the account.
    */
   public String getInvoiceTemplateId() {
     return this.invoiceTemplateId;
   }
 
   /**
-   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the Invoice
-   *     Customization feature is enabled. Used to specify which invoice template, if any, should be
-   *     used to generate invoices for the account.
+   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the site is
+   *     on a Pro or Enterprise plan. Used to specify which invoice template, if any, should be used
+   *     to generate invoices for the account.
    */
   public void setInvoiceTemplateId(final String invoiceTemplateId) {
     this.invoiceTemplateId = invoiceTemplateId;

--- a/src/main/java/com/recurly/v3/requests/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnPricing.java
@@ -18,10 +18,7 @@ public class AddOnPricing extends Request {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -49,19 +46,12 @@ public class AddOnPricing extends Request {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
@@ -151,16 +151,16 @@ public class BillingInfoCreate extends Request {
 
   /**
    * Tax identifier is required if adding a billing info that is a consumer card in Brazil or in
-   * Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax
-   * identifiers for all residents who pay taxes in Brazil and Argentina respectively.
+   * Argentina. This would be the customer's CPF/CNPJ (Brazil) and CUIT (Argentina). CPF, CNPJ and
+   * CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
    */
   @SerializedName("tax_identifier")
   @Expose
   private String taxIdentifier;
 
   /**
-   * This field and a value of `cpf` or `cuit` are required if adding a billing info that is an elo
-   * or hipercard type in Brazil or in Argentina.
+   * This field and a value of `cpf`, `cnpj` or `cuit` are required if adding a billing info that is
+   * an elo or hipercard type in Brazil or in Argentina.
    */
   @SerializedName("tax_identifier_type")
   @Expose
@@ -493,8 +493,8 @@ public class BillingInfoCreate extends Request {
 
   /**
    * Tax identifier is required if adding a billing info that is a consumer card in Brazil or in
-   * Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax
-   * identifiers for all residents who pay taxes in Brazil and Argentina respectively.
+   * Argentina. This would be the customer's CPF/CNPJ (Brazil) and CUIT (Argentina). CPF, CNPJ and
+   * CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
    */
   public String getTaxIdentifier() {
     return this.taxIdentifier;
@@ -502,25 +502,25 @@ public class BillingInfoCreate extends Request {
 
   /**
    * @param taxIdentifier Tax identifier is required if adding a billing info that is a consumer
-   *     card in Brazil or in Argentina. This would be the customer's CPF (Brazil) and CUIT
-   *     (Argentina). CPF and CUIT are tax identifiers for all residents who pay taxes in Brazil and
-   *     Argentina respectively.
+   *     card in Brazil or in Argentina. This would be the customer's CPF/CNPJ (Brazil) and CUIT
+   *     (Argentina). CPF, CNPJ and CUIT are tax identifiers for all residents who pay taxes in
+   *     Brazil and Argentina respectively.
    */
   public void setTaxIdentifier(final String taxIdentifier) {
     this.taxIdentifier = taxIdentifier;
   }
 
   /**
-   * This field and a value of `cpf` or `cuit` are required if adding a billing info that is an elo
-   * or hipercard type in Brazil or in Argentina.
+   * This field and a value of `cpf`, `cnpj` or `cuit` are required if adding a billing info that is
+   * an elo or hipercard type in Brazil or in Argentina.
    */
   public Constants.TaxIdentifierType getTaxIdentifierType() {
     return this.taxIdentifierType;
   }
 
   /**
-   * @param taxIdentifierType This field and a value of `cpf` or `cuit` are required if adding a
-   *     billing info that is an elo or hipercard type in Brazil or in Argentina.
+   * @param taxIdentifierType This field and a value of `cpf`, `cnpj` or `cuit` are required if
+   *     adding a billing info that is an elo or hipercard type in Brazil or in Argentina.
    */
   public void setTaxIdentifierType(final Constants.TaxIdentifierType taxIdentifierType) {
     this.taxIdentifierType = taxIdentifierType;

--- a/src/main/java/com/recurly/v3/requests/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanPricing.java
@@ -27,10 +27,7 @@ public class PlanPricing extends Request {
   @Expose
   private BigDecimal setupFee;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -69,19 +66,12 @@ public class PlanPricing extends Request {
     this.setupFee = setupFee;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/Pricing.java
+++ b/src/main/java/com/recurly/v3/requests/Pricing.java
@@ -18,10 +18,7 @@ public class Pricing extends Request {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -41,19 +38,12 @@ public class Pricing extends Request {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -111,10 +111,7 @@ public class SubscriptionChangeCreate extends Request {
   @Expose
   private SubscriptionChangeShippingCreate shipping;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -342,19 +339,12 @@ public class SubscriptionChangeCreate extends Request {
     this.shipping = shipping;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -106,10 +106,7 @@ public class SubscriptionUpdate extends Request {
   @Expose
   private SubscriptionShippingUpdate shipping;
 
-  /**
-   * This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use
-   * the POST subscription change route instead.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -311,18 +308,12 @@ public class SubscriptionUpdate extends Request {
     this.shipping = shipping;
   }
 
-  /**
-   * This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use
-   * the POST subscription change route instead.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive This field is deprecated. Do not use it anymore to update a subscription's
-   *     tax inclusivity. Use the POST subscription change route instead.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/Account.java
+++ b/src/main/java/com/recurly/v3/resources/Account.java
@@ -143,10 +143,10 @@ public class Account extends Resource {
   private String id;
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify if a non-default invoice template will be used to generate invoices
-   * for the account. For sites without multiple invoice templates enabled, the default template
-   * will always be used.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify if a non-default invoice template will be used to generate invoices for
+   * the account. For sites without multiple invoice templates enabled, the default template will
+   * always be used.
    */
   @SerializedName("invoice_template_id")
   @Expose
@@ -477,20 +477,20 @@ public class Account extends Resource {
   }
 
   /**
-   * Unique ID to identify an invoice template. Available when the Invoice Customization feature is
-   * enabled. Used to specify if a non-default invoice template will be used to generate invoices
-   * for the account. For sites without multiple invoice templates enabled, the default template
-   * will always be used.
+   * Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise
+   * plan. Used to specify if a non-default invoice template will be used to generate invoices for
+   * the account. For sites without multiple invoice templates enabled, the default template will
+   * always be used.
    */
   public String getInvoiceTemplateId() {
     return this.invoiceTemplateId;
   }
 
   /**
-   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the Invoice
-   *     Customization feature is enabled. Used to specify if a non-default invoice template will be
-   *     used to generate invoices for the account. For sites without multiple invoice templates
-   *     enabled, the default template will always be used.
+   * @param invoiceTemplateId Unique ID to identify an invoice template. Available when the site is
+   *     on a Pro or Enterprise plan. Used to specify if a non-default invoice template will be used
+   *     to generate invoices for the account. For sites without multiple invoice templates enabled,
+   *     the default template will always be used.
    */
   public void setInvoiceTemplateId(final String invoiceTemplateId) {
     this.invoiceTemplateId = invoiceTemplateId;

--- a/src/main/java/com/recurly/v3/resources/AccountBalanceAmount.java
+++ b/src/main/java/com/recurly/v3/resources/AccountBalanceAmount.java
@@ -22,6 +22,11 @@ public class AccountBalanceAmount extends Resource {
   @Expose
   private String currency;
 
+  /** Total amount for the prepayment credit invoices in a `processing` state on the account. */
+  @SerializedName("processing_prepayment_amount")
+  @Expose
+  private BigDecimal processingPrepaymentAmount;
+
   /** Total amount the account is past due. */
   public BigDecimal getAmount() {
     return this.amount;
@@ -40,5 +45,18 @@ public class AccountBalanceAmount extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /** Total amount for the prepayment credit invoices in a `processing` state on the account. */
+  public BigDecimal getProcessingPrepaymentAmount() {
+    return this.processingPrepaymentAmount;
+  }
+
+  /**
+   * @param processingPrepaymentAmount Total amount for the prepayment credit invoices in a
+   *     `processing` state on the account.
+   */
+  public void setProcessingPrepaymentAmount(final BigDecimal processingPrepaymentAmount) {
+    this.processingPrepaymentAmount = processingPrepaymentAmount;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/AddOnPricing.java
+++ b/src/main/java/com/recurly/v3/resources/AddOnPricing.java
@@ -17,10 +17,7 @@ public class AddOnPricing extends Resource {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -48,19 +45,12 @@ public class AddOnPricing extends Resource {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanPricing.java
@@ -26,10 +26,7 @@ public class PlanPricing extends Resource {
   @Expose
   private BigDecimal setupFee;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -68,19 +65,12 @@ public class PlanPricing extends Resource {
     this.setupFee = setupFee;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/Pricing.java
+++ b/src/main/java/com/recurly/v3/resources/Pricing.java
@@ -17,10 +17,7 @@ public class Pricing extends Resource {
   @Expose
   private String currency;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -40,19 +37,12 @@ public class Pricing extends Resource {
     this.currency = currency;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -94,10 +94,7 @@ public class SubscriptionChange extends Resource {
   @Expose
   private String subscriptionId;
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   @SerializedName("tax_inclusive")
   @Expose
   private Boolean taxInclusive;
@@ -270,19 +267,12 @@ public class SubscriptionChange extends Resource {
     this.subscriptionId = subscriptionId;
   }
 
-  /**
-   * Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature
-   * (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-   */
+  /** This field is deprecated. Please do not use it. */
   public Boolean getTaxInclusive() {
     return this.taxInclusive;
   }
 
-  /**
-   * @param taxInclusive Determines whether or not tax is included in the unit amount. The Tax
-   *     Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to
-   *     use this flag.
-   */
+  /** @param taxInclusive This field is deprecated. Please do not use it. */
   public void setTaxInclusive(final Boolean taxInclusive) {
     this.taxInclusive = taxInclusive;
   }


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.
- The invoice templates feature is now generally available to merchants with a Pro or Elite plan Recurly subscription. See [our documentation](https://docs.recurly.com/docs/invoice-customization#create-and-assigning-invoice-templates) for more information about that feature.