### PR TITLE
Fixes bug with putDunningCampaignBulkUpdate

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14922,6 +14922,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -20774,7 +20776,7 @@ components:
             zero then a `method_id` or `method_code` is required.
         address_id:
           type: string
-          titpe: Shipping address ID
+          title: Shipping address ID
           description: Assign a shipping address from the account's existing shipping
             addresses. If this and address are both present, address will take precedence.
         address:

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -2347,12 +2347,14 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * Assign a dunning campaign to multiple plans
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/put_dunning_campaign_bulk_update">put_dunning_campaign_bulk_update api documentation</a>
+   * @param dunningCampaignId Dunning Campaign ID, e.g. `e28zov4fw0v2`.
    * @param body The body of the request.
      * @return A list of updated plans.
    */
-  public DunningCampaignsBulkUpdateResponse putDunningCampaignBulkUpdate(DunningCampaignsBulkUpdate body) {
+  public DunningCampaignsBulkUpdateResponse putDunningCampaignBulkUpdate(String dunningCampaignId, DunningCampaignsBulkUpdate body) {
     final String url = "/dunning_campaigns/{dunning_campaign_id}/bulk_update";
     final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("dunning_campaign_id", dunningCampaignId);
     final String path = this.interpolatePath(url, urlParams);
     Type returnType = DunningCampaignsBulkUpdateResponse.class;
     return this.makeRequest("PUT", path, body, returnType);


### PR DESCRIPTION
The `putDunningCampaignBulkUpdate` method was missing the `dunningCampaignId` parameter, which is used to construct the request URL.