### PR TITLE
Breaking change: The constant RefuneMethod Enum has been renamed RefundMethod

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18148,11 +18148,14 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of
+            the request then `tax_code` must be absent.
         display_quantity:
           type: boolean
           title: Display quantity?
@@ -18367,14 +18370,14 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part
-            of the request then `tax_code` must be absent.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of
+            the request then `tax_code` must be absent.
         currencies:
           type: array
           title: Add-on pricing
@@ -18522,14 +18525,14 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`. If an `Item` is associated to the
-            `AddOn` then `tax code` must be absent.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes. If an `Item` is associated to the
+            `AddOn` then `tax_code` must be absent.
         display_quantity:
           type: boolean
           title: Display quantity?
@@ -19808,11 +19811,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -19916,11 +19921,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20012,11 +20019,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20466,7 +20475,16 @@ components:
           title: Amount
           description: |
             The amount to be refunded. The amount will be split between the line items.
-            If no amount is specified, it will default to refunding the total refundable amount on the invoice.
+            If `type` is "amount" and no amount is specified, it will default to refunding the total refundable amount on the invoice. Can only be present if `type` is "amount".
+        percentage:
+          type: integer
+          title: Percentage
+          description: The percentage of the remaining balance to be refunded. The
+            percentage will be split between the line items. If `type` is "percentage"
+            and no percentage is specified, it will default to refunding 100% of the
+            refundable amount on the invoice. Can only be present if `type` is "percentage".
+          minimum: 1
+          maximum: 100
         line_items:
           type: array
           title: Line items
@@ -20482,7 +20500,7 @@ components:
             - `all_credit` – Issues credit to the account for the entire amount of the refund. Only available when the Credit Invoices feature is enabled.
             - `all_transaction` – Refunds the entire amount back to transactions, using transactions from previous invoices if necessary. Only available when the Credit Invoices feature is enabled.
           default: credit_first
-          "$ref": "#/components/schemas/RefuneMethodEnum"
+          "$ref": "#/components/schemas/RefundMethodEnum"
         credit_customer_notes:
           type: string
           title: Credit customer notes
@@ -20873,11 +20891,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
         origin_tax_address_source:
@@ -20951,15 +20971,35 @@ components:
         quantity:
           type: integer
           title: Quantity
-          description: Line item quantity to be refunded.
+          description: Line item quantity to be refunded. Must be less than or equal
+            to the `quantity_remaining`. If `quantity_decimal`, `amount`, and `percentage`
+            are not present, `quantity` is required. If `amount` or `percentage` is
+            present, `quantity` must be absent.
         quantity_decimal:
           type: string
           title: Quantity Decimal
-          description: A floating-point alternative to Quantity. If this value is
-            present, it will be used in place of Quantity for calculations, and Quantity
-            will be the rounded integer value of this number. This field supports
-            up to 9 decimal places. The Decimal Quantity feature must be enabled to
-            utilize this field.
+          description: Decimal quantity to refund. The `quantity_decimal` will be
+            used to refund charges that has a NOT null quantity decimal. Must be less
+            than or equal to the `quantity_decimal_remaining`. If `quantity`, `amount`,
+            and `percentage` are not present, `quantity_decimal` is required. If `amount`
+            or `percentage` is present, `quantity_decimal` must be absent. The Decimal
+            Quantity feature must be enabled to utilize this field.
+        amount:
+          type: number
+          format: float
+          description: The specific amount to be refunded from the adjustment. Must
+            be less than or equal to the adjustment's remaining balance. If `quantity`,
+            `quantity_decimal` and `percentage` are not present, `amount` is required.
+            If `quantity`, `quantity_decimal`, or `percentage` is present, `amount`
+            must be absent.
+        percentage:
+          type: integer
+          description: The percentage of the adjustment's remaining balance to refund.
+            If `quantity`, `quantity_decimal` and `amount_in_cents` are not present,
+            `percentage` is required. If `quantity`, `quantity_decimal` or `amount_in_cents`
+            is present, `percentage` must be absent.
+          minimum: 1
+          maximum: 100
         prorate:
           type: boolean
           title: Prorate
@@ -21095,13 +21135,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         product_code:
           type: string
           title: Product code
@@ -21299,11 +21339,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Used by Avalara, Vertex, and Recurly’s EU VAT tax feature.
-            The tax code values are specific to each tax system. If you are using
-            Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -21512,13 +21554,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -21776,13 +21818,13 @@ components:
           minimum: 0
         tax_code:
           type: string
-          title: Tax code
-          description: Optional field used by Avalara, Vertex, and Recurly's EU VAT
-            tax feature to determine taxation rules. If you have your own AvaTax or
-            Vertex account configured, use their tax codes to assign specific tax
-            rules. If you are using Recurly's EU VAT feature, you can use values of
-            `unknown`, `physical`, or `digital`.
           maxLength: 50
+          title: Tax code
+          description: Optional field used by Avalara, Vertex, and Recurly's In-the-Box
+            tax solution to determine taxation rules. You can pass in specific tax
+            codes using any of these tax integrations. For Recurly's In-the-Box tax
+            offering you can also choose to instead use simple values of `unknown`,
+            `physical`, or `digital` tax codes.
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -26231,8 +26273,9 @@ components:
       type: string
       enum:
       - amount
+      - percentage
       - line_items
-    RefuneMethodEnum:
+    RefundMethodEnum:
       type: string
       enum:
       - all_credit
@@ -26246,6 +26289,7 @@ components:
       - ach
       - amazon
       - apple_pay
+      - braintree_apple_pay
       - check
       - credit_card
       - eft
@@ -26439,6 +26483,7 @@ components:
       - amazon_billing_agreement
       - apple_pay
       - bank_account_info
+      - braintree_apple_pay
       - check
       - credit_card
       - eft

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -846,12 +846,15 @@ public class Constants {
       @SerializedName("amount")
       AMOUNT,
     
+      @SerializedName("percentage")
+      PERCENTAGE,
+    
       @SerializedName("line_items")
       LINE_ITEMS,
     
     };
   
-    public enum RefuneMethod {
+    public enum RefundMethod {
       UNDEFINED,
     
       @SerializedName("all_credit")
@@ -882,6 +885,9 @@ public class Constants {
     
       @SerializedName("apple_pay")
       APPLE_PAY,
+    
+      @SerializedName("braintree_apple_pay")
+      BRAINTREE_APPLE_PAY,
     
       @SerializedName("check")
       CHECK,
@@ -1381,6 +1387,9 @@ public class Constants {
     
       @SerializedName("bank_account_info")
       BANK_ACCOUNT_INFO,
+    
+      @SerializedName("braintree_apple_pay")
+      BRAINTREE_APPLE_PAY,
     
       @SerializedName("check")
       CHECK,

--- a/src/main/java/com/recurly/v3/requests/AddOnCreate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnCreate.java
@@ -182,11 +182,11 @@ public class AddOnCreate extends Request {
   private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`. If `item_code`/`item_id` is part of the request then `tax_code` must
