### PR TITLE
fix: Adding workaround for incorrectly cased constants returned from the API

### DIFF
--- a/src/main/java/com/recurly/v3/JsonSerializer.java
+++ b/src/main/java/com/recurly/v3/JsonSerializer.java
@@ -81,7 +81,12 @@ public class JsonSerializer {
         in.nextNull();
         return null;
       }
-      T constant = nameToConstant.get(in.nextString());
+      String constantString = in.nextString();
+      T constant = nameToConstant.get(constantString);
+      // TODO: Remove this once the API stops Capitalizing the Coupon's redemption_resource
+      if (constant == null) {
+        constant = nameToConstant.get(constantString.toLowerCase());
+      }
       if (constant == null) {
         return nameToConstant.get("UNDEFINED");
       }

--- a/src/test/java/com/recurly/v3/JsonSerializerTest.java
+++ b/src/test/java/com/recurly/v3/JsonSerializerTest.java
@@ -22,6 +22,14 @@ public class JsonSerializerTest {
   }
 
   @Test
+  public void testDeserializeCapitalizedEnum() {
+    final JsonSerializer jsonSerializer = new JsonSerializer();
+    final MyResource mockResource =
+        jsonSerializer.deserialize("{\"my_constant\":\"TwEnty-thRee\"}", MyResource.class);
+    assertEquals(FixtureConstants.ConstantType.TWENTY_THREE, mockResource.getMyConstant());
+  }
+
+  @Test
   public void testDeserializeUnknownEnum() {
     final JsonSerializer jsonSerializer = new JsonSerializer();
     final MyResource mockResource =


### PR DESCRIPTION
The API is returning a capitalized `Account` or `Subscription` value for a Coupon's `redemption_resource` value. However, the API requires that the same value be lowercase when creating a Coupon.

Until the API can be corrected, we will attempt to convert the API response to lowercase if a constant value is not found.

**Testing**:

```java
import com.recurly.v3.Client;
import com.recurly.v3.resources.Coupon;

final Client client = new Client("<private api key>");
final Coupon coupon = client.getCoupon("code-" + couponCode);
System.out.println("Redemption Resource: " + coupon.getRedemptionResource());
```