### PR TITLE
Generated Latest Changes for v2021-02-25 (Taxable Address Control, RevRec)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -230,6 +230,8 @@ x-tagGroups:
   - shipping_method
   - dunning_campaigns
   - business_entities
+  - general_ledger_account
+  - performance_obligations
 tags:
 - name: site
   x-displayName: Site
@@ -242,7 +244,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices features to be enabled.
+    Recurly's item catalog requires the Credit Invoices feature to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -385,6 +387,55 @@ tags:
   x-displayName: Business Entities
   description: Describes the business address that will be used for invoices and taxes
     depending on settings and subscriber location.
+- name: general_ledger_account
+  x-displayName: General Ledger Account
+  description: |
+    A general ledger account is an account of record used to sort, store
+    and summarize a company's transactions. Recurly supports the balance
+    sheet (Liability) account and income (Revenue) account to be attached
+    to business entities, plans, or at the item level.
+
+    When invoices are created, system can default to the accounts based
+    on the GL Accounts attached at the plan/item level. The accounts can
+    be defaulted from the business entity level as well.
+
+    These accounts will be used in the Revenue Recognition module to create
+    the revenue journals that can be posted into Merchant GL system.
+
+    Revenue and Liability accounts can defined in the system using this
+    API or via the General Ledger Accounting page in the Admin UI and then
+    used at the plan/item level.
+
+    Recurly allows merchants to default the accounts at the following levels:
+    - Business Entities (default)
+    - Plans
+        - Base Price
+        - Setup Fee
+        - Add-ons
+    - Items
+    - Charges
+    - Gift Cards
+    - Shipping Methods
+    - Credits
+
+    If you are interested in Recurly Revenue Recognition features, please
+    contact a Recurly customer service representative.
+- name: performance_obligations
+  x-displayName: Performance Obligations
+  description: |
+    A performance obligation is a promise to provide a distinct good or
+    service or a series of distinct goods or services as defined by the revenue standard.
+    Performance obligations are completed and revenue is recognized either at a point in
+    time or over a period of time, depending on the type of obligation.
+    - Point in time  a company has to go through the criteria and determine if a performance
+    obligation is satisfied over time. If it does not meet those criteria, then the performance
+    obligation is satisfied and revenue recognized at the point in time when control of the good
+    or service is transferred to the customer.
+    - Over a period of time  a performance obligation is satisfied and revenue is recognized over
+    time if at least one of the following are met:
+      - The customer receives and consumes the benefits of the goods or services as they are provided
+      by the entity (routine, recurring services like a cleaning service are an example of a series of
+      services that are substantially the same and have the same pattern of transfer)
 paths:
   "/sites":
     get:
@@ -6566,7 +6617,7 @@ paths:
       - "$ref": "#/components/parameters/custom_field_definition_id"
       responses:
         '200':
-          description: An custom field definition.
+          description: A custom field definition.
           content:
             application/json:
               schema:
@@ -6672,6 +6723,150 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Custom
           Field Definition: %s\", definition.Id)"
+  "/general_ledger_accounts":
+    post:
+      tags:
+      - general_ledger_account
+      operationId: create_general_ledger_account
+      summary: Create a new general ledger account
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountCreate"
+        required: true
+      responses:
+        '201':
+          description: A new general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    get:
+      tags:
+      - general_ledger_account
+      operationId: list_general_ledger_accounts
+      summary: List a site's general ledger accounts
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/general_ledger_account_type_enum"
+      responses:
+        '200':
+          description: A list of the site's general ledger accounts.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccountList"
+        '404':
+          description: Incorrect site ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/general_ledger_accounts/{general_ledger_account_id}":
+    get:
+      tags:
+      - general_ledger_account
+      operationId: get_general_ledger_account
+      summary: Fetch a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      responses:
+        '200':
+          description: A general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    put:
+      tags:
+      - general_ledger_account
+      operationId: update_general_ledger_account
+      summary: Update a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountUpdate"
+        required: true
+      responses:
+        '200':
+          description: The updated general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations/{performance_obligation_id}":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligation
+      summary: Get a single Performance Obligation.
+      parameters:
+      - "$ref": "#/components/parameters/performance_obligation_id"
+      responses:
+        '200':
+          description: A single Performance Obligation.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligation"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligations
+      summary: Get a site's Performance Obligations
+      responses:
+        '200':
+          description: A list of Performance Obligations.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligationList"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/invoice_templates/{invoice_template_id}/accounts":
     get:
       tags:
@@ -8034,7 +8229,7 @@ paths:
       x-code-samples: []
   "/external_subscriptions/{external_subscription_id}":
     parameters:
-    - "$ref": "#/components/parameters/external_subscription_id"
+    - "$ref": "#/components/parameters/external_subscription_id_fetch"
     get:
       tags:
       - external_subscriptions
@@ -16093,10 +16288,10 @@ paths:
       tags:
       - external_payment_phases
       operationId: get_external_subscription_external_payment_phase
-      summary: Fetch an external payment_phase
+      summary: Fetch an external payment phase
       responses:
         '200':
-          description: Details for an external payment_phase.
+          description: Details for an external payment phase.
           content:
             application/json:
               schema:
@@ -16545,6 +16740,14 @@ components:
       required: true
       schema:
         type: string
+    external_subscription_id_fetch:
+      name: external_subscription_id
+      in: path
+      description: External subscription ID or external_id. For ID no prefix is used
+        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      required: true
+      schema:
+        type: string
     external_subscription_id:
       name: external_subscription_id
       in: path
@@ -16559,6 +16762,25 @@ components:
       required: true
       schema:
         type: string
+    general_ledger_account_id:
+      name: general_ledger_account_id
+      in: path
+      description: General Ledger Account ID
+      required: true
+      schema:
+        type: string
+        title: General Ledger Account ID
+        description: |
+          The ID of a general ledger account. General ledger accounts are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
+    general_ledger_account_type_enum:
+      name: account_type
+      in: query
+      description: General Ledger Account type by which to filter the response.
+      schema:
+        "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
     invoice_template_id:
       name: invoice_template_id
       in: path
@@ -16604,6 +16826,19 @@ components:
       required: true
       schema:
         type: string
+    performance_obligation_id:
+      name: performance_obligation_id
+      in: path
+      description: Performance Obligation id.
+      required: true
+      schema:
+        type: string
+        title: Performance Obligation ID
+        description: |
+          The ID of a performance obligation. Performance obligations are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
     plan_id:
       name: plan_id
       in: path
@@ -17858,6 +18093,30 @@ components:
           description: System-generated unique identifier for an measured unit associated
             with the add-on.
           maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -17972,7 +18231,7 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            Invoices` feature is enabled. If `item_id` and `item_code` are both present,
             `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
@@ -18031,6 +18290,30 @@ components:
           title: Plan ID
           maxLength: 13
           readOnly: true
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -18100,7 +18383,7 @@ components:
           minItems: 1
           description: |
             * If `item_code`/`item_id` is part of the request and the item
-            has a default currency then `currencies` is optional. If the item does
+            has a default currency, then `currencies` is optional. If the item does
             not have a default currency, then `currencies` is required. If `item_code`/`item_id`
             is not present `currencies` is required.
             * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