-   * be absent.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request
+   * then `tax_code` must be absent.
    */
   @SerializedName("tax_code")
   @Expose
@@ -590,22 +590,22 @@ public class AddOnCreate extends Request {
   }
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`. If `item_code`/`item_id` is part of the request then `tax_code` must
-   * be absent.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request
+   * then `tax_code` must be absent.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to
-   *     determine taxation rules. If you have your own AvaTax or Vertex account configured, use
-   *     their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature,
-   *     you can use values of `unknown`, `physical`, or `digital`. If `item_code`/`item_id` is part
-   *     of the request then `tax_code` must be absent.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is
+   *     part of the request then `tax_code` must be absent.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/AddOnUpdate.java
@@ -156,11 +156,11 @@ public class AddOnUpdate extends Request {
   private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`. If an `Item` is associated to the `AddOn` then `tax code` must be
-   * absent.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes. If an `Item` is associated to the `AddOn` then
+   * `tax_code` must be absent.
    */
   @SerializedName("tax_code")
   @Expose
@@ -485,22 +485,22 @@ public class AddOnUpdate extends Request {
   }
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`. If an `Item` is associated to the `AddOn` then `tax code` must be
-   * absent.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes. If an `Item` is associated to the `AddOn` then
+   * `tax_code` must be absent.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to
-   *     determine taxation rules. If you have your own AvaTax or Vertex account configured, use
-   *     their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature,
-   *     you can use values of `unknown`, `physical`, or `digital`. If an `Item` is associated to
-   *     the `AddOn` then `tax code` must be absent.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes. If an `Item` is associated
+   *     to the `AddOn` then `tax_code` must be absent.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/requests/InvoiceRefund.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceRefund.java
@@ -16,8 +16,9 @@ import java.util.List;
 public class InvoiceRefund extends Request {
 
   /**
-   * The amount to be refunded. The amount will be split between the line items. If no amount is
-   * specified, it will default to refunding the total refundable amount on the invoice.
+   * The amount to be refunded. The amount will be split between the line items. If `type` is
+   * "amount" and no amount is specified, it will default to refunding the total refundable amount
+   * on the invoice. Can only be present if `type` is "amount".
    */
   @SerializedName("amount")
   @Expose
@@ -52,6 +53,16 @@ public class InvoiceRefund extends Request {
   private List<LineItemRefund> lineItems;
 
   /**
+   * The percentage of the remaining balance to be refunded. The percentage will be split between
+   * the line items. If `type` is "percentage" and no percentage is specified, it will default to
+   * refunding 100% of the refundable amount on the invoice. Can only be present if `type` is
+   * "percentage".
+   */
+  @SerializedName("percentage")
+  @Expose
+  private Integer percentage;
+
+  /**
    * Indicates how the invoice should be refunded when both a credit and transaction are present on
    * the invoice: - `transaction_first` – Refunds the transaction first, then any amount is issued
    * as credit back to the account. Default value when Credit Invoices feature is enabled. -
@@ -64,7 +75,7 @@ public class InvoiceRefund extends Request {
    */
   @SerializedName("refund_method")
   @Expose
-  private Constants.RefuneMethod refundMethod;
+  private Constants.RefundMethod refundMethod;
 
   /** The type of refund. Amount and line items cannot both be specified in the request. */
   @SerializedName("type")
@@ -72,17 +83,18 @@ public class InvoiceRefund extends Request {
   private Constants.InvoiceRefundType type;
 
   /**
-   * The amount to be refunded. The amount will be split between the line items. If no amount is
-   * specified, it will default to refunding the total refundable amount on the invoice.
+   * The amount to be refunded. The amount will be split between the line items. If `type` is
+   * "amount" and no amount is specified, it will default to refunding the total refundable amount
+   * on the invoice. Can only be present if `type` is "amount".
    */
   public BigDecimal getAmount() {
     return this.amount;
   }
 
   /**
-   * @param amount The amount to be refunded. The amount will be split between the line items. If no
-   *     amount is specified, it will default to refunding the total refundable amount on the
-   *     invoice.
+   * @param amount The amount to be refunded. The amount will be split between the line items. If
+   *     `type` is "amount" and no amount is specified, it will default to refunding the total
+   *     refundable amount on the invoice. Can only be present if `type` is "amount".
    */
   public void setAmount(final BigDecimal amount) {
     this.amount = amount;
@@ -142,6 +154,26 @@ public class InvoiceRefund extends Request {
   }
 
   /**
+   * The percentage of the remaining balance to be refunded. The percentage will be split between
+   * the line items. If `type` is "percentage" and no percentage is specified, it will default to
+   * refunding 100% of the refundable amount on the invoice. Can only be present if `type` is
+   * "percentage".
+   */
+  public Integer getPercentage() {
+    return this.percentage;
+  }
+
+  /**
+   * @param percentage The percentage of the remaining balance to be refunded. The percentage will
+   *     be split between the line items. If `type` is "percentage" and no percentage is specified,
+   *     it will default to refunding 100% of the refundable amount on the invoice. Can only be
+   *     present if `type` is "percentage".
+   */
+  public void setPercentage(final Integer percentage) {
+    this.percentage = percentage;
+  }
+
+  /**
    * Indicates how the invoice should be refunded when both a credit and transaction are present on
    * the invoice: - `transaction_first` – Refunds the transaction first, then any amount is issued
    * as credit back to the account. Default value when Credit Invoices feature is enabled. -
@@ -152,7 +184,7 @@ public class InvoiceRefund extends Request {
    * back to transactions, using transactions from previous invoices if necessary. Only available
    * when the Credit Invoices feature is enabled.
    */
-  public Constants.RefuneMethod getRefundMethod() {
+  public Constants.RefundMethod getRefundMethod() {
     return this.refundMethod;
   }
 
@@ -167,7 +199,7 @@ public class InvoiceRefund extends Request {
    *     `all_transaction` – Refunds the entire amount back to transactions, using transactions from
    *     previous invoices if necessary. Only available when the Credit Invoices feature is enabled.
    */
-  public void setRefundMethod(final Constants.RefuneMethod refundMethod) {
+  public void setRefundMethod(final Constants.RefundMethod refundMethod) {
     this.refundMethod = refundMethod;
   }
 

--- a/src/main/java/com/recurly/v3/requests/ItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/ItemCreate.java
@@ -106,9 +106,10 @@ public class ItemCreate extends Request {
   private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -306,18 +307,20 @@ public class ItemCreate extends Request {
   }
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values
-   *     are specific to each tax system. If you are using Recurly’s EU VAT feature you can use
-   *     `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/requests/ItemUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/ItemUpdate.java
@@ -106,9 +106,10 @@ public class ItemUpdate extends Request {
   private Constants.RevenueScheduleType revenueScheduleType;
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -306,18 +307,20 @@ public class ItemUpdate extends Request {
   }
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values
-   *     are specific to each tax system. If you are using Recurly’s EU VAT feature you can use
-   *     `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/requests/LineItemCreate.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemCreate.java
@@ -186,10 +186,10 @@ public class LineItemCreate extends Request {
   private DateTime startDate;
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -580,20 +580,20 @@ public class LineItemCreate extends Request {
   }
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to
-   *     determine taxation rules. If you have your own AvaTax or Vertex account configured, use
-   *     their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature,
-   *     you can use values of `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/requests/LineItemRefund.java
+++ b/src/main/java/com/recurly/v3/requests/LineItemRefund.java
@@ -9,13 +9,33 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
+import java.math.BigDecimal;
 
 public class LineItemRefund extends Request {
+
+  /**
+   * The specific amount to be refunded from the adjustment. Must be less than or equal to the
+   * adjustment's remaining balance. If `quantity`, `quantity_decimal` and `percentage` are not
+   * present, `amount` is required. If `quantity`, `quantity_decimal`, or `percentage` is present,
+   * `amount` must be absent.
+   */
+  @SerializedName("amount")
+  @Expose
+  private BigDecimal amount;
 
   /** Line item ID */
   @SerializedName("id")
   @Expose
   private String id;
+
+  /**
+   * The percentage of the adjustment's remaining balance to refund. If `quantity`,
+   * `quantity_decimal` and `amount_in_cents` are not present, `percentage` is required. If
+   * `quantity`, `quantity_decimal` or `amount_in_cents` is present, `percentage` must be absent.
+   */
+  @SerializedName("percentage")
+  @Expose
+  private Integer percentage;
 
   /**
    * Set to `true` if the line item should be prorated; set to `false` if not. This can only be used
@@ -25,20 +45,45 @@ public class LineItemRefund extends Request {
   @Expose
   private Boolean prorate;
 
-  /** Line item quantity to be refunded. */
+  /**
+   * Line item quantity to be refunded. Must be less than or equal to the `quantity_remaining`. If
+   * `quantity_decimal`, `amount`, and `percentage` are not present, `quantity` is required. If
+   * `amount` or `percentage` is present, `quantity` must be absent.
+   */
   @SerializedName("quantity")
   @Expose
   private Integer quantity;
 
   /**
-   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
-   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
-   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
-   * this field.
+   * Decimal quantity to refund. The `quantity_decimal` will be used to refund charges that has a
+   * NOT null quantity decimal. Must be less than or equal to the `quantity_decimal_remaining`. If
+   * `quantity`, `amount`, and `percentage` are not present, `quantity_decimal` is required. If
+   * `amount` or `percentage` is present, `quantity_decimal` must be absent. The Decimal Quantity
+   * feature must be enabled to utilize this field.
    */
   @SerializedName("quantity_decimal")
   @Expose
   private String quantityDecimal;
+
+  /**
+   * The specific amount to be refunded from the adjustment. Must be less than or equal to the
+   * adjustment's remaining balance. If `quantity`, `quantity_decimal` and `percentage` are not
+   * present, `amount` is required. If `quantity`, `quantity_decimal`, or `percentage` is present,
+   * `amount` must be absent.
+   */
+  public BigDecimal getAmount() {
+    return this.amount;
+  }
+
+  /**
+   * @param amount The specific amount to be refunded from the adjustment. Must be less than or
+   *     equal to the adjustment's remaining balance. If `quantity`, `quantity_decimal` and
+   *     `percentage` are not present, `amount` is required. If `quantity`, `quantity_decimal`, or
+   *     `percentage` is present, `amount` must be absent.
+   */
+  public void setAmount(final BigDecimal amount) {
+    this.amount = amount;
+  }
 
   /** Line item ID */
   public String getId() {
@@ -48,6 +93,25 @@ public class LineItemRefund extends Request {
   /** @param id Line item ID */
   public void setId(final String id) {
     this.id = id;
+  }
+
+  /**
+   * The percentage of the adjustment's remaining balance to refund. If `quantity`,
+   * `quantity_decimal` and `amount_in_cents` are not present, `percentage` is required. If
+   * `quantity`, `quantity_decimal` or `amount_in_cents` is present, `percentage` must be absent.
+   */
+  public Integer getPercentage() {
+    return this.percentage;
+  }
+
+  /**
+   * @param percentage The percentage of the adjustment's remaining balance to refund. If
+   *     `quantity`, `quantity_decimal` and `amount_in_cents` are not present, `percentage` is
+   *     required. If `quantity`, `quantity_decimal` or `amount_in_cents` is present, `percentage`
+   *     must be absent.
+   */
+  public void setPercentage(final Integer percentage) {
+    this.percentage = percentage;
   }
 
   /**
@@ -66,31 +130,41 @@ public class LineItemRefund extends Request {
     this.prorate = prorate;
   }
 
-  /** Line item quantity to be refunded. */
+  /**
+   * Line item quantity to be refunded. Must be less than or equal to the `quantity_remaining`. If
+   * `quantity_decimal`, `amount`, and `percentage` are not present, `quantity` is required. If
+   * `amount` or `percentage` is present, `quantity` must be absent.
+   */
   public Integer getQuantity() {
     return this.quantity;
   }
 
-  /** @param quantity Line item quantity to be refunded. */
+  /**
+   * @param quantity Line item quantity to be refunded. Must be less than or equal to the
+   *     `quantity_remaining`. If `quantity_decimal`, `amount`, and `percentage` are not present,
+   *     `quantity` is required. If `amount` or `percentage` is present, `quantity` must be absent.
+   */
   public void setQuantity(final Integer quantity) {
     this.quantity = quantity;
   }
 
   /**
-   * A floating-point alternative to Quantity. If this value is present, it will be used in place of
-   * Quantity for calculations, and Quantity will be the rounded integer value of this number. This
-   * field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize
-   * this field.
+   * Decimal quantity to refund. The `quantity_decimal` will be used to refund charges that has a
+   * NOT null quantity decimal. Must be less than or equal to the `quantity_decimal_remaining`. If
+   * `quantity`, `amount`, and `percentage` are not present, `quantity_decimal` is required. If
+   * `amount` or `percentage` is present, `quantity_decimal` must be absent. The Decimal Quantity
+   * feature must be enabled to utilize this field.
    */
   public String getQuantityDecimal() {
     return this.quantityDecimal;
   }
 
   /**
-   * @param quantityDecimal A floating-point alternative to Quantity. If this value is present, it
-   *     will be used in place of Quantity for calculations, and Quantity will be the rounded
-   *     integer value of this number. This field supports up to 9 decimal places. The Decimal
-   *     Quantity feature must be enabled to utilize this field.
+   * @param quantityDecimal Decimal quantity to refund. The `quantity_decimal` will be used to
+   *     refund charges that has a NOT null quantity decimal. Must be less than or equal to the
+   *     `quantity_decimal_remaining`. If `quantity`, `amount`, and `percentage` are not present,
+   *     `quantity_decimal` is required. If `amount` or `percentage` is present, `quantity_decimal`
+   *     must be absent. The Decimal Quantity feature must be enabled to utilize this field.
    */
   public void setQuantityDecimal(final String quantityDecimal) {
     this.quantityDecimal = quantityDecimal;

--- a/src/main/java/com/recurly/v3/requests/PlanCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanCreate.java
@@ -206,10 +206,10 @@ public class PlanCreate extends Request {
   private Constants.RevenueScheduleType setupFeeRevenueScheduleType;
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -632,20 +632,20 @@ public class PlanCreate extends Request {
   }
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to
-   *     determine taxation rules. If you have your own AvaTax or Vertex account configured, use
-   *     their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature,
-   *     you can use values of `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/requests/PlanUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanUpdate.java
@@ -187,10 +187,10 @@ public class PlanUpdate extends Request {
   private Constants.RevenueScheduleType setupFeeRevenueScheduleType;
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -575,20 +575,20 @@ public class PlanUpdate extends Request {
   }
 
   /**
-   * Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to determine taxation
-   * rules. If you have your own AvaTax or Vertex account configured, use their tax codes to assign
-   * specific tax rules. If you are using Recurly's EU VAT feature, you can use values of `unknown`,
-   * `physical`, or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's EU VAT tax feature to
-   *     determine taxation rules. If you have your own AvaTax or Vertex account configured, use
-   *     their tax codes to assign specific tax rules. If you are using Recurly's EU VAT feature,
-   *     you can use values of `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/resources/AddOn.java
+++ b/src/main/java/com/recurly/v3/resources/AddOn.java
@@ -170,9 +170,11 @@ public class AddOn extends Resource {
   private Constants.ActiveState state;
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request
+   * then `tax_code` must be absent.
    */
   @SerializedName("tax_code")
   @Expose
@@ -545,18 +547,22 @@ public class AddOn extends Resource {
   }
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request
+   * then `tax_code` must be absent.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values
-   *     are specific to each tax system. If you are using Recurly’s EU VAT feature you can use
-   *     `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is
+   *     part of the request then `tax_code` must be absent.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/resources/Item.java
+++ b/src/main/java/com/recurly/v3/resources/Item.java
@@ -131,9 +131,10 @@ public class Item extends Resource {
   private Constants.ActiveState state;
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -386,18 +387,20 @@ public class Item extends Resource {
   }
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values
-   *     are specific to each tax system. If you are using Recurly’s EU VAT feature you can use
-   *     `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/resources/LineItem.java
+++ b/src/main/java/com/recurly/v3/resources/LineItem.java
@@ -346,9 +346,10 @@ public class LineItem extends Resource {
   private BigDecimal tax;
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -1101,18 +1102,20 @@ public class LineItem extends Resource {
   }
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values
-   *     are specific to each tax system. If you are using Recurly’s EU VAT feature you can use
-   *     `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;

--- a/src/main/java/com/recurly/v3/resources/Plan.java
+++ b/src/main/java/com/recurly/v3/resources/Plan.java
@@ -178,9 +178,10 @@ public class Plan extends Resource {
   private Constants.ActiveState state;
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   @SerializedName("tax_code")
   @Expose
@@ -551,18 +552,20 @@ public class Plan extends Resource {
   }
 
   /**
-   * Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to
-   * each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`,
-   * or `digital`.
+   * Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine
+   * taxation rules. You can pass in specific tax codes using any of these tax integrations. For
+   * Recurly's In-the-Box tax offering you can also choose to instead use simple values of
+   * `unknown`, `physical`, or `digital` tax codes.
    */
   public String getTaxCode() {
     return this.taxCode;
   }
 
   /**
-   * @param taxCode Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values
-   *     are specific to each tax system. If you are using Recurly’s EU VAT feature you can use
-   *     `unknown`, `physical`, or `digital`.
+   * @param taxCode Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to
+   *     determine taxation rules. You can pass in specific tax codes using any of these tax
+   *     integrations. For Recurly's In-the-Box tax offering you can also choose to instead use
+   *     simple values of `unknown`, `physical`, or `digital` tax codes.
    */
   public void setTaxCode(final String taxCode) {
     this.taxCode = taxCode;


### PR DESCRIPTION
## Breaking Changes in Client

- The constant `RefuneMethod` Enum has been renamed to `RefundMethod`