### PR TITLE
Generated Latest Changes for v2021-02-25 (gateway_attributes on PaymentMethod)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17853,6 +17853,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -23606,6 +23617,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal

--- a/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/BillingInfoCreate.java
@@ -80,6 +80,11 @@ public class BillingInfoCreate extends Request {
   @Expose
   private String fraudSessionId;
 
+  /** Additional attributes to send to the gateway. */
+  @SerializedName("gateway_attributes")
+  @Expose
+  private GatewayAttributes gatewayAttributes;
+
   /**
    * An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.
    */
@@ -358,6 +363,16 @@ public class BillingInfoCreate extends Request {
   /** @param fraudSessionId Fraud Session ID */
   public void setFraudSessionId(final String fraudSessionId) {
     this.fraudSessionId = fraudSessionId;
+  }
+
+  /** Additional attributes to send to the gateway. */
+  public GatewayAttributes getGatewayAttributes() {
+    return this.gatewayAttributes;
+  }
+
+  /** @param gatewayAttributes Additional attributes to send to the gateway. */
+  public void setGatewayAttributes(final GatewayAttributes gatewayAttributes) {
+    this.gatewayAttributes = gatewayAttributes;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/GatewayAttributes.java
+++ b/src/main/java/com/recurly/v3/requests/GatewayAttributes.java
@@ -1,0 +1,39 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class GatewayAttributes extends Request {
+
+  /**
+   * Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+   * Must be used in conjunction with gateway_token and gateway_code.
+   */
+  @SerializedName("account_reference")
+  @Expose
+  private String accountReference;
+
+  /**
+   * Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+   * Must be used in conjunction with gateway_token and gateway_code.
+   */
+  public String getAccountReference() {
+    return this.accountReference;
+  }
+
+  /**
+   * @param accountReference Used by Adyen gateways. The Shopper Reference value used when the
+   *     external token was created. Must be used in conjunction with gateway_token and
+   *     gateway_code.
+   */
+  public void setAccountReference(final String accountReference) {
+    this.accountReference = accountReference;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/GatewayAttributes.java
+++ b/src/main/java/com/recurly/v3/resources/GatewayAttributes.java
@@ -1,0 +1,35 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+
+public class GatewayAttributes extends Resource {
+
+  /**
+   * Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+   */
+  @SerializedName("account_reference")
+  @Expose
+  private String accountReference;
+
+  /**
+   * Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+   */
+  public String getAccountReference() {
+    return this.accountReference;
+  }
+
+  /**
+   * @param accountReference Used by Adyen gateways. The Shopper Reference value used when the
+   *     external token was created.
+   */
+  public void setAccountReference(final String accountReference) {
+    this.accountReference = accountReference;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/PaymentMethod.java
+++ b/src/main/java/com/recurly/v3/resources/PaymentMethod.java
@@ -51,6 +51,11 @@ public class PaymentMethod extends Resource {
   @Expose
   private String firstSix;
 
+  /** Gateway specific attributes associated with this PaymentMethod */
+  @SerializedName("gateway_attributes")
+  @Expose
+  private GatewayAttributes gatewayAttributes;
+
   /** An identifier for a specific payment gateway. */
   @SerializedName("gateway_code")
   @Expose
@@ -174,6 +179,16 @@ public class PaymentMethod extends Resource {
   /** @param firstSix Credit card number's first six digits. */
   public void setFirstSix(final String firstSix) {
     this.firstSix = firstSix;
+  }
+
+  /** Gateway specific attributes associated with this PaymentMethod */
+  public GatewayAttributes getGatewayAttributes() {
+    return this.gatewayAttributes;
+  }
+
+  /** @param gatewayAttributes Gateway specific attributes associated with this PaymentMethod */
+  public void setGatewayAttributes(final GatewayAttributes gatewayAttributes) {
+    this.gatewayAttributes = gatewayAttributes;
   }
 
   /** An identifier for a specific payment gateway. */


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod`

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present