### PR TITLE
Generated Latest Changes for v2021-02-25 (Proration Settings)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21253,6 +21253,34 @@ components:
           description: |
             The percentage taken of the monetary amount of usage tracked.
             This can be up to 4 decimal places represented as a string.
+    ProrationSettings:
+      type: object
+      title: Proration Settings
+      description: Allows you to control how any resulting charges and credits will
+        be calculated and prorated.
+      properties:
+        charge:
+          "$ref": "#/components/schemas/ProrationSettingsChargeEnum"
+        credit:
+          "$ref": "#/components/schemas/ProrationSettingsCreditEnum"
+    ProrationSettingsChargeEnum:
+      type: string
+      title: Charge
+      description: Determines how the amount charged is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
+    ProrationSettingsCreditEnum:
+      type: string
+      title: Credit
+      description: Determines how the amount credited is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
     Settings:
       type: object
       properties:
@@ -22476,6 +22504,8 @@ components:
           description: The new set of ramp intervals for the subscription.
           items:
             "$ref": "#/components/schemas/SubscriptionRampInterval"
+        proration_settings:
+          "$ref": "#/components/schemas/ProrationSettings"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -10,6 +10,34 @@ import com.google.gson.annotations.SerializedName;
 
 public class Constants {
   
+    public enum ProrationSettingsCharge {
+      UNDEFINED,
+    
+      @SerializedName("full_amount")
+      FULL_AMOUNT,
+    
+      @SerializedName("prorated_amount")
+      PRORATED_AMOUNT,
+    
+      @SerializedName("none")
+      NONE,
+    
+    };
+  
+    public enum ProrationSettingsCredit {
+      UNDEFINED,
+    
+      @SerializedName("full_amount")
+      FULL_AMOUNT,
+    
+      @SerializedName("prorated_amount")
+      PRORATED_AMOUNT,
+    
+      @SerializedName("none")
+      NONE,
+    
+    };
+  
     public enum ExternalProductReferenceConnectionType {
       UNDEFINED,
     

--- a/src/main/java/com/recurly/v3/requests/ProrationSettings.java
+++ b/src/main/java/com/recurly/v3/requests/ProrationSettings.java
@@ -1,0 +1,45 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class ProrationSettings extends Request {
+
+  /** Determines how the amount charged is determined for this change */
+  @SerializedName("charge")
+  @Expose
+  private Constants.ProrationSettingsCharge charge;
+
+  /** Determines how the amount credited is determined for this change */
+  @SerializedName("credit")
+  @Expose
+  private Constants.ProrationSettingsCredit credit;
+
+  /** Determines how the amount charged is determined for this change */
+  public Constants.ProrationSettingsCharge getCharge() {
+    return this.charge;
+  }
+
+  /** @param charge Determines how the amount charged is determined for this change */
+  public void setCharge(final Constants.ProrationSettingsCharge charge) {
+    this.charge = charge;
+  }
+
+  /** Determines how the amount credited is determined for this change */
+  public Constants.ProrationSettingsCredit getCredit() {
+    return this.credit;
+  }
+
+  /** @param credit Determines how the amount credited is determined for this change */
+  public void setCredit(final Constants.ProrationSettingsCredit credit) {
+    this.credit = credit;
+  }
+}

--- a/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
+++ b/src/main/java/com/recurly/v3/requests/SubscriptionChangeCreate.java
@@ -107,6 +107,13 @@ public class SubscriptionChangeCreate extends Request {
   @Expose
   private String poNumber;
 
+  /**
+   * Allows you to control how any resulting charges and credits will be calculated and prorated.
+   */
+  @SerializedName("proration_settings")
+  @Expose
+  private ProrationSettings prorationSettings;
+
   /** Optionally override the default quantity of 1. */
   @SerializedName("quantity")
   @Expose
@@ -349,6 +356,21 @@ public class SubscriptionChangeCreate extends Request {
    */
   public void setPoNumber(final String poNumber) {
     this.poNumber = poNumber;
+  }
+
+  /**
+   * Allows you to control how any resulting charges and credits will be calculated and prorated.
+   */
+  public ProrationSettings getProrationSettings() {
+    return this.prorationSettings;
+  }
+
+  /**
+   * @param prorationSettings Allows you to control how any resulting charges and credits will be
+   *     calculated and prorated.
+   */
+  public void setProrationSettings(final ProrationSettings prorationSettings) {
+    this.prorationSettings = prorationSettings;
   }
 
   /** Optionally override the default quantity of 1. */


### PR DESCRIPTION
Adds support for passing `proration_settings` to the following endpoints:

- POST /subscriptions/:id/change
- POST /subscriptions/:id/change/preview