### PR TITLE
chore: Update dependencies to address security warnings:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <okhttp3.version>4.7.2</okhttp3.version>
+        <okhttp3.version>4.12.0</okhttp3.version>
         <surefire.version>3.0.0-M4</surefire.version>
-        <jacoco.version>0.8.5</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
     </properties>
 
     <build>
@@ -214,16 +214,15 @@
                 <autoReleaseAfterClose>true</autoReleaseAfterClose>
               </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.owasp</groupId>
+              <artifactId>dependency-check-maven</artifactId>
+              <version>9.1.0</version>
+            </plugin>
         </plugins>
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -295,20 +294,13 @@
         </dependency>
 
         <!-- Specify versions of transitive dependencies
-            xerces:xercesImpl introduced through jacoco-maven-plugin and doxia-core
-              - can be removed when mvn dependency:list shows version 2.12.0 or higher and no snyk reported vulnerabilities
             plexus:plexus-utils introduced through jacoco-maven-plugin, maven-compiler-plugin, and others
               - can be removed when mvn dependency:list shows version 3.0.24 or higher and no snyk reported vulnerabilities
         -->
         <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-            <version>2.12.2</version>
-        </dependency>
-        <dependency>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-utils</artifactId>
-          <version>3.2.1</version>
-      </dependency>
+          <version>3.5.1</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Update dependencies to address security warnings:

| package | previous version | new version | dependency type |
| - | - | - | - |
| okhttp3 | 4.7.2 | 4.12.0 | primary |
| jacoco-maven-plugin | 0.8.5 | 0.8.12 | primary |
| plexus-utils | 3.2.1 | 3.5.1 | transitive |

Removes primary dependency `maven-compiler-plugin`, which resolves #216.

Removes transitive dependency `xercesImpl` as it is no longer necessary.

Adds `dependency-check-maven` plugin to check dependencies.
