### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21336,23 +21336,29 @@ components:
           description: Provides the tax type as "vat" for EU VAT, "usst" for U.S.
             Sales Tax, or the 2 letter country code for country level tax types like
             Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+            Not present when Avalara for Communications is enabled.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For U.S. Sales
             Tax, this will be the 2 letter state code. For EU VAT this will be the
             2 letter country code. For all country level tax types, this will display
-            the regional tax, like VAT, GST, or PST.
+            the regional tax, like VAT, GST, or PST. Not present when Avalara for
+            Communications is enabled.
         rate:
           type: number
           format: float
           title: Rate
+          description: The combined tax rate. Not present when Avalara for Communications
+            is enabled.
         tax_details:
           type: array
-          description: Provides additional tax details for Canadian Sales Tax when
-            there is tax applied at both the country and province levels. This will
-            only be populated for the Invoice response when fetching a single invoice
-            and not for the InvoiceList or LineItem.
+          description: Provides additional tax details for Communications taxes when
+            Avalara for Communications is enabled or Canadian Sales Tax when there
+            is tax applied at both the country and province levels. This will only
+            be populated for the Invoice response when fetching a single invoice and
+            not for the InvoiceList or LineItemList. Only populated for a single LineItem
+            fetch when Avalara for Communications is enabled.
           items:
             "$ref": "#/components/schemas/TaxDetail"
     TaxDetail:
@@ -21362,13 +21368,15 @@ components:
         type:
           type: string
           title: Type
-          description: Provides the tax type for the region. For Canadian Sales Tax,
+          description: Provides the tax type for the region or type of Comminications
+            tax when Avalara for Communications is enabled. For Canadian Sales Tax,
             this will be GST, HST, QST or PST.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For Canadian
             Sales Tax, this will be either the 2 letter province code or country code.
+            Not present when Avalara for Communications is enabled.
         rate:
           type: number
           format: float
@@ -21379,6 +21387,22 @@ components:
           format: float
           title: Tax
           description: The total tax applied for this tax type.
+        name:
+          type: string
+          title: Name
+          description: Provides the name of the Communications tax applied. Present
+            only when Avalara for Communications is enabled.
+        level:
+          type: string
+          title: Level
+          description: Provides the jurisdiction level for the Communications tax
+            applied. Example values include city, state and federal. Present only
+            when Avalara for Communications is enabled.
+        billable:
+          type: boolean
+          title: Billable
+          description: Whether or not the line item is taxable. Only populated for
+            a single LineItem fetch when Avalara for Communications is enabled.
     Transaction:
       type: object
       properties:

--- a/src/main/java/com/recurly/v3/resources/TaxDetail.java
+++ b/src/main/java/com/recurly/v3/resources/TaxDetail.java
@@ -11,6 +11,30 @@ import com.recurly.v3.Resource;
 
 public class TaxDetail extends Resource {
 
+  /**
+   * Whether or not the line item is taxable. Only populated for a single LineItem fetch when
+   * Avalara for Communications is enabled.
+   */
+  @SerializedName("billable")
+  @Expose
+  private Boolean billable;
+
+  /**
+   * Provides the jurisdiction level for the Communications tax applied. Example values include
+   * city, state and federal. Present only when Avalara for Communications is enabled.
+   */
+  @SerializedName("level")
+  @Expose
+  private String level;
+
+  /**
+   * Provides the name of the Communications tax applied. Present only when Avalara for
+   * Communications is enabled.
+   */
+  @SerializedName("name")
+  @Expose
+  private String name;
+
   /** Provides the tax rate for the region. */
   @SerializedName("rate")
   @Expose
@@ -18,7 +42,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the
-   * 2 letter province code or country code.
+   * 2 letter province code or country code. Not present when Avalara for Communications is enabled.
    */
   @SerializedName("region")
   @Expose
@@ -30,12 +54,60 @@ public class TaxDetail extends Resource {
   private Float tax;
 
   /**
-   * Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or
-   * PST.
+   * Provides the tax type for the region or type of Comminications tax when Avalara for
+   * Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
    */
   @SerializedName("type")
   @Expose
   private String type;
+
+  /**
+   * Whether or not the line item is taxable. Only populated for a single LineItem fetch when
+   * Avalara for Communications is enabled.
+   */
+  public Boolean getBillable() {
+    return this.billable;
+  }
+
+  /**
+   * @param billable Whether or not the line item is taxable. Only populated for a single LineItem
+   *     fetch when Avalara for Communications is enabled.
+   */
+  public void setBillable(final Boolean billable) {
+    this.billable = billable;
+  }
+
+  /**
+   * Provides the jurisdiction level for the Communications tax applied. Example values include
+   * city, state and federal. Present only when Avalara for Communications is enabled.
+   */
+  public String getLevel() {
+    return this.level;
+  }
+
+  /**
+   * @param level Provides the jurisdiction level for the Communications tax applied. Example values
+   *     include city, state and federal. Present only when Avalara for Communications is enabled.
+   */
+  public void setLevel(final String level) {
+    this.level = level;
+  }
+
+  /**
+   * Provides the name of the Communications tax applied. Present only when Avalara for
+   * Communications is enabled.
+   */
+  public String getName() {
+    return this.name;
+  }
+
+  /**
+   * @param name Provides the name of the Communications tax applied. Present only when Avalara for
+   *     Communications is enabled.
+   */
+  public void setName(final String name) {
+    this.name = name;
+  }
 
   /** Provides the tax rate for the region. */
   public Float getRate() {
@@ -49,7 +121,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the
-   * 2 letter province code or country code.
+   * 2 letter province code or country code. Not present when Avalara for Communications is enabled.
    */
   public String getRegion() {
     return this.region;
@@ -57,7 +129,8 @@ public class TaxDetail extends Resource {
 
   /**
    * @param region Provides the tax region applied on an invoice. For Canadian Sales Tax, this will
-   *     be either the 2 letter province code or country code.
+   *     be either the 2 letter province code or country code. Not present when Avalara for
+   *     Communications is enabled.
    */
   public void setRegion(final String region) {
     this.region = region;
@@ -74,16 +147,16 @@ public class TaxDetail extends Resource {
   }
 
   /**
-   * Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or
-   * PST.
+   * Provides the tax type for the region or type of Comminications tax when Avalara for
+   * Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
    */
   public String getType() {
     return this.type;
   }
 
   /**
-   * @param type Provides the tax type for the region. For Canadian Sales Tax, this will be GST,
-   *     HST, QST or PST.
+   * @param type Provides the tax type for the region or type of Comminications tax when Avalara for
+   *     Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
    */
   public void setType(final String type) {
     this.type = type;

--- a/src/main/java/com/recurly/v3/resources/TaxInfo.java
+++ b/src/main/java/com/recurly/v3/resources/TaxInfo.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class TaxInfo extends Resource {
 
-  /** Rate */
+  /** The combined tax rate. Not present when Avalara for Communications is enabled. */
   @SerializedName("rate")
   @Expose
   private Float rate;
@@ -20,16 +20,19 @@ public class TaxInfo extends Resource {
   /**
    * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter
    * state code. For EU VAT this will be the 2 letter country code. For all country level tax types,
-   * this will display the regional tax, like VAT, GST, or PST.
+   * this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for
+   * Communications is enabled.
    */
   @SerializedName("region")
   @Expose
   private String region;
 
   /**
-   * Provides additional tax details for Canadian Sales Tax when there is tax applied at both the
-   * country and province levels. This will only be populated for the Invoice response when fetching
-   * a single invoice and not for the InvoiceList or LineItem.
+   * Provides additional tax details for Communications taxes when Avalara for Communications is
+   * enabled or Canadian Sales Tax when there is tax applied at both the country and province
+   * levels. This will only be populated for the Invoice response when fetching a single invoice and
+   * not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when
+   * Avalara for Communications is enabled.
    */
   @SerializedName("tax_details")
   @Expose
@@ -38,18 +41,18 @@ public class TaxInfo extends Resource {
   /**
    * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country
    * code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU
-   * European countries.
+   * European countries. Not present when Avalara for Communications is enabled.
    */
   @SerializedName("type")
   @Expose
   private String type;
 
-  /** Rate */
+  /** The combined tax rate. Not present when Avalara for Communications is enabled. */
   public Float getRate() {
     return this.rate;
   }
 
-  /** @param rate Rate */
+  /** @param rate The combined tax rate. Not present when Avalara for Communications is enabled. */
   public void setRate(final Float rate) {
     this.rate = rate;
   }
@@ -57,7 +60,8 @@ public class TaxInfo extends Resource {
   /**
    * Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter
    * state code. For EU VAT this will be the 2 letter country code. For all country level tax types,
-   * this will display the regional tax, like VAT, GST, or PST.
+   * this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for
+   * Communications is enabled.
    */
   public String getRegion() {
     return this.region;
@@ -66,25 +70,30 @@ public class TaxInfo extends Resource {
   /**
    * @param region Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be
    *     the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country
-   *     level tax types, this will display the regional tax, like VAT, GST, or PST.
+   *     level tax types, this will display the regional tax, like VAT, GST, or PST. Not present
+   *     when Avalara for Communications is enabled.
    */
   public void setRegion(final String region) {
     this.region = region;
   }
 
   /**
-   * Provides additional tax details for Canadian Sales Tax when there is tax applied at both the
-   * country and province levels. This will only be populated for the Invoice response when fetching
-   * a single invoice and not for the InvoiceList or LineItem.
+   * Provides additional tax details for Communications taxes when Avalara for Communications is
+   * enabled or Canadian Sales Tax when there is tax applied at both the country and province
+   * levels. This will only be populated for the Invoice response when fetching a single invoice and
+   * not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when
+   * Avalara for Communications is enabled.
    */
   public List<TaxDetail> getTaxDetails() {
     return this.taxDetails;
   }
 
   /**
-   * @param taxDetails Provides additional tax details for Canadian Sales Tax when there is tax
-   *     applied at both the country and province levels. This will only be populated for the
-   *     Invoice response when fetching a single invoice and not for the InvoiceList or LineItem.
+   * @param taxDetails Provides additional tax details for Communications taxes when Avalara for
+   *     Communications is enabled or Canadian Sales Tax when there is tax applied at both the
+   *     country and province levels. This will only be populated for the Invoice response when
+   *     fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a
+   *     single LineItem fetch when Avalara for Communications is enabled.
    */
   public void setTaxDetails(final List<TaxDetail> taxDetails) {
     this.taxDetails = taxDetails;
@@ -93,7 +102,7 @@ public class TaxInfo extends Resource {
   /**
    * Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country
    * code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU
-   * European countries.
+   * European countries. Not present when Avalara for Communications is enabled.
    */
   public String getType() {
     return this.type;
@@ -102,7 +111,8 @@ public class TaxInfo extends Resource {
   /**
    * @param type Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2
    *     letter country code for country level tax types like Canada, Australia, New Zealand,
-   *     Israel, and all non-EU European countries.
+   *     Israel, and all non-EU European countries. Not present when Avalara for Communications is
+   *     enabled.
    */
   public void setType(final String type) {
     this.type = type;


### PR DESCRIPTION
LineItem response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`
  * `billable`

Invoice response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`