### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17259,7 +17259,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18828,6 +18828,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         accounting_code:
           type: string
           title: Plan accounting code
@@ -19006,6 +19022,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19137,6 +19169,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19214,6 +19247,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19291,6 +19329,19 @@ components:
             a non-default dunning campaign should be assigned to this plan. For sites
             without multiple dunning campaigns enabled, the default dunning campaign
             will always be used.
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     AddOnPricing:
       type: object
       properties:
@@ -19311,6 +19362,24 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+      required:
+      - currency
+      - unit_amount
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
       required:
       - currency
       - unit_amount
@@ -19899,6 +19968,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20362,6 +20438,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20501,6 +20584,12 @@ components:
           - moto
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangePreview:
       type: object
       allOf:
@@ -20652,6 +20741,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -20803,6 +20898,12 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -20986,6 +21087,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info

--- a/src/main/java/com/recurly/v3/requests/PlanCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanCreate.java
@@ -115,6 +115,20 @@ public class PlanCreate extends Request {
   @Expose
   private String name;
 
+  /**
+   * A fixed pricing model has the same price for each billing period. A ramp pricing model defines
+   * a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing
+   * periods. The price change could be an increase or decrease.
+   */
+  @SerializedName("pricing_model")
+  @Expose
+  private String pricingModel;
+
+  /** Ramp Intervals */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<PlanRampInterval> rampIntervals;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -373,6 +387,34 @@ public class PlanCreate extends Request {
    */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * A fixed pricing model has the same price for each billing period. A ramp pricing model defines
+   * a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing
+   * periods. The price change could be an increase or decrease.
+   */
+  public String getPricingModel() {
+    return this.pricingModel;
+  }
+
+  /**
+   * @param pricingModel A fixed pricing model has the same price for each billing period. A ramp
+   *     pricing model defines a set of Ramp Intervals, where a subscription changes price on a
+   *     specified cadence of billing periods. The price change could be an increase or decrease.
+   */
+  public void setPricingModel(final String pricingModel) {
+    this.pricingModel = pricingModel;
+  }
+
+  /** Ramp Intervals */
+  public List<PlanRampInterval> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /** @param rampIntervals Ramp Intervals */
+  public void setRampIntervals(final List<PlanRampInterval> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanPricing.java
@@ -31,7 +31,7 @@ public class PlanPricing extends Request {
   @Expose
   private Boolean taxInclusive;
 
-  /** Unit price */
+  /** This field should not be sent when the pricing model is 'ramp'. */
   @SerializedName("unit_amount")
   @Expose
   private Float unitAmount;
@@ -75,12 +75,12 @@ public class PlanPricing extends Request {
     this.taxInclusive = taxInclusive;
   }
 
-  /** Unit price */
+  /** This field should not be sent when the pricing model is 'ramp'. */
   public Float getUnitAmount() {
     return this.unitAmount;
   }
 
-  /** @param unitAmount Unit price */
+  /** @param unitAmount This field should not be sent when the pricing model is 'ramp'. */
   public void setUnitAmount(final Float unitAmount) {
     this.unitAmount = unitAmount;
   }

--- a/src/main/java/com/recurly/v3/requests/PlanRampInterval.java
+++ b/src/main/java/com/recurly/v3/requests/PlanRampInterval.java
@@ -1,0 +1,45 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+import java.util.List;
+
+public class PlanRampInterval extends Request {
+
+  /** Represents the price for the ramp interval. */
+  @SerializedName("currencies")
+  @Expose
+  private List<PlanRampPricing> currencies;
+
+  /** Represents the first billing cycle of a ramp. */
+  @SerializedName("starting_billing_cycle")
+  @Expose
+  private Integer startingBillingCycle;
+
+  /** Represents the price for the ramp interval. */
+  public List<PlanRampPricing> getCurrencies() {
+    return this.currencies;
+  }
+
+  /** @param currencies Represents the price for the ramp interval. */
+  public void setCurrencies(final List<PlanRampPricing> currencies) {
+    this.currencies = currencies;
+  }
+
+  /** Represents the first billing cycle of a ramp. */
+  public Integer getStartingBillingCycle() {
+    return this.startingBillingCycle;
+  }
+
+  /** @param startingBillingCycle Represents the first billing cycle of a ramp. */
+  public void setStartingBillingCycle(final Integer startingBillingCycle) {
+    this.startingBillingCycle = startingBillingCycle;
+  }
+}

--- a/src/main/java/com/recurly/v3/requests/PlanRampPricing.java
+++ b/src/main/java/com/recurly/v3/requests/PlanRampPricing.java
@@ -1,0 +1,44 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class PlanRampPricing extends Request {
+
+  /** 3-letter ISO 4217 currency code. */
+  @SerializedName("currency")
+  @Expose
+  private String currency;
+
+  /** Represents the price for the Ramp Interval. */
+  @SerializedName("unit_amount")
+  @Expose
+  private Float unitAmount;
+
+  /** 3-letter ISO 4217 currency code. */
+  public String getCurrency() {
+    return this.currency;
+  }
+
+  /** @param currency 3-letter ISO 4217 currency code. */
+  public void setCurrency(final String currency) {
+    this.currency = currency;
+  }
+
+  /** Represents the price for the Ramp Interval. */
+  public Float getUnitAmount() {
+    return this.unitAmount;
+  }
+
+  /** @param unitAmount Represents the price for the Ramp Interval. */
+  public void setUnitAmount(final Float unitAmount) {
+    this.unitAmount = unitAmount;
+  }
+}

--- a/src/main/java/com/recurly/v3/requests/PlanUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanUpdate.java
@@ -105,6 +105,11 @@ public class PlanUpdate extends Request {
   @Expose
   private String name;
 
+  /** Ramp Intervals */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<PlanRampInterval> rampIntervals;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -343,6 +348,16 @@ public class PlanUpdate extends Request {
    */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /** Ramp Intervals */
+  public List<PlanRampInterval> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /** @param rampIntervals Ramp Intervals */
+  public void setRampIntervals(final List<PlanRampInterval> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -94,6 +94,11 @@ public class SubscriptionChangeCreate extends Request {
   @Expose
   private Integer quantity;
 
+  /** The new set of ramp intervals for the subscription. */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<SubscriptionRampInterval> rampIntervals;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -300,6 +305,16 @@ public class SubscriptionChangeCreate extends Request {
   /** @param quantity Optionally override the default quantity of 1. */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /** The new set of ramp intervals for the subscription. */
+  public List<SubscriptionRampInterval> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /** @param rampIntervals The new set of ramp intervals for the subscription. */
+  public void setRampIntervals(final List<SubscriptionRampInterval> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -130,6 +130,11 @@ public class SubscriptionCreate extends Request {
   @Expose
   private Integer quantity;
 
+  /** The new set of ramp intervals for the subscription. */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<SubscriptionRampInterval> rampIntervals;
+
   /**
    * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the
    * length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
@@ -443,6 +448,16 @@ public class SubscriptionCreate extends Request {
   /** @param quantity Optionally override the default quantity of 1. */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /** The new set of ramp intervals for the subscription. */
+  public List<SubscriptionRampInterval> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /** @param rampIntervals The new set of ramp intervals for the subscription. */
+  public void setRampIntervals(final List<SubscriptionRampInterval> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionPurchase.java
@@ -60,6 +60,11 @@ public class SubscriptionPurchase extends Request {
   @Expose
   private Integer quantity;
 
+  /** The new set of ramp intervals for the subscription. */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<SubscriptionRampInterval> rampIntervals;
+
   /**
    * If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the
    * length of subsequent terms. Defaults to the plan's `total_billing_cycles`.
@@ -211,6 +216,16 @@ public class SubscriptionPurchase extends Request {
   /** @param quantity Optionally override the default quantity of 1. */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /** The new set of ramp intervals for the subscription. */
+  public List<SubscriptionRampInterval> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /** @param rampIntervals The new set of ramp intervals for the subscription. */
+  public void setRampIntervals(final List<SubscriptionRampInterval> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionRampInterval.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionRampInterval.java
@@ -1,0 +1,46 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class SubscriptionRampInterval extends Request {
+
+  /** Represents how many billing cycles are included in a ramp interval. */
+  @SerializedName("starting_billing_cycle")
+  @Expose
+  private Integer startingBillingCycle;
+
+  /** Represents the price for the ramp interval. */
+  @SerializedName("unit_amount")
+  @Expose
+  private Integer unitAmount;
+
+  /** Represents how many billing cycles are included in a ramp interval. */
+  public Integer getStartingBillingCycle() {
+    return this.startingBillingCycle;
+  }
+
+  /**
+   * @param startingBillingCycle Represents how many billing cycles are included in a ramp interval.
+   */
+  public void setStartingBillingCycle(final Integer startingBillingCycle) {
+    this.startingBillingCycle = startingBillingCycle;
+  }
+
+  /** Represents the price for the ramp interval. */
+  public Integer getUnitAmount() {
+    return this.unitAmount;
+  }
+
+  /** @param unitAmount Represents the price for the ramp interval. */
+  public void setUnitAmount(final Integer unitAmount) {
+    this.unitAmount = unitAmount;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/Plan.java
+++ b/src/main/java/com/recurly/v3/resources/Plan.java
@@ -130,6 +130,20 @@ public class Plan extends Resource {
   @Expose
   private String object;
 
+  /**
+   * A fixed pricing model has the same price for each billing period. A ramp pricing model defines
+   * a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing
+   * periods. The price change could be an increase or decrease.
+   */
+  @SerializedName("pricing_model")
+  @Expose
+  private String pricingModel;
+
+  /** Ramp Intervals */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<PlanRampInterval> rampIntervals;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -428,6 +442,34 @@ public class Plan extends Resource {
   /** @param object Object type */
   public void setObject(final String object) {
     this.object = object;
+  }
+
+  /**
+   * A fixed pricing model has the same price for each billing period. A ramp pricing model defines
+   * a set of Ramp Intervals, where a subscription changes price on a specified cadence of billing
+   * periods. The price change could be an increase or decrease.
+   */
+  public String getPricingModel() {
+    return this.pricingModel;
+  }
+
+  /**
+   * @param pricingModel A fixed pricing model has the same price for each billing period. A ramp
+   *     pricing model defines a set of Ramp Intervals, where a subscription changes price on a
+   *     specified cadence of billing periods. The price change could be an increase or decrease.
+   */
+  public void setPricingModel(final String pricingModel) {
+    this.pricingModel = pricingModel;
+  }
+
+  /** Ramp Intervals */
+  public List<PlanRampInterval> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /** @param rampIntervals Ramp Intervals */
+  public void setRampIntervals(final List<PlanRampInterval> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/PlanPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanPricing.java
@@ -30,7 +30,7 @@ public class PlanPricing extends Resource {
   @Expose
   private Boolean taxInclusive;
 
-  /** Unit price */
+  /** This field should not be sent when the pricing model is 'ramp'. */
   @SerializedName("unit_amount")
   @Expose
   private Float unitAmount;
@@ -74,12 +74,12 @@ public class PlanPricing extends Resource {
     this.taxInclusive = taxInclusive;
   }
 
-  /** Unit price */
+  /** This field should not be sent when the pricing model is 'ramp'. */
   public Float getUnitAmount() {
     return this.unitAmount;
   }
 
-  /** @param unitAmount Unit price */
+  /** @param unitAmount This field should not be sent when the pricing model is 'ramp'. */
   public void setUnitAmount(final Float unitAmount) {
     this.unitAmount = unitAmount;
   }

--- a/src/main/java/com/recurly/v3/resources/PlanRampInterval.java
+++ b/src/main/java/com/recurly/v3/resources/PlanRampInterval.java
@@ -1,0 +1,44 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+import java.util.List;
+
+public class PlanRampInterval extends Resource {
+
+  /** Represents the price for the ramp interval. */
+  @SerializedName("currencies")
+  @Expose
+  private List<PlanRampPricing> currencies;
+
+  /** Represents the first billing cycle of a ramp. */
+  @SerializedName("starting_billing_cycle")
+  @Expose
+  private Integer startingBillingCycle;
+
+  /** Represents the price for the ramp interval. */
+  public List<PlanRampPricing> getCurrencies() {
+    return this.currencies;
+  }
+
+  /** @param currencies Represents the price for the ramp interval. */
+  public void setCurrencies(final List<PlanRampPricing> currencies) {
+    this.currencies = currencies;
+  }
+
+  /** Represents the first billing cycle of a ramp. */
+  public Integer getStartingBillingCycle() {
+    return this.startingBillingCycle;
+  }
+
+  /** @param startingBillingCycle Represents the first billing cycle of a ramp. */
+  public void setStartingBillingCycle(final Integer startingBillingCycle) {
+    this.startingBillingCycle = startingBillingCycle;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/PlanRampPricing.java
+++ b/src/main/java/com/recurly/v3/resources/PlanRampPricing.java
@@ -1,0 +1,43 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+
+public class PlanRampPricing extends Resource {
+
+  /** 3-letter ISO 4217 currency code. */
+  @SerializedName("currency")
+  @Expose
+  private String currency;
+
+  /** Represents the price for the Ramp Interval. */
+  @SerializedName("unit_amount")
+  @Expose
+  private Float unitAmount;
+
+  /** 3-letter ISO 4217 currency code. */
+  public String getCurrency() {
+    return this.currency;
+  }
+
+  /** @param currency 3-letter ISO 4217 currency code. */
+  public void setCurrency(final String currency) {
+    this.currency = currency;
+  }
+
+  /** Represents the price for the Ramp Interval. */
+  public Float getUnitAmount() {
+    return this.unitAmount;
+  }
+
+  /** @param unitAmount Represents the price for the Ramp Interval. */
+  public void setUnitAmount(final Float unitAmount) {
+    this.unitAmount = unitAmount;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -178,6 +178,11 @@ public class Subscription extends Resource {
   @Expose
   private Integer quantity;
 
+  /** The ramp intervals representing the pricing schedule for the subscription. */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<SubscriptionRampIntervalResponse> rampIntervals;
+
   /** The remaining billing cycles in the current term. */
   @SerializedName("remaining_billing_cycles")
   @Expose
@@ -606,6 +611,18 @@ public class Subscription extends Resource {
   /** @param quantity Subscription quantity */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /** The ramp intervals representing the pricing schedule for the subscription. */
+  public List<SubscriptionRampIntervalResponse> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /**
+   * @param rampIntervals The ramp intervals representing the pricing schedule for the subscription.
+   */
+  public void setRampIntervals(final List<SubscriptionRampIntervalResponse> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** The remaining billing cycles in the current term. */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChange.java
@@ -77,6 +77,11 @@ public class SubscriptionChange extends Resource {
   @Expose
   private Integer quantity;
 
+  /** The ramp intervals representing the pricing schedule for the subscription. */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<SubscriptionRampIntervalResponse> rampIntervals;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -238,6 +243,18 @@ public class SubscriptionChange extends Resource {
   /** @param quantity Subscription quantity */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /** The ramp intervals representing the pricing schedule for the subscription. */
+  public List<SubscriptionRampIntervalResponse> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /**
+   * @param rampIntervals The ramp intervals representing the pricing schedule for the subscription.
+   */
+  public void setRampIntervals(final List<SubscriptionRampIntervalResponse> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionChangePreview.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionChangePreview.java
@@ -77,6 +77,11 @@ public class SubscriptionChangePreview extends Resource {
   @Expose
   private Integer quantity;
 
+  /** The ramp intervals representing the pricing schedule for the subscription. */
+  @SerializedName("ramp_intervals")
+  @Expose
+  private List<SubscriptionRampIntervalResponse> rampIntervals;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -238,6 +243,18 @@ public class SubscriptionChangePreview extends Resource {
   /** @param quantity Subscription quantity */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /** The ramp intervals representing the pricing schedule for the subscription. */
+  public List<SubscriptionRampIntervalResponse> getRampIntervals() {
+    return this.rampIntervals;
+  }
+
+  /**
+   * @param rampIntervals The ramp intervals representing the pricing schedule for the subscription.
+   */
+  public void setRampIntervals(final List<SubscriptionRampIntervalResponse> rampIntervals) {
+    this.rampIntervals = rampIntervals;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
@@ -1,0 +1,62 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+
+public class SubscriptionRampIntervalResponse extends Resource {
+
+  /** Represents how many billing cycles are left in a ramp interval. */
+  @SerializedName("remaining_billing_cycles")
+  @Expose
+  private Integer remainingBillingCycles;
+
+  /** Represents how many billing cycles are included in a ramp interval. */
+  @SerializedName("starting_billing_cycle")
+  @Expose
+  private Integer startingBillingCycle;
+
+  /** Represents the price for the ramp interval. */
+  @SerializedName("unit_amount")
+  @Expose
+  private Integer unitAmount;
+
+  /** Represents how many billing cycles are left in a ramp interval. */
+  public Integer getRemainingBillingCycles() {
+    return this.remainingBillingCycles;
+  }
+
+  /**
+   * @param remainingBillingCycles Represents how many billing cycles are left in a ramp interval.
+   */
+  public void setRemainingBillingCycles(final Integer remainingBillingCycles) {
+    this.remainingBillingCycles = remainingBillingCycles;
+  }
+
+  /** Represents how many billing cycles are included in a ramp interval. */
+  public Integer getStartingBillingCycle() {
+    return this.startingBillingCycle;
+  }
+
+  /**
+   * @param startingBillingCycle Represents how many billing cycles are included in a ramp interval.
+   */
+  public void setStartingBillingCycle(final Integer startingBillingCycle) {
+    this.startingBillingCycle = startingBillingCycle;
+  }
+
+  /** Represents the price for the ramp interval. */
+  public Integer getUnitAmount() {
+    return this.unitAmount;
+  }
+
+  /** @param unitAmount Represents the price for the ramp interval. */
+  public void setUnitAmount(final Integer unitAmount) {
+    this.unitAmount = unitAmount;
+  }
+}


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription
