### PR TITLE
Generated Latest Changes for v2021-02-25 (add UUID to external subscriptions)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16743,8 +16743,9 @@ components:
     external_subscription_id_fetch:
       name: external_subscription_id
       in: path
-      description: External subscription ID or external_id. For ID no prefix is used
-        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      description: External subscription ID, external_id or uuid. For ID no prefix
+        is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g.
+        `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
       required: true
       schema:
         type: string
@@ -25100,6 +25101,10 @@ components:
           title: External Id
           description: The id of the subscription in the external systems., I.e. Apple
             App Store or Google Play Store.
+        uuid:
+          type: string
+          title: Uuid
+          description: Universally Unique Identifier created automatically.
         last_purchased:
           type: string
           format: date-time

--- a/src/main/java/com/recurly/v3/Client.java
+++ b/src/main/java/com/recurly/v3/Client.java
@@ -1557,7 +1557,7 @@ endpoint to obtain only the newly generated `UniqueCouponCodes`.
    * Fetch an external subscription
    *
    * @see <a href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription">get_external_subscription api documentation</a>
-   * @param externalSubscriptionId External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+   * @param externalSubscriptionId External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
      * @return Settings for an external subscription.
    */
   public ExternalSubscription getExternalSubscription(String externalSubscriptionId) {

--- a/src/main/java/com/recurly/v3/resources/ExternalSubscription.java
+++ b/src/main/java/com/recurly/v3/resources/ExternalSubscription.java
@@ -134,6 +134,11 @@ public class ExternalSubscription extends Resource {
   @Expose
   private DateTime updatedAt;
 
+  /** Universally Unique Identifier created automatically. */
+  @SerializedName("uuid")
+  @Expose
+  private String uuid;
+
   /** Account mini details */
   public AccountMini getAccount() {
     return this.account;
@@ -388,5 +393,15 @@ public class ExternalSubscription extends Resource {
   /** @param updatedAt When the external subscription was updated in Recurly. */
   public void setUpdatedAt(final DateTime updatedAt) {
     this.updatedAt = updatedAt;
+  }
+
+  /** Universally Unique Identifier created automatically. */
+  public String getUuid() {
+    return this.uuid;
+  }
+
+  /** @param uuid Universally Unique Identifier created automatically. */
+  public void setUuid(final String uuid) {
+    this.uuid = uuid;
   }
 }


### PR DESCRIPTION
We are giving the ability to fetch external subscriptions by uuid v3 v2021-02-25

Get `/external_subscriptions/uuid-<uuid_code>` replace <uuid_code> for specific uuid value