@@ -18189,6 +18472,30 @@ components:
             to the `AddOn` then `accounting code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
           description: When this add-on is invoiced, the line item will use this revenue
@@ -18271,7 +18578,7 @@ components:
             `percentage_tiers` is an array of objects, which must have the set of tiers
             per currency and the currency code. The tier_type must be `volume` or `tiered`,
             if not, it must be absent. There must be one tier without an `ending_amount` value
-            which represents the final tier.  This feature is currently in development and
+            which represents the final tier. This feature is currently in development and
             requires approval and enablement, please contact support.
     BillingInfo:
       type: object
@@ -19210,6 +19517,171 @@ components:
             are removed from the accouts or subscriptions, will be hard deleted an
             no longer visible.
           readOnly: true
+    GeneralLedgerAccountId:
+      type: string
+      title: General Ledger Account ID
+      description: |
+        The ID of a general ledger account. General ledger accounts are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    GeneralLedgerAccountCode:
+      type: string
+      title: Accounting code for the ledger account.
+      description: |
+        Unique code to identify the ledger account. Each code must start
+        with a letter or number. The following special characters are
+        allowed: `-_.,:`
+      pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+      maxLength: 255
+    GeneralLedgerAccountDescription:
+      type: string
+      title: Description
+      description: Optional description.
+      maxLength: 255
+    GeneralLedgerAccount:
+      type: object
+      description: Full general ledger account details.
+      properties:
+        id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        object:
+          type: string
+          title: Object type
+          default: general_ledger_account
+          readOnly: true
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
+    GeneralLedgerAccountList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GeneralLedgerAccount"
+    GeneralLedgerAccountCreate:
+      type: object
+      description: Create a new liability or revenue general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+    GeneralLedgerAccountUpdate:
+      type: object
+      description: Update an existing general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+    PerformanceObligationId:
+      type: string
+      title: Performance Obligation ID
+      description: |
+        The ID of a performance obligation. Performance obligations are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    PerformanceObligation:
+      type: object
+      description: Performance obligation details
+      properties:
+        id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        name:
+          title: Performance Obligation Name
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          readOnly: true
+          format: date-time
+        updated_at:
+          title: Last updated at
+          type: string
+          readOnly: true
+          format: date-time
+    PerformanceObligationList:
+      type: object
+      description: List of Performance Obligations
+      properties:
+        object:
+          title: Object type
+          type: string
+        data:
+          title: Performance Obligation
+          type: array
+          items:
+            "$ref": "#/components/schemas/PerformanceObligation"
     ItemMini:
       type: object
       title: Item mini details
@@ -19294,6 +19766,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19378,6 +19874,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19450,6 +19970,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -20269,6 +20813,32 @@ components:
           format: float
           title: Discount
           description: The discount applied to the line item.
+        liability_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        revenue_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax:
           type: number
           format: float
@@ -20310,6 +20880,10 @@ components:
           maxLength: 50
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         proration_rate:
           type: number
           format: float
@@ -20470,6 +21044,30 @@ components:
             is part of the request then `accounting_code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20537,6 +21135,10 @@ components:
           format: date-time
           title: End date
           description: If this date is provided, it indicates the end of a time range.
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
       required:
       - currency
       - unit_amount
@@ -20834,6 +21436,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21050,6 +21700,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21508,6 +22206,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -21580,6 +22302,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
       required:
       - code
       - name
@@ -21618,6 +22364,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
     ShippingFeeCreate:
       type: object
       properties:
@@ -23980,8 +24750,6 @@ components:
         object:
           type: string
           title: Object type
-        external_subscription:
-          "$ref": "#/components/schemas/ExternalSubscription"
         started_at:
           type: string
           format: date-time
@@ -24279,6 +25047,12 @@ components:
           "$ref": "#/components/schemas/AccountMini"
         external_product_reference:
           "$ref": "#/components/schemas/ExternalProductReferenceMini"
+        external_payment_phases:
+          type: array
+          title: External payment phases
+          description: The phases of the external subscription payment lifecycle.
+          items:
+            "$ref": "#/components/schemas/ExternalPaymentPhase"
         external_id:
           type: string
           title: External Id
@@ -24351,6 +25125,12 @@ components:
           title: Test
           description: An indication of whether or not the external subscription was
             purchased in a sandbox environment.
+          default: false
+        imported:
+          type: boolean
+          title: Imported
+          description: An indication of whether or not the external subscription was
+            created by a historical data import.
           default: false
         created_at:
           type: string
@@ -24682,6 +25462,10 @@ components:
           description: Address information for the business entity that will be used
             for calculating taxes.
           "$ref": "#/components/schemas/Address"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         default_vat_number:
           type: string
           title: Default VAT number
@@ -24699,6 +25483,22 @@ components:
           items:
             type: string
             title: Country code
+        default_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        default_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -24797,6 +25597,30 @@ components:
           description: The delivery details for the gift card.
           readOnly: true
           "$ref": "#/components/schemas/GiftCardDelivery"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -25978,3 +26802,30 @@ components:
       type: string
       enum:
       - paid
+    GeneralLedgerAccountTypeEnum:
+      type: string
+      enum:
+      - liability
+      - revenue
+    OriginTaxAddressSourceEnum:
+      type: string
+      title: Origin tax address source
+      description: The source of the address that will be used as the origin in determining
+        taxes. Available only when the site is on an Elite plan. A value of "origin"
+        refers to the "Business entity tax address". A value of "destination" refers
+        to the "Customer tax address".
+      default: origin
+      enum:
+      - origin
+      - destination
+    DestinationTaxAddressSourceEnum:
+      type: string
+      title: Destination tax address source
+      description: The source of the address that will be used as the destinaion in
+        determining taxes. Available only when the site is on an Elite plan. A value
+        of "destination" refers to the "Customer tax address". A value of "origin"
+        refers to the "Business entity tax address".
+      default: destination
+      enum:
+      - destination
+      - origin

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -1080,7 +1080,7 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_custom_field_definition">get_custom_field_definition api documentation</a>
    * @param customFieldDefinitionId Custom Field Definition ID
