### PR TITLE
Generated Latest Changes for v2019-10-10(Decimal Usage and Quantities)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14463,6 +14463,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -18423,6 +18425,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18503,6 +18513,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18544,6 +18561,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -19335,7 +19360,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21093,7 +21118,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21104,7 +21129,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
@@ -21533,10 +21558,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           type: string
           enum:
@@ -21609,10 +21635,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -2290,12 +2290,14 @@ public class Client extends BaseClient {
    * Assign a dunning campaign to multiple plans
    *
    * @see <a href="https://developers.recurly.com/api/v2019-10-10#operation/put_dunning_campaign_bulk_update">put_dunning_campaign_bulk_update api documentation</a>
+   * @param dunningCampaignId Dunning Campaign ID, e.g. `e28zov4fw0v2`.
    * @param body The body of the request.
      * @return A list of updated plans.
    */
-  public DunningCampaignsBulkUpdateResponse putDunningCampaignBulkUpdate(DunningCampaignsBulkUpdate body) {
+  public DunningCampaignsBulkUpdateResponse putDunningCampaignBulkUpdate(String dunningCampaignId, DunningCampaignsBulkUpdate body) {
     final String url = "/dunning_campaigns/{dunning_campaign_id}/bulk_update";
     final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("dunning_campaign_id", dunningCampaignId);
     final String path = this.interpolatePath(url, urlParams);
     Type returnType = DunningCampaignsBulkUpdateResponse.class;
     return this.makeRequest("PUT", path, body, returnType);

--- a/src/main/java/com/recurly/v3/requests/LineItemRefund.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemRefund.java
@@ -30,6 +30,16 @@ public class LineItemRefund extends Request {
   @Expose
   private Integer quantity;
 
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  @SerializedName("quantity_decimal")
+  @Expose
+  private String quantityDecimal;
+
   /** Line item ID */
   public String getId() {
     return this.id;
@@ -64,5 +74,25 @@ public class LineItemRefund extends Request {
   /** @param quantity Line item quantity to be refunded. */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  public String getQuantityDecimal() {
+    return this.quantityDecimal;
+  }
+
+  /**
+   * @param quantityDecimal A floating-point alternative to Quantity. If this value is present, it
+   *     will be used in place of Quantity for calculations, and Quantity will be the rounded
+   *     integer value of this number. This field supports up to 9 decimal places. The Decimal
+   *     Quantity feature must be enabled to utilize this field.
+   */
+  public void setQuantityDecimal(final String quantityDecimal) {
+    this.quantityDecimal = quantityDecimal;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/PlanRampInterval.java
+++ b/src/main/java/com/recurly/v3/requests/PlanRampInterval.java
@@ -18,7 +18,7 @@ public class PlanRampInterval extends Request {
   @Expose
   private List<PlanRampPricing> currencies;
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -33,12 +33,12 @@ public class PlanRampInterval extends Request {
     this.currencies = currencies;
   }
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /** @param startingBillingCycle Represents the first billing cycle of a ramp. */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/requests/SubscriptionRampInterval.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionRampInterval.java
@@ -12,7 +12,7 @@ import com.recurly.v3.resources.*;
 
 public class SubscriptionRampInterval extends Request {
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -22,14 +22,12 @@ public class SubscriptionRampInterval extends Request {
   @Expose
   private Integer unitAmount;
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /**
-   * @param startingBillingCycle Represents how many billing cycles are included in a ramp interval.
-   */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/requests/UsageCreate.java
+++ b/src/main/java/com/recurly/v3/requests/UsageCreate.java
@@ -14,9 +14,10 @@ import org.joda.time.DateTime;
 public class UsageCreate extends Request {
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   @SerializedName("amount")
   @Expose
@@ -44,18 +45,21 @@ public class UsageCreate extends Request {
   private DateTime usageTimestamp;
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   public Float getAmount() {
     return this.amount;
   }
 
   /**
-   * @param amount The amount of usage. Can be positive, negative, or 0. No decimals allowed, we
-   *     will strip them. If the usage-based add-on is billed with a percentage, your usage will be
-   *     a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+   * @param amount The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity
+   *     feature is enabled, this value will be rounded to nine decimal places. Otherwise, all
+   *     digits after the decimal will be stripped. If the usage-based add-on is billed with a
+   *     percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is
+   *     "500").
    */
   public void setAmount(final Float amount) {
     this.amount = amount;

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -219,6 +219,16 @@ public class LineItem extends Resource {
   @Expose
   private Integer quantity;
 
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  @SerializedName("quantity_decimal")
+  @Expose
+  private String quantityDecimal;
+
   /** Refund? */
   @SerializedName("refund")
   @Expose
@@ -231,6 +241,15 @@ public class LineItem extends Resource {
   @SerializedName("refunded_quantity")
   @Expose
   private Integer refundedQuantity;
+
+  /**
+   * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being
+   * refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+   * The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  @SerializedName("refunded_quantity_decimal")
+  @Expose
+  private String refundedQuantityDecimal;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -765,6 +784,26 @@ public class LineItem extends Resource {
     this.quantity = quantity;
   }
 
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  public String getQuantityDecimal() {
+    return this.quantityDecimal;
+  }
+
+  /**
+   * @param quantityDecimal A floating-point alternative to Quantity. If this value is present, it
+   *     will be used in place of Quantity for calculations, and Quantity will be the rounded
+   *     integer value of this number. This field supports up to 9 decimal places. The Decimal
+   *     Quantity feature must be enabled to utilize this field.
+   */
+  public void setQuantityDecimal(final String quantityDecimal) {
+    this.quantityDecimal = quantityDecimal;
+  }
+
   /** Refund? */
   public Boolean getRefund() {
     return this.refund;
@@ -789,6 +828,25 @@ public class LineItem extends Resource {
    */
   public void setRefundedQuantity(final Integer refundedQuantity) {
     this.refundedQuantity = refundedQuantity;
+  }
+
+  /**
+   * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being
+   * refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+   * The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  public String getRefundedQuantityDecimal() {
+    return this.refundedQuantityDecimal;
+  }
+
+  /**
+   * @param refundedQuantityDecimal A floating-point alternative to Refunded Quantity. For refund
+   *     charges, the quantity being refunded. For non-refund charges, the total quantity refunded
+   *     (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize
+   *     this field.
+   */
+  public void setRefundedQuantityDecimal(final String refundedQuantityDecimal) {
+    this.refundedQuantityDecimal = refundedQuantityDecimal;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/PlanRampInterval.java
+++ b/src/main/java/com/recurly/v3/resources/PlanRampInterval.java
@@ -17,7 +17,7 @@ public class PlanRampInterval extends Resource {
   @Expose
   private List<PlanRampPricing> currencies;
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -32,12 +32,12 @@ public class PlanRampInterval extends Resource {
     this.currencies = currencies;
   }
 
-  /** Represents the first billing cycle of a ramp. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /** @param startingBillingCycle Represents the first billing cycle of a ramp. */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
@@ -16,7 +16,7 @@ public class SubscriptionRampIntervalResponse extends Resource {
   @Expose
   private Integer remainingBillingCycles;
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   @SerializedName("starting_billing_cycle")
   @Expose
   private Integer startingBillingCycle;
@@ -38,14 +38,12 @@ public class SubscriptionRampIntervalResponse extends Resource {
     this.remainingBillingCycles = remainingBillingCycles;
   }
 
-  /** Represents how many billing cycles are included in a ramp interval. */
+  /** Represents the billing cycle where a ramp interval starts. */
   public Integer getStartingBillingCycle() {
     return this.startingBillingCycle;
   }
 
-  /**
-   * @param startingBillingCycle Represents how many billing cycles are included in a ramp interval.
-   */
+  /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
   }

--- a/src/main/java/com/recurly/v3/resources/Usage.java
+++ b/src/main/java/com/recurly/v3/resources/Usage.java
@@ -14,9 +14,10 @@ import org.joda.time.DateTime;
 public class Usage extends Resource {
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   @SerializedName("amount")
   @Expose
@@ -107,18 +108,21 @@ public class Usage extends Resource {
   private String usageType;
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   public Float getAmount() {
     return this.amount;
   }
 
   /**
-   * @param amount The amount of usage. Can be positive, negative, or 0. No decimals allowed, we
-   *     will strip them. If the usage-based add-on is billed with a percentage, your usage will be
-   *     a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+   * @param amount The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity
+   *     feature is enabled, this value will be rounded to nine decimal places. Otherwise, all
+   *     digits after the decimal will be stripped. If the usage-based add-on is billed with a
+   *     percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is
+   *     "500").
    */
   public void setAmount(final Float amount) {
     this.amount = amount;


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantityDecimal`, `getRefundedQuantityDecimal `,  `refundedQuantityDecimal` and `getRefundedQuantityDecimal` to `LineItem` class
- Add `quantityDecimal ` property and `getQuantityDecimal ` method to `LineItemRefund` class.
- Update `Usage` `amount` property description

Fix Bulk Dunning Campaign update
- Update `putDunningCampaignBulkUpdate` method to receive the `dunningCampaignId`