### PR TITLE
Generated Latest Changes for v2021-02-25 (Ramp Dates, Net Terms, Invoice Business Entity)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15202,7 +15202,7 @@ paths:
 
         Use for **Adyen HPP** and **Online Banking** transaction requests.
         This runs the validations but not the transactions.
-        The API request allows the inclusion of one of the following fields: **external_hpp_type** with `'adyen'` and **online_banking_payment_type** with `'ideal'` or `'sofort'` in the **billing_info** object.
+        The API request allows the inclusion of the following field: **external_hpp_type** with `'adyen'` in the **billing_info** object.
 
         For additional information regarding shipping fees, please see https://docs.recurly.com/docs/shipping
 
@@ -18291,6 +18291,7 @@ components:
           "$ref": "#/components/schemas/ExternalHppTypeEnum"
         online_banking_payment_type:
           "$ref": "#/components/schemas/OnlineBankingPaymentTypeEnum"
+          deprecated: true
         card_type:
           "$ref": "#/components/schemas/CardTypeEnum"
     BillingInfoVerify:
@@ -19332,13 +19333,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         address:
           "$ref": "#/components/schemas/InvoiceAddress"
         shipping_address:
@@ -19516,13 +19528,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
-          default: 0
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
+          default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         po_number:
           type: string
           title: Purchase order number
@@ -19629,6 +19652,11 @@ components:
         number:
           type: string
           title: Invoice number
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
         type:
           title: Invoice type
           "$ref": "#/components/schemas/InvoiceTypeEnum"
@@ -21600,13 +21628,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -22162,13 +22201,17 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer normally paired with `Net Terms Type` and representing the number of days past
+            the current date (for `net` Net Terms Type) or days after the last day of the current
+            month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+            change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22373,13 +22416,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22549,13 +22603,24 @@ components:
         net_terms:
           type: integer
           title: Terms that the subscription is due on
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         gateway_code:
           type: string
           title: Gateway Code
@@ -22694,6 +22759,14 @@ components:
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
+        starting_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval starts
+        ending_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval ends
         unit_amount:
           type: number
           format: float
@@ -23253,13 +23326,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -24798,6 +24882,19 @@ components:
       - at_range_start
       - evenly
       - never
+    NetTermsTypeEnum:
+      type: string
+      title: Net Terms Type
+      description: |
+        Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+        This field is only available when the EOM Net Terms feature is enabled.
+      enum:
+      - net
+      - eom
+      default: net
     InvoiceTypeEnum:
       type: string
       enum:

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -677,6 +677,17 @@ public class Constants {
     
     };
   
