### PR TITLE
Update tests 3.x

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -2,8 +2,8 @@
 set -e
 
 if [[ -z "${TRAVIS}" ]]; then
-  RECURLY_INSECURE=true mvn clean test jacoco:report
+  mvn clean test jacoco:report
 else
-    RECURLY_INSECURE=true mvn clean test
-#   RECURLY_INSECURE=true mvn clean test jacoco:report coveralls:report
+    mvn clean test
+#   mvn clean test jacoco:report coveralls:report
 fi

--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -345,11 +345,15 @@ public class BaseClientTest {
 
   @Test
   public void testSetApiUrl() {
-    final MockClient client = new MockClient("apiKey");
-    final String newApiUrl = "https://my.base.url/";
-    client._setApiUrl(newApiUrl);
+    try (MockedStatic<BaseClient> theMock = mockStatic(BaseClient.class)) {
+      theMock.when(() -> BaseClient.envEnabled(eq("RECURLY_INSECURE"))).thenReturn(true);
 
-    assertEquals(newApiUrl, client.getApiUrl());
+      final MockClient client = new MockClient("apiKey");
+      final String newApiUrl = "https://my.base.url/";
+      client._setApiUrl(newApiUrl);
+
+      assertEquals(newApiUrl, client.getApiUrl());
+    }
   }
 
   @Test


### PR DESCRIPTION
Update tests so that they do not depends on the `RECURLY_INSECURE` environment variable being set.