### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2441,6 +2441,47 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction)"
+  "/accounts/{account_id}/billing_info/verify_cvv":
+    post:
+      tags:
+      - billing_info
+      operationId: verify_billing_info_cvv
+      summary: Verify an account's credit card billing cvv
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BillingInfoVerifyCVV"
+      responses:
+        '200':
+          description: Transaction information from verify.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Transaction"
+        '429':
+          description: Over limit error. A credit card can only be checked 3 times
+            in 24 hours.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Invalid billing information, or error running the verification
+            transaction.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorMayHaveTransaction"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/billing_infos":
     get:
       tags:
@@ -16942,6 +16983,12 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+    BillingInfoVerifyCVV:
+      type: object
+      properties:
+        verification_value:
+          type: string
+          description: Unique security code for a credit card.
     Coupon:
       type: object
       properties:
@@ -19275,7 +19322,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21239,7 +21286,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21250,7 +21297,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -301,6 +301,23 @@ public class Client extends BaseClient {
   }
 
   /**
+   * Verify an account's credit card billing cvv
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/verify_billing_info_cvv">verify_billing_info_cvv api documentation</a>
+   * @param accountId Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+   * @param body The body of the request.
+     * @return Transaction information from verify.
+   */
+  public Transaction verifyBillingInfoCvv(String accountId, BillingInfoVerifyCVV body) {
+    final String url = "/accounts/{account_id}/billing_info/verify_cvv";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("account_id", accountId);
+    final String path = this.interpolatePath(url, urlParams);
+    Type returnType = Transaction.class;
+    return this.makeRequest("POST", path, body, returnType);
+  }
+
+  /**
    * Get the list of billing information associated with an account
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/list_billing_infos">list_billing_infos api documentation</a>

--- a/src/main/java/com/recurly/v3/requests/BillingInfoVerifyCVV.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoVerifyCVV.java
@@ -1,0 +1,29 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class BillingInfoVerifyCVV extends Request {
+
+  /** Unique security code for a credit card. */
+  @SerializedName("verification_value")
+  @Expose
+  private String verificationValue;
+
+  /** Unique security code for a credit card. */
+  public String getVerificationValue() {
+    return this.verificationValue;
+  }
+
+  /** @param verificationValue Unique security code for a credit card. */
+  public void setVerificationValue(final String verificationValue) {
+    this.verificationValue = verificationValue;
+  }
+}

--- a/src/main/java/com/recurly/v3/requests/PlanRampInterval.java
+++ b/src/main/java/com/recurly/v3/requests/PlanRampInterval.java
@@ -18,7 +18,7 @@ public class PlanRampInterval extends Request {
   @Expose
   private List<PlanRampPricing> currencies;
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -33,12 +33,12 @@ public class PlanRampInterval extends Request {
     this.currencies = currencies;
   }
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /** @param startingBillingCycle Represents the first billing cycle of a ramp. */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionRampInterval.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionRampInterval.java
@@ -12,7 +12,7 @@ import com.recurly.v3.resources.*;
 
 public class SubscriptionRampInterval extends Request {
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -22,14 +22,12 @@ public class SubscriptionRampInterval extends Request {
   @Expose
   private Integer unitAmount;
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /**
-   * @param startingBillingCycle Represents how many billing cycles are included in a ramp interval.
-   */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/resources/PlanRampInterval.java
+++ b/src/main/java/com/recurly/v3/resources/PlanRampInterval.java
@@ -17,7 +17,7 @@ public class PlanRampInterval extends Resource {
   @Expose
   private List<PlanRampPricing> currencies;
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -32,12 +32,12 @@ public class PlanRampInterval extends Resource {
     this.currencies = currencies;
   }
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /** @param startingBillingCycle Represents the first billing cycle of a ramp. */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
@@ -16,7 +16,7 @@ public class SubscriptionRampIntervalResponse extends Resource {
   @Expose
   private Integer remainingBillingCycles;
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -38,14 +38,12 @@ public class SubscriptionRampIntervalResponse extends Resource {
     this.remainingBillingCycles = remainingBillingCycles;
   }
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /**
-   * @param startingBillingCycle Represents how many billing cycles are included in a ramp interval.
-   */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }


### PR DESCRIPTION
- Added `/accounts/{account_id}/billing_info/verify_cvv` route which takes a `verification_value` and returns a transaction if the `verification_value` matches the cvv of the credit card on file. A `422` is returned if the `verification_value` does not match the credit card on file and the a `429` is returned if the same credit card is checked more than 3 times in 24 hours.