### PR TITLE
Generated Latest Changes for v2021-02-25(Decimal Usage and Quantities and DunningEvent new fields)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort

--- a/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
@@ -57,7 +57,10 @@ public class BillingInfoCreate extends Request {
   @Expose
   private String cvv;
 
-  /** Use for Adyen HPP billing info. */
+  /**
+   * Use for Adyen HPP billing info. This should only be used as part of a pending purchase request,
+   * when the billing info is nested inside an account object.
+   */
   @SerializedName("external_hpp_type")
   @Expose
   private Constants.ExternalHppType externalHppType;
@@ -121,7 +124,10 @@ public class BillingInfoCreate extends Request {
   @Expose
   private String number;
 
-  /** Use for Online Banking billing info. */
+  /**
+   * Use for Online Banking billing info. This should only be used as part of a pending purchase
+   * request, when the billing info is nested inside an account object.
+   */
   @SerializedName("online_banking_payment_type")
   @Expose
   private Constants.OnlineBankingPaymentType onlineBankingPaymentType;
@@ -303,12 +309,18 @@ public class BillingInfoCreate extends Request {
     this.cvv = cvv;
   }
 
-  /** Use for Adyen HPP billing info. */
+  /**
+   * Use for Adyen HPP billing info. This should only be used as part of a pending purchase request,
+   * when the billing info is nested inside an account object.
+   */
   public Constants.ExternalHppType getExternalHppType() {
     return this.externalHppType;
   }
 
-  /** @param externalHppType Use for Adyen HPP billing info. */
+  /**
+   * @param externalHppType Use for Adyen HPP billing info. This should only be used as part of a
+   *     pending purchase request, when the billing info is nested inside an account object.
+   */
   public void setExternalHppType(final Constants.ExternalHppType externalHppType) {
     this.externalHppType = externalHppType;
   }
@@ -435,12 +447,19 @@ public class BillingInfoCreate extends Request {
     this.number = number;
   }
 
-  /** Use for Online Banking billing info. */
+  /**
+   * Use for Online Banking billing info. This should only be used as part of a pending purchase
+   * request, when the billing info is nested inside an account object.
+   */
   public Constants.OnlineBankingPaymentType getOnlineBankingPaymentType() {
     return this.onlineBankingPaymentType;
   }
 
-  /** @param onlineBankingPaymentType Use for Online Banking billing info. */
+  /**
+   * @param onlineBankingPaymentType Use for Online Banking billing info. This should only be used
+   *     as part of a pending purchase request, when the billing info is nested inside an account
+   *     object.
+   */
   public void setOnlineBankingPaymentType(
       final Constants.OnlineBankingPaymentType onlineBankingPaymentType) {
     this.onlineBankingPaymentType = onlineBankingPaymentType;

--- a/src/main/java/com/recurly/v3/requests/LineItemRefund.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemRefund.java
@@ -30,6 +30,16 @@ public class LineItemRefund extends Request {
   @Expose
   private Integer quantity;
 
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  @SerializedName("quantity_decimal")
+  @Expose
+  private String quantityDecimal;
+
   /** Line item ID */
   public String getId() {
     return this.id;
@@ -64,5 +74,25 @@ public class LineItemRefund extends Request {
   /** @param quantity Line item quantity to be refunded. */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  public String getQuantityDecimal() {
+    return this.quantityDecimal;
+  }
+
+  /**
+   * @param quantityDecimal A floating-point alternative to Quantity. If this value is present, it
+   *     will be used in place of Quantity for calculations, and Quantity will be the rounded
+   *     integer value of this number. This field supports up to 9 decimal places. The Decimal
+   *     Quantity feature must be enabled to utilize this field.
+   */
+  public void setQuantityDecimal(final String quantityDecimal) {
+    this.quantityDecimal = quantityDecimal;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/UsageCreate.java
+++ b/src/main/java/com/recurly/v3/requests/UsageCreate.java
@@ -15,9 +15,10 @@ import org.joda.time.DateTime;
 public class UsageCreate extends Request {
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   @SerializedName("amount")
   @Expose
@@ -45,18 +46,21 @@ public class UsageCreate extends Request {
   private DateTime usageTimestamp;
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   public BigDecimal getAmount() {
     return this.amount;
   }
 
   /**
-   * @param amount The amount of usage. Can be positive, negative, or 0. No decimals allowed, we
-   *     will strip them. If the usage-based add-on is billed with a percentage, your usage will be
-   *     a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+   * @param amount The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity
+   *     feature is enabled, this value will be rounded to nine decimal places. Otherwise, all
+   *     digits after the decimal will be stripped. If the usage-based add-on is billed with a
+   *     percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is
+   *     "500").
    */
   public void setAmount(final BigDecimal amount) {
     this.amount = amount;

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -96,6 +96,16 @@ public class Invoice extends Resource {
   @Expose
   private String dunningCampaignId;
 
+  /** Number of times the event was sent. */
+  @SerializedName("dunning_events_sent")
+  @Expose
+  private Integer dunningEventsSent;
+
+  /** Last communication attempt. */
+  @SerializedName("final_dunning_event")
+  @Expose
+  private Boolean finalDunningEvent;
+
   /**
    * Identifies if the invoice has more line items than are returned in `line_items`. If
    * `has_more_line_items` is `true`, then a request needs to be made to the
@@ -413,6 +423,26 @@ public class Invoice extends Resource {
    */
   public void setDunningCampaignId(final String dunningCampaignId) {
     this.dunningCampaignId = dunningCampaignId;
+  }
+
+  /** Number of times the event was sent. */
+  public Integer getDunningEventsSent() {
+    return this.dunningEventsSent;
+  }
+
+  /** @param dunningEventsSent Number of times the event was sent. */
+  public void setDunningEventsSent(final Integer dunningEventsSent) {
+    this.dunningEventsSent = dunningEventsSent;
+  }
+
+  /** Last communication attempt. */
+  public Boolean getFinalDunningEvent() {
+    return this.finalDunningEvent;
+  }
+
+  /** @param finalDunningEvent Last communication attempt. */
+  public void setFinalDunningEvent(final Boolean finalDunningEvent) {
+    this.finalDunningEvent = finalDunningEvent;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -221,6 +221,16 @@ public class LineItem extends Resource {
   @Expose
   private Integer quantity;
 
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  @SerializedName("quantity_decimal")
+  @Expose
+  private String quantityDecimal;
+
   /** Refund? */
   @SerializedName("refund")
   @Expose
@@ -233,6 +243,15 @@ public class LineItem extends Resource {
   @SerializedName("refunded_quantity")
   @Expose
   private Integer refundedQuantity;
+
+  /**
+   * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being
+   * refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+   * The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  @SerializedName("refunded_quantity_decimal")
+  @Expose
+  private String refundedQuantityDecimal;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -772,6 +791,26 @@ public class LineItem extends Resource {
     this.quantity = quantity;
   }
 
+  /**
+   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
+   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
+   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
+   * this field.
+   */
+  public String getQuantityDecimal() {
+    return this.quantityDecimal;
+  }
+
+  /**
+   * @param quantityDecimal A floating-point alternative to Quantity. If this value is present, it
+   *     will be used in place of Quantity for calculations, and Quantity will be the rounded
+   *     integer value of this number. This field supports up to 9 decimal places. The Decimal
+   *     Quantity feature must be enabled to utilize this field.
+   */
+  public void setQuantityDecimal(final String quantityDecimal) {
+    this.quantityDecimal = quantityDecimal;
+  }
+
   /** Refund? */
   public Boolean getRefund() {
     return this.refund;
@@ -796,6 +835,25 @@ public class LineItem extends Resource {
    */
   public void setRefundedQuantity(final Integer refundedQuantity) {
     this.refundedQuantity = refundedQuantity;
+  }
+
+  /**
+   * A floating-point alternative to Refunded Quantity. For refund charges, the quantity being
+   * refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+   * The Decimal Quantity feature must be enabled to utilize this field.
+   */
+  public String getRefundedQuantityDecimal() {
+    return this.refundedQuantityDecimal;
+  }
+
+  /**
+   * @param refundedQuantityDecimal A floating-point alternative to Refunded Quantity. For refund
+   *     charges, the quantity being refunded. For non-refund charges, the total quantity refunded
+   *     (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize
+   *     this field.
+   */
+  public void setRefundedQuantityDecimal(final String refundedQuantityDecimal) {
+    this.refundedQuantityDecimal = refundedQuantityDecimal;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/Usage.java
+++ b/src/main/java/com/recurly/v3/resources/Usage.java
@@ -16,9 +16,10 @@ import org.joda.time.DateTime;
 public class Usage extends Resource {
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   @SerializedName("amount")
   @Expose
@@ -124,18 +125,21 @@ public class Usage extends Resource {
   private Constants.UsageType usageType;
 
   /**
-   * The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them.
-   * If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you
-   * will want to format in cents. (e.g., $5.00 is "500").
+   * The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is
+   * enabled, this value will be rounded to nine decimal places. Otherwise, all digits after the
+   * decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage
+   * should be a monetary amount formatted in cents (e.g., $5.00 is "500").
    */
   public BigDecimal getAmount() {
     return this.amount;
   }
 
   /**
-   * @param amount The amount of usage. Can be positive, negative, or 0. No decimals allowed, we
-   *     will strip them. If the usage-based add-on is billed with a percentage, your usage will be
-   *     a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+   * @param amount The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity
+   *     feature is enabled, this value will be rounded to nine decimal places. Otherwise, all
+   *     digits after the decimal will be stripped. If the usage-based add-on is billed with a
+   *     percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is
+   *     "500").
    */
   public void setAmount(final BigDecimal amount) {
     this.amount = amount;


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantityDecimal`, `getRefundedQuantityDecimal `,  `refundedQuantityDecimal` and `getRefundedQuantityDecimal` to `LineItem` class
- Add `quantityDecimal ` property and `getQuantityDecimal ` method to `LineItemRefund` class.
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`