+    public enum NetTermsType {
+      UNDEFINED,
+    
+      @SerializedName("net")
+      NET,
+    
+      @SerializedName("eom")
+      EOM,
+    
+    };
+  
     public enum InvoiceType {
       UNDEFINED,
     

--- a/src/main/java/com/recurly/v3/requests/InvoiceCreate.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceCreate.java
@@ -46,14 +46,36 @@ public class InvoiceCreate extends Request {
   private String currency;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /** For manual invoicing, this identifies the PO number associated with the subscription. */
   @SerializedName("po_number")
@@ -146,23 +168,64 @@ public class InvoiceCreate extends Request {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer paired with `Net Terms Type` and representing the number of days past
+   *     the current date (for `net` Net Terms Type) or days after the last day of the current month
+   *     (for `eom` Net Terms Type) that the invoice will become past due. For any value, an
+   *     additional 24 hours is added to ensure the customer has the entire last day to make payment
+   *     before becoming past due. For example:
+   *     <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours
+   *     after it's created. If an invoice is due `net 30`, it will become past due at 31 days
+   *     exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day
+   *     of the current month.
+   *     <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15,
+   *     30, 45, 60, or 90`. For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /** For manual invoicing, this identifies the PO number associated with the subscription. */

--- a/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PurchaseCreate.java
@@ -75,14 +75,36 @@ public class PurchaseCreate extends Request {
   private List<LineItemCreate> lineItems;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /** For manual invoicing, this identifies the PO number associated with the subscription. */
   @SerializedName("po_number")
@@ -248,23 +270,64 @@ public class PurchaseCreate extends Request {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer paired with `Net Terms Type` and representing the number of days past
+   *     the current date (for `net` Net Terms Type) or days after the last day of the current month
+   *     (for `eom` Net Terms Type) that the invoice will become past due. For any value, an
+   *     additional 24 hours is added to ensure the customer has the entire last day to make payment
+   *     before becoming past due. For example:
+   *     <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours
+   *     after it's created. If an invoice is due `net 30`, it will become past due at 31 days
+   *     exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day
+   *     of the current month.
+   *     <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15,
+   *     30, 45, 60, or 90`. For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /** For manual invoicing, this identifies the PO number associated with the subscription. */

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -62,14 +62,29 @@ public class SubscriptionChangeCreate extends Request {
   private List<CustomField> customFields;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer normally paired with `Net Terms Type` and representing the number of days past the
+   * current date (for `net` Net Terms Type) or days after the last day of the current month (for
+   * `eom` Net Terms Type) that the invoice will become past due. During a subscription change, it's
+   * not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+   *
+   * <p>For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /**
    * If you want to change to a new plan, you can provide the plan's code or id. If both are
@@ -242,23 +257,52 @@ public class SubscriptionChangeCreate extends Request {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer normally paired with `Net Terms Type` and representing the number of days past the
+   * current date (for `net` Net Terms Type) or days after the last day of the current month (for
+   * `eom` Net Terms Type) that the invoice will become past due. During a subscription change, it's
+   * not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+   *
+   * <p>For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer normally paired with `Net Terms Type` and representing the number of
+   *     days past the current date (for `net` Net Terms Type) or days after the last day of the
+   *     current month (for `eom` Net Terms Type) that the invoice will become past due. During a
+   *     subscription change, it's not necessary to provide both the `Net Terms Type` and `Net
+   *     Terms` parameters.
+   *     <p>For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionCreate.java
@@ -87,14 +87,36 @@ public class SubscriptionCreate extends Request {
   private String giftCardRedemptionCode;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /**
    * If present, this sets the date the subscription's next billing period will start
@@ -366,23 +388,64 @@ public class SubscriptionCreate extends Request {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer paired with `Net Terms Type` and representing the number of days past
+   *     the current date (for `net` Net Terms Type) or days after the last day of the current month
+   *     (for `eom` Net Terms Type) that the invoice will become past due. For any value, an
+   *     additional 24 hours is added to ensure the customer has the entire last day to make payment
+   *     before becoming past due. For example:
+   *     <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours
+   *     after it's created. If an invoice is due `net 30`, it will become past due at 31 days
+   *     exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day
+   *     of the current month.
+   *     <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15,
+   *     30, 45, 60, or 90`. For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionUpdate.java
@@ -58,14 +58,36 @@ public class SubscriptionUpdate extends Request {
   private String gatewayCode;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /**
    * If present, this sets the date the subscription's next billing period will start
@@ -207,23 +229,64 @@ public class SubscriptionUpdate extends Request {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer paired with `Net Terms Type` and representing the number of days past
+   *     the current date (for `net` Net Terms Type) or days after the last day of the current month
+   *     (for `eom` Net Terms Type) that the invoice will become past due. For any value, an
+   *     additional 24 hours is added to ensure the customer has the entire last day to make payment
+   *     before becoming past due. For example:
+   *     <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours
+   *     after it's created. If an invoice is due `net 30`, it will become past due at 31 days
+   *     exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day
+   *     of the current month.
+   *     <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15,
+   *     30, 45, 60, or 90`. For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -134,14 +134,36 @@ public class Invoice extends Resource {
   private List<LineItem> lineItems;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /**
    * If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have
@@ -521,23 +543,64 @@ public class Invoice extends Resource {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer paired with `Net Terms Type` and representing the number of days past
+   *     the current date (for `net` Net Terms Type) or days after the last day of the current month
+   *     (for `eom` Net Terms Type) that the invoice will become past due. For any value, an
+   *     additional 24 hours is added to ensure the customer has the entire last day to make payment
+   *     before becoming past due. For example:
+   *     <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours
+   *     after it's created. If an invoice is due `net 30`, it will become past due at 31 days
+   *     exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day
+   *     of the current month.
+   *     <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15,
+   *     30, 45, 60, or 90`. For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/InvoiceMini.java
+++ b/src/main/java/com/recurly/v3/resources/InvoiceMini.java
@@ -12,6 +12,14 @@ import com.recurly.v3.Resource;
 
 public class InvoiceMini extends Resource {
 
+  /**
+   * Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple
+   * Business Entities` feature is enabled.
+   */
+  @SerializedName("business_entity_id")
+  @Expose
+  private String businessEntityId;
+
   /** Invoice ID */
   @SerializedName("id")
   @Expose
@@ -36,6 +44,22 @@ public class InvoiceMini extends Resource {
   @SerializedName("type")
   @Expose
   private Constants.InvoiceType type;
+
+  /**
+   * Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple
+   * Business Entities` feature is enabled.
+   */
+  public String getBusinessEntityId() {
+    return this.businessEntityId;
+  }
+
+  /**
+   * @param businessEntityId Unique ID to identify the business entity assigned to the invoice.
+   *     Available when the `Multiple Business Entities` feature is enabled.
+   */
+  public void setBusinessEntityId(final String businessEntityId) {
+    this.businessEntityId = businessEntityId;
+  }
 
   /** Invoice ID */
   public String getId() {

--- a/src/main/java/com/recurly/v3/resources/Subscription.java
+++ b/src/main/java/com/recurly/v3/resources/Subscription.java
@@ -151,14 +151,36 @@ public class Subscription extends Resource {
   private String id;
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   @SerializedName("net_terms")
   @Expose
   private Integer netTerms;
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  @SerializedName("net_terms_type")
+  @Expose
+  private Constants.NetTermsType netTermsType;
 
   /** Object type */
   @SerializedName("object")
@@ -583,23 +605,64 @@ public class Subscription extends Resource {
   }
 
   /**
-   * Integer representing the number of days after an invoice's creation that the invoice will
-   * become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will
-   * become past due 24 hours after it’s created. If an invoice is due net 30, it will become past
-   * due at 31 days exactly.
+   * Integer paired with `Net Terms Type` and representing the number of days past the current date
+   * (for `net` Net Terms Type) or days after the last day of the current month (for `eom` Net Terms
+   * Type) that the invoice will become past due. For any value, an additional 24 hours is added to
+   * ensure the customer has the entire last day to make payment before becoming past due. For
+   * example:
+   *
+   * <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after
+   * it's created. If an invoice is due `net 30`, it will become past due at 31 days exactly. If an
+   * invoice is due `eom 30`, it will become past due 31 days from the last day of the current
+   * month.
+   *
+   * <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30,
+   * 45, 60, or 90`. For more information please visit our docs page
+   * (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public Integer getNetTerms() {
     return this.netTerms;
   }
 
   /**
-   * @param netTerms Integer representing the number of days after an invoice's creation that the
-   *     invoice will become past due. If an invoice's net terms are set to '0', it is due 'On
-   *     Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30,
-   *     it will become past due at 31 days exactly.
+   * @param netTerms Integer paired with `Net Terms Type` and representing the number of days past
+   *     the current date (for `net` Net Terms Type) or days after the last day of the current month
+   *     (for `eom` Net Terms Type) that the invoice will become past due. For any value, an
+   *     additional 24 hours is added to ensure the customer has the entire last day to make payment
+   *     before becoming past due. For example:
+   *     <p>If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours
+   *     after it's created. If an invoice is due `net 30`, it will become past due at 31 days
+   *     exactly. If an invoice is due `eom 30`, it will become past due 31 days from the last day
+   *     of the current month.
+   *     <p>When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15,
+   *     30, 45, 60, or 90`. For more information please visit our docs page
+   *     (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
    */
   public void setNetTerms(final Integer netTerms) {
     this.netTerms = netTerms;
+  }
+
+  /**
+   * Optionally supplied string that may be either `net` or `eom` (end-of-month). When `net`, an
+   * invoice becomes past due the specified number of `Net Terms` days from the current date. When
+   * `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of
+   * the current month.
+   *
+   * <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public Constants.NetTermsType getNetTermsType() {
+    return this.netTermsType;
+  }
+
+  /**
+   * @param netTermsType Optionally supplied string that may be either `net` or `eom`
+   *     (end-of-month). When `net`, an invoice becomes past due the specified number of `Net Terms`
+   *     days from the current date. When `eom` an invoice becomes past due the specified number of
+   *     `Net Terms` days from the last day of the current month.
+   *     <p>This field is only available when the EOM Net Terms feature is enabled.
+   */
+  public void setNetTermsType(final Constants.NetTermsType netTermsType) {
+    this.netTermsType = netTermsType;
   }
 
   /** Object type */

--- a/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
+++ b/src/main/java/com/recurly/v3/resources/SubscriptionRampIntervalResponse.java
@@ -9,8 +9,14 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
 import java.math.BigDecimal;
+import org.joda.time.DateTime;
 
 public class SubscriptionRampIntervalResponse extends Resource {
+
+  /** Date the ramp interval ends */
+  @SerializedName("ending_on")
+  @Expose
+  private DateTime endingOn;
 
   /** Represents how many billing cycles are left in a ramp interval. */
   @SerializedName("remaining_billing_cycles")
@@ -22,10 +28,25 @@ public class SubscriptionRampIntervalResponse extends Resource {
   @Expose
   private Integer startingBillingCycle;
 
+  /** Date the ramp interval starts */
+  @SerializedName("starting_on")
+  @Expose
+  private DateTime startingOn;
+
   /** Represents the price for the ramp interval. */
   @SerializedName("unit_amount")
   @Expose
   private BigDecimal unitAmount;
+
+  /** Date the ramp interval ends */
+  public DateTime getEndingOn() {
+    return this.endingOn;
+  }
+
+  /** @param endingOn Date the ramp interval ends */
+  public void setEndingOn(final DateTime endingOn) {
+    this.endingOn = endingOn;
+  }
 
   /** Represents how many billing cycles are left in a ramp interval. */
   public Integer getRemainingBillingCycles() {
@@ -47,6 +68,16 @@ public class SubscriptionRampIntervalResponse extends Resource {
   /** @param startingBillingCycle Represents the billing cycle where a ramp interval starts. */
   public void setStartingBillingCycle(final Integer startingBillingCycle) {
     this.startingBillingCycle = startingBillingCycle;
+  }
+
+  /** Date the ramp interval starts */
+  public DateTime getStartingOn() {
+    return this.startingOn;
+  }
+
+  /** @param startingOn Date the ramp interval starts */
+  public void setStartingOn(final DateTime startingOn) {
+    this.startingOn = startingOn;
   }
 
   /** Represents the price for the ramp interval. */


### PR DESCRIPTION
- Adds `NetTermsType` to the `Subscription`, `SubscriptionChange`, `Purchase`, and `Invoice` resources
- Adds `BusinessEntityId` to the `InvoiceMini` resource
- Adds `StartingOn` and `EndingOn` to `SubscriptionRampIntervalResponse` resources