### PR TITLE
Generated Latest Changes for v2021-02-25 (usedTaxService on Invoice)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19032,6 +19032,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number
@@ -24043,7 +24050,9 @@ components:
       - es-MX
       - es-US
       - fi-FI
+      - fr-BE
       - fr-CA
+      - fr-CH
       - fr-FR
       - hi-IN
       - it-IT

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -320,8 +320,14 @@ public class Constants {
       @SerializedName("fi-FI")
       FI_FI,
     
+      @SerializedName("fr-BE")
+      FR_BE,
+    
       @SerializedName("fr-CA")
       FR_CA,
+    
+      @SerializedName("fr-CH")
+      FR_CH,
     
       @SerializedName("fr-FR")
       FR_FR,

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -240,6 +240,15 @@ public class Invoice extends Resource {
   @Expose
   private DateTime updatedAt;
 
+  /**
+   * Will be `true` when the invoice had a successful response from the tax service and `false` when
+   * the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was
+   * processed without tax due to a non-blocking error returned from the tax service.
+   */
+  @SerializedName("used_tax_service")
+  @Expose
+  private Boolean usedTaxService;
+
   /** Invoice UUID */
   @SerializedName("uuid")
   @Expose
@@ -727,6 +736,25 @@ public class Invoice extends Resource {
   /** @param updatedAt Last updated at */
   public void setUpdatedAt(final DateTime updatedAt) {
     this.updatedAt = updatedAt;
+  }
+
+  /**
+   * Will be `true` when the invoice had a successful response from the tax service and `false` when
+   * the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was
+   * processed without tax due to a non-blocking error returned from the tax service.
+   */
+  public Boolean getUsedTaxService() {
+    return this.usedTaxService;
+  }
+
+  /**
+   * @param usedTaxService Will be `true` when the invoice had a successful response from the tax
+   *     service and `false` when the invoice was not sent to tax service due to a lack of address
+   *     or enabled jurisdiction or was processed without tax due to a non-blocking error returned
+   *     from the tax service.
+   */
+  public void setUsedTaxService(final Boolean usedTaxService) {
+    this.usedTaxService = usedTaxService;
   }
 
   /** Invoice UUID */


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `usedTaxService`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.