-     * @return An custom field definition.
+     * @return A custom field definition.
    */
   public CustomFieldDefinition getCustomFieldDefinition(String customFieldDefinitionId) {
     final String url = "/custom_field_definitions/{custom_field_definition_id}";
@@ -1089,6 +1089,101 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
     final String path = this.interpolatePath(url, urlParams);
     Type returnType = CustomFieldDefinition.class;
     return this.makeRequest("GET", path, returnType);
+  }
+
+  /**
+   * Create a new general ledger account
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account">create_general_ledger_account api documentation</a>
+   * @param body The body of the request.
+     * @return A new general ledger account.
+   */
+  public GeneralLedgerAccount createGeneralLedgerAccount(GeneralLedgerAccountCreate body) {
+    final String url = "/general_ledger_accounts";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    final String path = this.interpolatePath(url, urlParams);
+    Type returnType = GeneralLedgerAccount.class;
+    return this.makeRequest("POST", path, body, returnType);
+  }
+
+  /**
+   * List a site's general ledger accounts
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/list_general_ledger_accounts">list_general_ledger_accounts api documentation</a>
+   * @param queryParams The {@link QueryParams} for this endpoint.
+     * @return A list of the site's general ledger accounts.
+   */
+  public Pager<GeneralLedgerAccount> listGeneralLedgerAccounts(QueryParams queryParams) {
+    final String url = "/general_ledger_accounts";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    if (queryParams == null) queryParams = new QueryParams();
+    final HashMap<String, Object> paramsMap = queryParams.getParams();
+    final String path = this.interpolatePath(url, urlParams);
+    Type parameterizedType = TypeToken.getParameterized(Pager.class, GeneralLedgerAccount.class).getType();
+    return new Pager<>(path, paramsMap, this, parameterizedType);
+  }
+
+  /**
+   * Fetch a general ledger account
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account">get_general_ledger_account api documentation</a>
+   * @param generalLedgerAccountId General Ledger Account ID
+     * @return A general ledger account.
+   */
+  public GeneralLedgerAccount getGeneralLedgerAccount(String generalLedgerAccountId) {
+    final String url = "/general_ledger_accounts/{general_ledger_account_id}";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("general_ledger_account_id", generalLedgerAccountId);
+    final String path = this.interpolatePath(url, urlParams);
+    Type returnType = GeneralLedgerAccount.class;
+    return this.makeRequest("GET", path, returnType);
+  }
+
+  /**
+   * Update a general ledger account
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account">update_general_ledger_account api documentation</a>
+   * @param generalLedgerAccountId General Ledger Account ID
+   * @param body The body of the request.
+     * @return The updated general ledger account.
+   */
+  public GeneralLedgerAccount updateGeneralLedgerAccount(String generalLedgerAccountId, GeneralLedgerAccountUpdate body) {
+    final String url = "/general_ledger_accounts/{general_ledger_account_id}";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("general_ledger_account_id", generalLedgerAccountId);
+    final String path = this.interpolatePath(url, urlParams);
+    Type returnType = GeneralLedgerAccount.class;
+    return this.makeRequest("PUT", path, body, returnType);
+  }
+
+  /**
+   * Get a single Performance Obligation.
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation">get_performance_obligation api documentation</a>
+   * @param performanceObligationId Performance Obligation id.
+     * @return A single Performance Obligation.
+   */
+  public PerformanceObligation getPerformanceObligation(String performanceObligationId) {
+    final String url = "/performance_obligations/{performance_obligation_id}";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    urlParams.put("performance_obligation_id", performanceObligationId);
+    final String path = this.interpolatePath(url, urlParams);
+    Type returnType = PerformanceObligation.class;
+    return this.makeRequest("GET", path, returnType);
+  }
+
+  /**
+   * Get a site's Performance Obligations
+   *
+   * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligations">get_performance_obligations api documentation</a>
+     * @return A list of Performance Obligations.
+   */
+  public Pager<PerformanceObligation> getPerformanceObligations() {
+    final String url = "/performance_obligations";
+    final HashMap<String, String> urlParams = new HashMap<String, String>();
+    final String path = this.interpolatePath(url, urlParams);
+    Type parameterizedType = TypeToken.getParameterized(Pager.class, PerformanceObligation.class).getType();
+    return new Pager<>(path, null, this, parameterizedType);
   }
 
   /**
@@ -1462,7 +1557,7 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * Fetch an external subscription
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription">get_external_subscription api documentation</a>
-   * @param externalSubscriptionId External subscription id
+   * @param externalSubscriptionId External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
      * @return Settings for an external subscription.
    */
   public ExternalSubscription getExternalSubscription(String externalSubscriptionId) {
@@ -2838,12 +2933,12 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
   }
 
   /**
-   * Fetch an external payment_phase
+   * Fetch an external payment phase
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</a>
    * @param externalSubscriptionId External subscription id
    * @param externalPaymentPhaseId External payment phase ID, e.g. `a34ypb2ef9w1`.
-     * @return Details for an external payment_phase.
+     * @return Details for an external payment phase.
    */
   public ExternalPaymentPhase getExternalSubscriptionExternalPaymentPhase(String externalSubscriptionId, String externalPaymentPhaseId) {
     final String url = "/external_subscriptions/{external_subscription_id}/external_payment_phases/{external_payment_phase_id}";

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -2273,4 +2273,37 @@ public class Constants {
     
     };
   
+    public enum GeneralLedgerAccountType {
+      UNDEFINED,
+    
+      @SerializedName("liability")
+      LIABILITY,
+    
+      @SerializedName("revenue")
+      REVENUE,
+    
+    };
+  
+    public enum OriginTaxAddressSource {
+      UNDEFINED,
+    
+      @SerializedName("origin")
+      ORIGIN,
+    
+      @SerializedName("destination")
+      DESTINATION,
+    
+    };
+  
+    public enum DestinationTaxAddressSource {
+      UNDEFINED,
+    
+      @SerializedName("destination")
+      DESTINATION,
+    
+      @SerializedName("origin")
+      ORIGIN,
+    
+    };
+  
 }

--- a/src/main/java/com/recurly/v3/QueryParams.java
+++ b/src/main/java/com/recurly/v3/QueryParams.java
@@ -82,6 +82,10 @@ public class QueryParams {
     this.add("related_type", relatedType);
   }
 
+  public void setAccountType(final Constants.GeneralLedgerAccountType accountType) {
+    this.add("account_type", accountType);
+  }
+
   public void setRefund(final Constants.RefundType refund) {
     this.add("refund", refund);
   }

--- a/src/main/java/com/recurly/v3/requests/AddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnCreate.java
@@ -60,7 +60,7 @@ public class AddOnCreate extends Request {
   private String code;
 
   /**
-   * * If `item_code`/`item_id` is part of the request and the item has a default currency then
+   * * If `item_code`/`item_id` is part of the request and the item has a default currency, then
    * `currencies` is optional. If the item does not have a default currency, then `currencies` is
    * required. If `item_code`/`item_id` is not present `currencies` is required. If the add-on's
    * `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. Must be
@@ -81,7 +81,7 @@ public class AddOnCreate extends Request {
   private Boolean displayQuantity;
 
   /**
-   * Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If
+   * Unique code to identify an item. Available when the `Credit Invoices` feature is enabled. If
    * `item_id` and `item_code` are both present, `item_id` will be used.
    */
   @SerializedName("item_code")
@@ -95,6 +95,14 @@ public class AddOnCreate extends Request {
   @SerializedName("item_id")
   @Expose
   private String itemId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
 
   /**
    * System-generated unique identifier for a measured unit to be associated with the add-on. Either
@@ -143,10 +151,26 @@ public class AddOnCreate extends Request {
   @Expose
   private List<PercentageTiersByCurrency> percentageTiers;
 
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
   /** Plan ID */
   @SerializedName("plan_id")
   @Expose
   private String planId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * When this add-on is invoiced, the line item will use this revenue schedule. If
@@ -313,7 +337,7 @@ public class AddOnCreate extends Request {
   }
 
   /**
-   * * If `item_code`/`item_id` is part of the request and the item has a default currency then
+   * * If `item_code`/`item_id` is part of the request and the item has a default currency, then
    * `currencies` is optional. If the item does not have a default currency, then `currencies` is
    * required. If `item_code`/`item_id` is not present `currencies` is required. If the add-on's
    * `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must be absent. Must be
@@ -325,7 +349,7 @@ public class AddOnCreate extends Request {
 
   /**
    * @param currencies * If `item_code`/`item_id` is part of the request and the item has a default
-   *     currency then `currencies` is optional. If the item does not have a default currency, then
+   *     currency, then `currencies` is optional. If the item does not have a default currency, then
    *     `currencies` is required. If `item_code`/`item_id` is not present `currencies` is required.
    *     If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`, then `currencies` must
    *     be absent. Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
@@ -358,7 +382,7 @@ public class AddOnCreate extends Request {
   }
 
   /**
-   * Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If
+   * Unique code to identify an item. Available when the `Credit Invoices` feature is enabled. If
    * `item_id` and `item_code` are both present, `item_id` will be used.
    */
   public String getItemCode() {
@@ -367,7 +391,7 @@ public class AddOnCreate extends Request {
 
   /**
    * @param itemCode Unique code to identify an item. Available when the `Credit Invoices` feature
-   *     are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+   *     is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
    */
   public void setItemCode(final String itemCode) {
     this.itemCode = itemCode;
@@ -388,6 +412,23 @@ public class AddOnCreate extends Request {
    */
   public void setItemId(final String itemId) {
     this.itemId = itemId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
   }
 
   /**
@@ -487,6 +528,23 @@ public class AddOnCreate extends Request {
     this.percentageTiers = percentageTiers;
   }
 
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
   /** Plan ID */
   public String getPlanId() {
     return this.planId;
@@ -495,6 +553,22 @@ public class AddOnCreate extends Request {
   /** @param planId Plan ID */
   public void setPlanId(final String planId) {
     this.planId = planId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
@@ -77,6 +77,14 @@ public class AddOnUpdate extends Request {
   private String id;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * System-generated unique identifier for a measured unit to be associated with the add-on. Either
    * `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If
    * `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
@@ -121,6 +129,22 @@ public class AddOnUpdate extends Request {
   @SerializedName("percentage_tiers")
   @Expose
   private List<PercentageTiersByCurrency> percentageTiers;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * When this add-on is invoiced, the line item will use this revenue schedule. If
@@ -298,6 +322,23 @@ public class AddOnUpdate extends Request {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * System-generated unique identifier for a measured unit to be associated with the add-on. Either
    * `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If
    * `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.
@@ -390,6 +431,39 @@ public class AddOnUpdate extends Request {
    */
   public void setPercentageTiers(final List<PercentageTiersByCurrency> percentageTiers) {
     this.percentageTiers = percentageTiers;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/GeneralLedgerAccountCreate.java
+++ b/src/main/java/com/recurly/v3/requests/GeneralLedgerAccountCreate.java
@@ -1,0 +1,67 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class GeneralLedgerAccountCreate extends Request {
+
+  @SerializedName("account_type")
+  @Expose
+  private Constants.GeneralLedgerAccountType accountType;
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  @SerializedName("code")
+  @Expose
+  private String code;
+
+  /** Optional description. */
+  @SerializedName("description")
+  @Expose
+  private String description;
+
+  public Constants.GeneralLedgerAccountType getAccountType() {
+    return this.accountType;
+  }
+
+  /** @param accountType */
+  public void setAccountType(final Constants.GeneralLedgerAccountType accountType) {
+    this.accountType = accountType;
+  }
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  public String getCode() {
+    return this.code;
+  }
+
+  /**
+   * @param code Unique code to identify the ledger account. Each code must start with a letter or
+   *     number. The following special characters are allowed: `-_.,:`
+   */
+  public void setCode(final String code) {
+    this.code = code;
+  }
+
+  /** Optional description. */
+  public String getDescription() {
+    return this.description;
+  }
+
+  /** @param description Optional description. */
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/recurly/v3/requests/GeneralLedgerAccountUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/GeneralLedgerAccountUpdate.java
@@ -1,0 +1,53 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class GeneralLedgerAccountUpdate extends Request {
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  @SerializedName("code")
+  @Expose
+  private String code;
+
+  /** Optional description. */
+  @SerializedName("description")
+  @Expose
+  private String description;
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  public String getCode() {
+    return this.code;
+  }
+
+  /**
+   * @param code Unique code to identify the ledger account. Each code must start with a letter or
+   *     number. The following special characters are allowed: `-_.,:`
+   */
+  public void setCode(final String code) {
+    this.code = code;
+  }
+
+  /** Optional description. */
+  public String getDescription() {
+    return this.description;
+  }
+
+  /** @param description Optional description. */
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+}

--- a/src/main/java/com/recurly/v3/requests/ItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/ItemCreate.java
@@ -69,12 +69,36 @@ public class ItemCreate extends Request {
   private String externalSku;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time
    * basis.
    */
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -206,6 +230,23 @@ public class ItemCreate extends Request {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time
    * basis.
    */
@@ -219,6 +260,39 @@ public class ItemCreate extends Request {
    */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/ItemUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/ItemUpdate.java
@@ -69,12 +69,36 @@ public class ItemUpdate extends Request {
   private String externalSku;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time
    * basis.
    */
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -206,6 +230,23 @@ public class ItemUpdate extends Request {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time
    * basis.
    */
@@ -219,6 +260,39 @@ public class ItemUpdate extends Request {
    */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -82,6 +82,15 @@ public class LineItemCreate extends Request {
   @Expose
   private String description;
 
+  /**
+   * The source of the address that will be used as the destinaion in determining taxes. Available
+   * only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax
+   * address". A value of "origin" refers to the "Business entity tax address".
+   */
+  @SerializedName("destination_tax_address_source")
+  @Expose
+  private Constants.DestinationTaxAddressSource destinationTaxAddressSource;
+
   /** If this date is provided, it indicates the end of a time range. */
   @SerializedName("end_date")
   @Expose
@@ -101,6 +110,14 @@ public class LineItemCreate extends Request {
   private String itemId;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and
    * `type` is `credit`. Set this value in order to track gift card credits from external gift cards
    * (like InComm). It also skips billing information requirements. Origin `prepayment` is only
@@ -110,6 +127,23 @@ public class LineItemCreate extends Request {
   @SerializedName("origin")
   @Expose
   private Constants.LineItemCreateOrigin origin;
+
+  /**
+   * The source of the address that will be used as the origin in determining taxes. Available only
+   * when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax
+   * address". A value of "destination" refers to the "Customer tax address".
+   */
+  @SerializedName("origin_tax_address_source")
+  @Expose
+  private Constants.OriginTaxAddressSource originTaxAddressSource;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
 
   /**
    * Optional field to track a product code or SKU for the line item. This can be used to later
@@ -128,6 +162,14 @@ public class LineItemCreate extends Request {
   @SerializedName("quantity")
   @Expose
   private Integer quantity;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -320,6 +362,26 @@ public class LineItemCreate extends Request {
     this.description = description;
   }
 
+  /**
+   * The source of the address that will be used as the destinaion in determining taxes. Available
+   * only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax
+   * address". A value of "origin" refers to the "Business entity tax address".
+   */
+  public Constants.DestinationTaxAddressSource getDestinationTaxAddressSource() {
+    return this.destinationTaxAddressSource;
+  }
+
+  /**
+   * @param destinationTaxAddressSource The source of the address that will be used as the
+   *     destinaion in determining taxes. Available only when the site is on an Elite plan. A value
+   *     of "destination" refers to the "Customer tax address". A value of "origin" refers to the
+   *     "Business entity tax address".
+   */
+  public void setDestinationTaxAddressSource(
+      final Constants.DestinationTaxAddressSource destinationTaxAddressSource) {
+    this.destinationTaxAddressSource = destinationTaxAddressSource;
+  }
+
   /** If this date is provided, it indicates the end of a time range. */
   public DateTime getEndDate() {
     return this.endDate;
@@ -360,6 +422,23 @@ public class LineItemCreate extends Request {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and
    * `type` is `credit`. Set this value in order to track gift card credits from external gift cards
    * (like InComm). It also skips billing information requirements. Origin `prepayment` is only
@@ -380,6 +459,43 @@ public class LineItemCreate extends Request {
    */
   public void setOrigin(final Constants.LineItemCreateOrigin origin) {
     this.origin = origin;
+  }
+
+  /**
+   * The source of the address that will be used as the origin in determining taxes. Available only
+   * when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax
+   * address". A value of "destination" refers to the "Customer tax address".
+   */
+  public Constants.OriginTaxAddressSource getOriginTaxAddressSource() {
+    return this.originTaxAddressSource;
+  }
+
+  /**
+   * @param originTaxAddressSource The source of the address that will be used as the origin in
+   *     determining taxes. Available only when the site is on an Elite plan. A value of "origin"
+   *     refers to the "Business entity tax address". A value of "destination" refers to the
+   *     "Customer tax address".
+   */
+  public void setOriginTaxAddressSource(
+      final Constants.OriginTaxAddressSource originTaxAddressSource) {
+    this.originTaxAddressSource = originTaxAddressSource;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
   }
 
   /**
@@ -416,6 +532,22 @@ public class LineItemCreate extends Request {
    */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/PlanCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanCreate.java
@@ -118,12 +118,28 @@ public class PlanCreate extends Request {
   private Constants.IntervalUnit intervalUnit;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's
    * invoice.
    */
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
 
   /**
    * A fixed pricing model has the same price for each billing period. A ramp pricing model defines
@@ -139,6 +155,14 @@ public class PlanCreate extends Request {
   @Expose
   private List<PlanRampInterval> rampIntervals;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
+
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
   @Expose
@@ -151,6 +175,30 @@ public class PlanCreate extends Request {
   @SerializedName("setup_fee_accounting_code")
   @Expose
   private String setupFeeAccountingCode;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("setup_fee_liability_gl_account_id")
+  @Expose
+  private String setupFeeLiabilityGlAccountId;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("setup_fee_performance_obligation_id")
+  @Expose
+  private String setupFeePerformanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("setup_fee_revenue_gl_account_id")
+  @Expose
+  private String setupFeeRevenueGlAccountId;
 
   /** Setup fee revenue schedule type */
   @SerializedName("setup_fee_revenue_schedule_type")
@@ -402,6 +450,23 @@ public class PlanCreate extends Request {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's
    * invoice.
    */
@@ -415,6 +480,23 @@ public class PlanCreate extends Request {
    */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
   }
 
   /**
@@ -445,6 +527,22 @@ public class PlanCreate extends Request {
     this.rampIntervals = rampIntervals;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
+  }
+
   /** Revenue schedule type */
   public Constants.RevenueScheduleType getRevenueScheduleType() {
     return this.revenueScheduleType;
@@ -469,6 +567,57 @@ public class PlanCreate extends Request {
    */
   public void setSetupFeeAccountingCode(final String setupFeeAccountingCode) {
     this.setupFeeAccountingCode = setupFeeAccountingCode;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getSetupFeeLiabilityGlAccountId() {
+    return this.setupFeeLiabilityGlAccountId;
+  }
+
+  /**
+   * @param setupFeeLiabilityGlAccountId The ID of a general ledger account. General ledger accounts
+   *     are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setSetupFeeLiabilityGlAccountId(final String setupFeeLiabilityGlAccountId) {
+    this.setupFeeLiabilityGlAccountId = setupFeeLiabilityGlAccountId;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getSetupFeePerformanceObligationId() {
+    return this.setupFeePerformanceObligationId;
+  }
+
+  /**
+   * @param setupFeePerformanceObligationId The ID of a performance obligation. Performance
+   *     obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec
+   *     Advanced features.
+   */
+  public void setSetupFeePerformanceObligationId(final String setupFeePerformanceObligationId) {
+    this.setupFeePerformanceObligationId = setupFeePerformanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getSetupFeeRevenueGlAccountId() {
+    return this.setupFeeRevenueGlAccountId;
+  }
+
+  /**
+   * @param setupFeeRevenueGlAccountId The ID of a general ledger account. General ledger accounts
+   *     are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setSetupFeeRevenueGlAccountId(final String setupFeeRevenueGlAccountId) {
+    this.setupFeeRevenueGlAccountId = setupFeeRevenueGlAccountId;
   }
 
   /** Setup fee revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/PlanUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanUpdate.java
@@ -108,6 +108,14 @@ public class PlanUpdate extends Request {
   private String id;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's
    * invoice.
    */
@@ -115,10 +123,26 @@ public class PlanUpdate extends Request {
   @Expose
   private String name;
 
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
   /** Ramp Intervals */
   @SerializedName("ramp_intervals")
   @Expose
   private List<PlanRampInterval> rampIntervals;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -132,6 +156,30 @@ public class PlanUpdate extends Request {
   @SerializedName("setup_fee_accounting_code")
   @Expose
   private String setupFeeAccountingCode;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("setup_fee_liability_gl_account_id")
+  @Expose
+  private String setupFeeLiabilityGlAccountId;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("setup_fee_performance_obligation_id")
+  @Expose
+  private String setupFeePerformanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("setup_fee_revenue_gl_account_id")
+  @Expose
+  private String setupFeeRevenueGlAccountId;
 
   /** Setup fee revenue schedule type */
   @SerializedName("setup_fee_revenue_schedule_type")
@@ -363,6 +411,23 @@ public class PlanUpdate extends Request {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * This name describes your plan and will appear on the Hosted Payment Page and the subscriber's
    * invoice.
    */
@@ -378,6 +443,23 @@ public class PlanUpdate extends Request {
     this.name = name;
   }
 
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
   /** Ramp Intervals */
   public List<PlanRampInterval> getRampIntervals() {
     return this.rampIntervals;
@@ -386,6 +468,22 @@ public class PlanUpdate extends Request {
   /** @param rampIntervals Ramp Intervals */
   public void setRampIntervals(final List<PlanRampInterval> rampIntervals) {
     this.rampIntervals = rampIntervals;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /** Revenue schedule type */
@@ -412,6 +510,57 @@ public class PlanUpdate extends Request {
    */
   public void setSetupFeeAccountingCode(final String setupFeeAccountingCode) {
     this.setupFeeAccountingCode = setupFeeAccountingCode;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getSetupFeeLiabilityGlAccountId() {
+    return this.setupFeeLiabilityGlAccountId;
+  }
+
+  /**
+   * @param setupFeeLiabilityGlAccountId The ID of a general ledger account. General ledger accounts
+   *     are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setSetupFeeLiabilityGlAccountId(final String setupFeeLiabilityGlAccountId) {
+    this.setupFeeLiabilityGlAccountId = setupFeeLiabilityGlAccountId;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getSetupFeePerformanceObligationId() {
+    return this.setupFeePerformanceObligationId;
+  }
+
+  /**
+   * @param setupFeePerformanceObligationId The ID of a performance obligation. Performance
+   *     obligations are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec
+   *     Advanced features.
+   */
+  public void setSetupFeePerformanceObligationId(final String setupFeePerformanceObligationId) {
+    this.setupFeePerformanceObligationId = setupFeePerformanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getSetupFeeRevenueGlAccountId() {
+    return this.setupFeeRevenueGlAccountId;
+  }
+
+  /**
+   * @param setupFeeRevenueGlAccountId The ID of a general ledger account. General ledger accounts
+   *     are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setSetupFeeRevenueGlAccountId(final String setupFeeRevenueGlAccountId) {
+    this.setupFeeRevenueGlAccountId = setupFeeRevenueGlAccountId;
   }
 
   /** Setup fee revenue schedule type */

--- a/src/main/java/com/recurly/v3/requests/ShippingMethodCreate.java
+++ b/src/main/java/com/recurly/v3/requests/ShippingMethodCreate.java
@@ -22,10 +22,34 @@ public class ShippingMethodCreate extends Request {
   @Expose
   private String code;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
   /** The name of the shipping method displayed to customers. */
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific
@@ -60,6 +84,23 @@ public class ShippingMethodCreate extends Request {
     this.code = code;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
   /** The name of the shipping method displayed to customers. */
   public String getName() {
     return this.name;
@@ -68,6 +109,39 @@ public class ShippingMethodCreate extends Request {
   /** @param name The name of the shipping method displayed to customers. */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/ShippingMethodUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/ShippingMethodUpdate.java
@@ -22,10 +22,34 @@ public class ShippingMethodUpdate extends Request {
   @Expose
   private String code;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
   /** The name of the shipping method displayed to customers. */
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific
@@ -60,6 +84,23 @@ public class ShippingMethodUpdate extends Request {
     this.code = code;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
   /** The name of the shipping method displayed to customers. */
   public String getName() {
     return this.name;
@@ -68,6 +109,39 @@ public class ShippingMethodUpdate extends Request {
   /** @param name The name of the shipping method displayed to customers. */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/AddOn.java
+++ b/src/main/java/com/recurly/v3/resources/AddOn.java
@@ -93,6 +93,14 @@ public class AddOn extends Resource {
   @Expose
   private ItemMini item;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
   /** System-generated unique identifier for an measured unit associated with the add-on. */
   @SerializedName("measured_unit_id")
   @Expose
@@ -126,10 +134,26 @@ public class AddOn extends Resource {
   @Expose
   private List<PercentageTiersByCurrency> percentageTiers;
 
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
   /** Plan ID */
   @SerializedName("plan_id")
   @Expose
   private String planId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * When this add-on is invoiced, the line item will use this revenue schedule. If
@@ -363,6 +387,23 @@ public class AddOn extends Resource {
     this.item = item;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
   /** System-generated unique identifier for an measured unit associated with the add-on. */
   public String getMeasuredUnitId() {
     return this.measuredUnitId;
@@ -432,6 +473,23 @@ public class AddOn extends Resource {
     this.percentageTiers = percentageTiers;
   }
 
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
   /** Plan ID */
   public String getPlanId() {
     return this.planId;
@@ -440,6 +498,22 @@ public class AddOn extends Resource {
   /** @param planId Plan ID */
   public void setPlanId(final String planId) {
     this.planId = planId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/BusinessEntity.java
+++ b/src/main/java/com/recurly/v3/resources/BusinessEntity.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -23,15 +24,40 @@ public class BusinessEntity extends Resource {
   @Expose
   private DateTime createdAt;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("default_liability_gl_account_id")
+  @Expose
+  private String defaultLiabilityGlAccountId;
+
   /** Registration number for the customer used on the invoice. */
   @SerializedName("default_registration_number")
   @Expose
   private String defaultRegistrationNumber;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("default_revenue_gl_account_id")
+  @Expose
+  private String defaultRevenueGlAccountId;
+
   /** VAT number for the customer used on the invoice. */
   @SerializedName("default_vat_number")
   @Expose
   private String defaultVatNumber;
+
+  /**
+   * The source of the address that will be used as the destinaion in determining taxes. Available
+   * only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax
+   * address". A value of "origin" refers to the "Business entity tax address".
+   */
+  @SerializedName("destination_tax_address_source")
+  @Expose
+  private Constants.DestinationTaxAddressSource destinationTaxAddressSource;
 
   /** Business entity ID */
   @SerializedName("id")
@@ -52,6 +78,15 @@ public class BusinessEntity extends Resource {
   @SerializedName("object")
   @Expose
   private String object;
+
+  /**
+   * The source of the address that will be used as the origin in determining taxes. Available only
+   * when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax
+   * address". A value of "destination" refers to the "Customer tax address".
+   */
+  @SerializedName("origin_tax_address_source")
+  @Expose
+  private Constants.OriginTaxAddressSource originTaxAddressSource;
 
   /** List of countries for which the business entity will be used. */
   @SerializedName("subscriber_location_countries")
@@ -88,6 +123,23 @@ public class BusinessEntity extends Resource {
     this.createdAt = createdAt;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getDefaultLiabilityGlAccountId() {
+    return this.defaultLiabilityGlAccountId;
+  }
+
+  /**
+   * @param defaultLiabilityGlAccountId The ID of a general ledger account. General ledger accounts
+   *     are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setDefaultLiabilityGlAccountId(final String defaultLiabilityGlAccountId) {
+    this.defaultLiabilityGlAccountId = defaultLiabilityGlAccountId;
+  }
+
   /** Registration number for the customer used on the invoice. */
   public String getDefaultRegistrationNumber() {
     return this.defaultRegistrationNumber;
@@ -98,6 +150,23 @@ public class BusinessEntity extends Resource {
     this.defaultRegistrationNumber = defaultRegistrationNumber;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getDefaultRevenueGlAccountId() {
+    return this.defaultRevenueGlAccountId;
+  }
+
+  /**
+   * @param defaultRevenueGlAccountId The ID of a general ledger account. General ledger accounts
+   *     are only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setDefaultRevenueGlAccountId(final String defaultRevenueGlAccountId) {
+    this.defaultRevenueGlAccountId = defaultRevenueGlAccountId;
+  }
+
   /** VAT number for the customer used on the invoice. */
   public String getDefaultVatNumber() {
     return this.defaultVatNumber;
@@ -106,6 +175,26 @@ public class BusinessEntity extends Resource {
   /** @param defaultVatNumber VAT number for the customer used on the invoice. */
   public void setDefaultVatNumber(final String defaultVatNumber) {
     this.defaultVatNumber = defaultVatNumber;
+  }
+
+  /**
+   * The source of the address that will be used as the destinaion in determining taxes. Available
+   * only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax
+   * address". A value of "origin" refers to the "Business entity tax address".
+   */
+  public Constants.DestinationTaxAddressSource getDestinationTaxAddressSource() {
+    return this.destinationTaxAddressSource;
+  }
+
+  /**
+   * @param destinationTaxAddressSource The source of the address that will be used as the
+   *     destinaion in determining taxes. Available only when the site is on an Elite plan. A value
+   *     of "destination" refers to the "Customer tax address". A value of "origin" refers to the
+   *     "Business entity tax address".
+   */
+  public void setDestinationTaxAddressSource(
+      final Constants.DestinationTaxAddressSource destinationTaxAddressSource) {
+    this.destinationTaxAddressSource = destinationTaxAddressSource;
   }
 
   /** Business entity ID */
@@ -149,6 +238,26 @@ public class BusinessEntity extends Resource {
   /** @param object Object type */
   public void setObject(final String object) {
     this.object = object;
+  }
+
+  /**
+   * The source of the address that will be used as the origin in determining taxes. Available only
+   * when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax
+   * address". A value of "destination" refers to the "Customer tax address".
+   */
+  public Constants.OriginTaxAddressSource getOriginTaxAddressSource() {
+    return this.originTaxAddressSource;
+  }
+
+  /**
+   * @param originTaxAddressSource The source of the address that will be used as the origin in
+   *     determining taxes. Available only when the site is on an Elite plan. A value of "origin"
+   *     refers to the "Business entity tax address". A value of "destination" refers to the
+   *     "Customer tax address".
+   */
+  public void setOriginTaxAddressSource(
+      final Constants.OriginTaxAddressSource originTaxAddressSource) {
+    this.originTaxAddressSource = originTaxAddressSource;
   }
 
   /** List of countries for which the business entity will be used. */

--- a/src/main/java/com/recurly/v3/resources/ExternalPaymentPhase.java
+++ b/src/main/java/com/recurly/v3/resources/ExternalPaymentPhase.java
@@ -37,11 +37,6 @@ public class ExternalPaymentPhase extends Resource {
   @Expose
   private DateTime endsAt;
 
-  /** Subscription from an external resource such as Apple App Store or Google Play Store. */
-  @SerializedName("external_subscription")
-  @Expose
-  private ExternalSubscription externalSubscription;
-
   /** System-generated unique identifier for an external payment phase ID, e.g. `e28zov4fw0v2`. */
   @SerializedName("id")
   @Expose
@@ -135,19 +130,6 @@ public class ExternalPaymentPhase extends Resource {
   /** @param endsAt Ends At */
   public void setEndsAt(final DateTime endsAt) {
     this.endsAt = endsAt;
-  }
-
-  /** Subscription from an external resource such as Apple App Store or Google Play Store. */
-  public ExternalSubscription getExternalSubscription() {
-    return this.externalSubscription;
-  }
-
-  /**
-   * @param externalSubscription Subscription from an external resource such as Apple App Store or
-   *     Google Play Store.
-   */
-  public void setExternalSubscription(final ExternalSubscription externalSubscription) {
-    this.externalSubscription = externalSubscription;
   }
 
   /** System-generated unique identifier for an external payment phase ID, e.g. `e28zov4fw0v2`. */

--- a/src/main/java/com/recurly/v3/resources/ExternalSubscription.java
+++ b/src/main/java/com/recurly/v3/resources/ExternalSubscription.java
@@ -8,6 +8,7 @@ package com.recurly.v3.resources;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Resource;
+import java.util.List;
 import org.joda.time.DateTime;
 
 public class ExternalSubscription extends Resource {
@@ -57,6 +58,11 @@ public class ExternalSubscription extends Resource {
   @Expose
   private String externalId;
 
+  /** The phases of the external subscription payment lifecycle. */
+  @SerializedName("external_payment_phases")
+  @Expose
+  private List<ExternalPaymentPhase> externalPaymentPhases;
+
   /** External Product Reference details */
   @SerializedName("external_product_reference")
   @Expose
@@ -66,6 +72,14 @@ public class ExternalSubscription extends Resource {
   @SerializedName("id")
   @Expose
   private String id;
+
+  /**
+   * An indication of whether or not the external subscription was created by a historical data
+   * import.
+   */
+  @SerializedName("imported")
+  @Expose
+  private Boolean imported;
 
   /** An indication of whether or not the external subscription is in a grace period. */
   @SerializedName("in_grace_period")
@@ -211,6 +225,16 @@ public class ExternalSubscription extends Resource {
     this.externalId = externalId;
   }
 
+  /** The phases of the external subscription payment lifecycle. */
+  public List<ExternalPaymentPhase> getExternalPaymentPhases() {
+    return this.externalPaymentPhases;
+  }
+
+  /** @param externalPaymentPhases The phases of the external subscription payment lifecycle. */
+  public void setExternalPaymentPhases(final List<ExternalPaymentPhase> externalPaymentPhases) {
+    this.externalPaymentPhases = externalPaymentPhases;
+  }
+
   /** External Product Reference details */
   public ExternalProductReferenceMini getExternalProductReference() {
     return this.externalProductReference;
@@ -233,6 +257,22 @@ public class ExternalSubscription extends Resource {
    */
   public void setId(final String id) {
     this.id = id;
+  }
+
+  /**
+   * An indication of whether or not the external subscription was created by a historical data
+   * import.
+   */
+  public Boolean getImported() {
+    return this.imported;
+  }
+
+  /**
+   * @param imported An indication of whether or not the external subscription was created by a
+   *     historical data import.
+   */
+  public void setImported(final Boolean imported) {
+    this.imported = imported;
   }
 
   /** An indication of whether or not the external subscription is in a grace period. */

--- a/src/main/java/com/recurly/v3/resources/GeneralLedgerAccount.java
+++ b/src/main/java/com/recurly/v3/resources/GeneralLedgerAccount.java
@@ -1,0 +1,136 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
+import com.recurly.v3.Resource;
+import org.joda.time.DateTime;
+
+public class GeneralLedgerAccount extends Resource {
+
+  @SerializedName("account_type")
+  @Expose
+  private Constants.GeneralLedgerAccountType accountType;
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  @SerializedName("code")
+  @Expose
+  private String code;
+
+  /** Created at */
+  @SerializedName("created_at")
+  @Expose
+  private DateTime createdAt;
+
+  /** Optional description. */
+  @SerializedName("description")
+  @Expose
+  private String description;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("id")
+  @Expose
+  private String id;
+
+  /** Object type */
+  @SerializedName("object")
+  @Expose
+  private String object;
+
+  /** Last updated at */
+  @SerializedName("updated_at")
+  @Expose
+  private DateTime updatedAt;
+
+  public Constants.GeneralLedgerAccountType getAccountType() {
+    return this.accountType;
+  }
+
+  /** @param accountType */
+  public void setAccountType(final Constants.GeneralLedgerAccountType accountType) {
+    this.accountType = accountType;
+  }
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  public String getCode() {
+    return this.code;
+  }
+
+  /**
+   * @param code Unique code to identify the ledger account. Each code must start with a letter or
+   *     number. The following special characters are allowed: `-_.,:`
+   */
+  public void setCode(final String code) {
+    this.code = code;
+  }
+
+  /** Created at */
+  public DateTime getCreatedAt() {
+    return this.createdAt;
+  }
+
+  /** @param createdAt Created at */
+  public void setCreatedAt(final DateTime createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  /** Optional description. */
+  public String getDescription() {
+    return this.description;
+  }
+
+  /** @param description Optional description. */
+  public void setDescription(final String description) {
+    this.description = description;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getId() {
+    return this.id;
+  }
+
+  /**
+   * @param id The ID of a general ledger account. General ledger accounts are only accessible as a
+   *     part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  /** Object type */
+  public String getObject() {
+    return this.object;
+  }
+
+  /** @param object Object type */
+  public void setObject(final String object) {
+    this.object = object;
+  }
+
+  /** Last updated at */
+  public DateTime getUpdatedAt() {
+    return this.updatedAt;
+  }
+
+  /** @param updatedAt Last updated at */
+  public void setUpdatedAt(final DateTime updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/GiftCard.java
+++ b/src/main/java/com/recurly/v3/resources/GiftCard.java
@@ -61,10 +61,26 @@ public class GiftCard extends Resource {
   @Expose
   private String id;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
   /** Object type */
   @SerializedName("object")
   @Expose
   private String object;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
 
   /** The product code or SKU of the gift card product. */
   @SerializedName("product_code")
@@ -105,6 +121,14 @@ public class GiftCard extends Resource {
   @SerializedName("redemption_invoice_id")
   @Expose
   private String redemptionInvoiceId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * The amount of the gift card, which is the amount of the charge to the gifter account and the
@@ -215,6 +239,23 @@ public class GiftCard extends Resource {
     this.id = id;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
   /** Object type */
   public String getObject() {
     return this.object;
@@ -223,6 +264,23 @@ public class GiftCard extends Resource {
   /** @param object Object type */
   public void setObject(final String object) {
     this.object = object;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
   }
 
   /** The product code or SKU of the gift card product. */
@@ -306,6 +364,22 @@ public class GiftCard extends Resource {
    */
   public void setRedemptionInvoiceId(final String redemptionInvoiceId) {
     this.redemptionInvoiceId = redemptionInvoiceId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/Item.java
+++ b/src/main/java/com/recurly/v3/resources/Item.java
@@ -84,6 +84,14 @@ public class Item extends Resource {
   private String id;
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
+  /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time
    * basis.
    */
@@ -95,6 +103,22 @@ public class Item extends Resource {
   @SerializedName("object")
   @Expose
   private String object;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -266,6 +290,23 @@ public class Item extends Resource {
   }
 
   /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
+  /**
    * This name describes your item and will appear on the invoice when it's purchased on a one time
    * basis.
    */
@@ -289,6 +330,39 @@ public class Item extends Resource {
   /** @param object Object type */
   public void setObject(final String object) {
     this.object = object;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -107,6 +107,15 @@ public class LineItem extends Resource {
   @Expose
   private String description;
 
+  /**
+   * The source of the address that will be used as the destinaion in determining taxes. Available
+   * only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax
+   * address". A value of "origin" refers to the "Business entity tax address".
+   */
+  @SerializedName("destination_tax_address_source")
+  @Expose
+  private Constants.DestinationTaxAddressSource destinationTaxAddressSource;
+
   /** The discount applied to the line item. */
   @SerializedName("discount")
   @Expose
@@ -170,6 +179,14 @@ public class LineItem extends Resource {
   @Expose
   private Constants.LegacyCategory legacyCategory;
 
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  @SerializedName("liability_gl_account_code")
+  @Expose
+  private String liabilityGlAccountCode;
+
   /** Object type */
   @SerializedName("object")
   @Expose
@@ -181,12 +198,29 @@ public class LineItem extends Resource {
   private Constants.LineItemOrigin origin;
 
   /**
+   * The source of the address that will be used as the origin in determining taxes. Available only
+   * when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax
+   * address". A value of "destination" refers to the "Customer tax address".
+   */
+  @SerializedName("origin_tax_address_source")
+  @Expose
+  private Constants.OriginTaxAddressSource originTaxAddressSource;
+
+  /**
    * The invoice where the credit originated. Will only have a value if the line item is a credit
    * created from a previous credit, or if the credit was created from a charge refund.
    */
   @SerializedName("original_line_item_invoice_id")
   @Expose
   private String originalLineItemInvoiceId;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
 
   /** If the line item is a charge or credit for a plan or add-on, this is the plan's code. */
   @SerializedName("plan_code")
@@ -262,6 +296,14 @@ public class LineItem extends Resource {
   @SerializedName("refunded_quantity_decimal")
   @Expose
   private String refundedQuantityDecimal;
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  @SerializedName("revenue_gl_account_code")
+  @Expose
+  private String revenueGlAccountCode;
 
   /** Revenue schedule type */
   @SerializedName("revenue_schedule_type")
@@ -555,6 +597,26 @@ public class LineItem extends Resource {
     this.description = description;
   }
 
+  /**
+   * The source of the address that will be used as the destinaion in determining taxes. Available
+   * only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax
+   * address". A value of "origin" refers to the "Business entity tax address".
+   */
+  public Constants.DestinationTaxAddressSource getDestinationTaxAddressSource() {
+    return this.destinationTaxAddressSource;
+  }
+
+  /**
+   * @param destinationTaxAddressSource The source of the address that will be used as the
+   *     destinaion in determining taxes. Available only when the site is on an Elite plan. A value
+   *     of "destination" refers to the "Customer tax address". A value of "origin" refers to the
+   *     "Business entity tax address".
+   */
+  public void setDestinationTaxAddressSource(
+      final Constants.DestinationTaxAddressSource destinationTaxAddressSource) {
+    this.destinationTaxAddressSource = destinationTaxAddressSource;
+  }
+
   /** The discount applied to the line item. */
   public BigDecimal getDiscount() {
     return this.discount;
@@ -685,6 +747,22 @@ public class LineItem extends Resource {
     this.legacyCategory = legacyCategory;
   }
 
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  public String getLiabilityGlAccountCode() {
+    return this.liabilityGlAccountCode;
+  }
+
+  /**
+   * @param liabilityGlAccountCode Unique code to identify the ledger account. Each code must start
+   *     with a letter or number. The following special characters are allowed: `-_.,:`
+   */
+  public void setLiabilityGlAccountCode(final String liabilityGlAccountCode) {
+    this.liabilityGlAccountCode = liabilityGlAccountCode;
+  }
+
   /** Object type */
   public String getObject() {
     return this.object;
@@ -709,6 +787,26 @@ public class LineItem extends Resource {
   }
 
   /**
+   * The source of the address that will be used as the origin in determining taxes. Available only
+   * when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax
+   * address". A value of "destination" refers to the "Customer tax address".
+   */
+  public Constants.OriginTaxAddressSource getOriginTaxAddressSource() {
+    return this.originTaxAddressSource;
+  }
+
+  /**
+   * @param originTaxAddressSource The source of the address that will be used as the origin in
+   *     determining taxes. Available only when the site is on an Elite plan. A value of "origin"
+   *     refers to the "Business entity tax address". A value of "destination" refers to the
+   *     "Customer tax address".
+   */
+  public void setOriginTaxAddressSource(
+      final Constants.OriginTaxAddressSource originTaxAddressSource) {
+    this.originTaxAddressSource = originTaxAddressSource;
+  }
+
+  /**
    * The invoice where the credit originated. Will only have a value if the line item is a credit
    * created from a previous credit, or if the credit was created from a charge refund.
    */
@@ -723,6 +821,23 @@ public class LineItem extends Resource {
    */
   public void setOriginalLineItemInvoiceId(final String originalLineItemInvoiceId) {
     this.originalLineItemInvoiceId = originalLineItemInvoiceId;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
   }
 
   /** If the line item is a charge or credit for a plan or add-on, this is the plan's code. */
@@ -882,6 +997,22 @@ public class LineItem extends Resource {
    */
   public void setRefundedQuantityDecimal(final String refundedQuantityDecimal) {
     this.refundedQuantityDecimal = refundedQuantityDecimal;
+  }
+
+  /**
+   * Unique code to identify the ledger account. Each code must start with a letter or number. The
+   * following special characters are allowed: `-_.,:`
+   */
+  public String getRevenueGlAccountCode() {
+    return this.revenueGlAccountCode;
+  }
+
+  /**
+   * @param revenueGlAccountCode Unique code to identify the ledger account. Each code must start
+   *     with a letter or number. The following special characters are allowed: `-_.,:`
+   */
+  public void setRevenueGlAccountCode(final String revenueGlAccountCode) {
+    this.revenueGlAccountCode = revenueGlAccountCode;
   }
 
   /** Revenue schedule type */

--- a/src/main/java/com/recurly/v3/resources/PerformanceObligation.java
+++ b/src/main/java/com/recurly/v3/resources/PerformanceObligation.java
@@ -1,0 +1,83 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+import org.joda.time.DateTime;
+
+public class PerformanceObligation extends Resource {
+
+  /** Created At */
+  @SerializedName("created_at")
+  @Expose
+  private DateTime createdAt;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("id")
+  @Expose
+  private String id;
+
+  /** Performance Obligation Name */
+  @SerializedName("name")
+  @Expose
+  private String name;
+
+  /** Last updated at */
+  @SerializedName("updated_at")
+  @Expose
+  private DateTime updatedAt;
+
+  /** Created At */
+  public DateTime getCreatedAt() {
+    return this.createdAt;
+  }
+
+  /** @param createdAt Created At */
+  public void setCreatedAt(final DateTime createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getId() {
+    return this.id;
+  }
+
+  /**
+   * @param id The ID of a performance obligation. Performance obligations are only accessible as a
+   *     part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  /** Performance Obligation Name */
+  public String getName() {
+    return this.name;
+  }
+
+  /** @param name Performance Obligation Name */
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  /** Last updated at */
+  public DateTime getUpdatedAt() {
+    return this.updatedAt;
+  }
+
+  /** @param updatedAt Last updated at */
+  public void setUpdatedAt(final DateTime updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/ShippingMethod.java
+++ b/src/main/java/com/recurly/v3/resources/ShippingMethod.java
@@ -37,6 +37,14 @@ public class ShippingMethod extends Resource {
   @Expose
   private String id;
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("liability_gl_account_id")
+  @Expose
+  private String liabilityGlAccountId;
+
   /** The name of the shipping method displayed to customers. */
   @SerializedName("name")
   @Expose
@@ -46,6 +54,22 @@ public class ShippingMethod extends Resource {
   @SerializedName("object")
   @Expose
   private String object;
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("performance_obligation_id")
+  @Expose
+  private String performanceObligationId;
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  @SerializedName("revenue_gl_account_id")
+  @Expose
+  private String revenueGlAccountId;
 
   /**
    * Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax code values are specific
@@ -115,6 +139,23 @@ public class ShippingMethod extends Resource {
     this.id = id;
   }
 
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getLiabilityGlAccountId() {
+    return this.liabilityGlAccountId;
+  }
+
+  /**
+   * @param liabilityGlAccountId The ID of a general ledger account. General ledger accounts are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setLiabilityGlAccountId(final String liabilityGlAccountId) {
+    this.liabilityGlAccountId = liabilityGlAccountId;
+  }
+
   /** The name of the shipping method displayed to customers. */
   public String getName() {
     return this.name;
@@ -133,6 +174,39 @@ public class ShippingMethod extends Resource {
   /** @param object Object type */
   public void setObject(final String object) {
     this.object = object;
+  }
+
+  /**
+   * The ID of a performance obligation. Performance obligations are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getPerformanceObligationId() {
+    return this.performanceObligationId;
+  }
+
+  /**
+   * @param performanceObligationId The ID of a performance obligation. Performance obligations are
+   *     only accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced
+   *     features.
+   */
+  public void setPerformanceObligationId(final String performanceObligationId) {
+    this.performanceObligationId = performanceObligationId;
+  }
+
+  /**
+   * The ID of a general ledger account. General ledger accounts are only accessible as a part of
+   * the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public String getRevenueGlAccountId() {
+    return this.revenueGlAccountId;
+  }
+
+  /**
+   * @param revenueGlAccountId The ID of a general ledger account. General ledger accounts are only
+   *     accessible as a part of the Recurly RevRec Standard and Recurly RevRec Advanced features.
+   */
+  public void setRevenueGlAccountId(final String revenueGlAccountId) {
+    this.revenueGlAccountId = revenueGlAccountId;
   }
 
   /**


### PR DESCRIPTION
**Taxable Address Control**
* GET external_subscription by external-id
* Add `destination_tax_address_source` and `origin_tax_address_source` to line_item and business_entity resources

**RevRec**
*  list_general_ledger_accounts
* get_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* update_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* get_performance_obligations
* get_performance_obligation by `performance_obligation_id`
* Add `default_liability_gl_account_id` and `default_revenue_gl_account_id` to business_entity resource
* Add `liability_gl_account_id`, `revenue_gl_account_id`, and `performance_obligation_id` to the following resources
    - add_on
    - business_entity
    - gift_card
    - item
    - shipping_method
* Add `liability_gl_account_code` and `revenue_gl_account_code` to line_item resource