### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21353,6 +21353,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21568,6 +21573,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21832,6 +21842,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing

--- a/src/main/java/com/recurly/v3/requests/PlanCreate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanCreate.java
@@ -243,6 +243,11 @@ public class PlanCreate extends Request {
   @Expose
   private Constants.IntervalUnit trialUnit;
 
+  /** Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`. */
+  @SerializedName("vertex_transaction_type")
+  @Expose
+  private String vertexTransactionType;
+
   /**
    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to
    * plan's code.
@@ -709,5 +714,18 @@ public class PlanCreate extends Request {
   /** @param trialUnit Units for the plan's trial period. */
   public void setTrialUnit(final Constants.IntervalUnit trialUnit) {
     this.trialUnit = trialUnit;
+  }
+
+  /** Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`. */
+  public String getVertexTransactionType() {
+    return this.vertexTransactionType;
+  }
+
+  /**
+   * @param vertexTransactionType Used by Vertex for tax calculations. Possible values are `sale`,
+   *     `rental`, `lease`.
+   */
+  public void setVertexTransactionType(final String vertexTransactionType) {
+    this.vertexTransactionType = vertexTransactionType;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/PlanUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/PlanUpdate.java
@@ -224,6 +224,11 @@ public class PlanUpdate extends Request {
   @Expose
   private Constants.IntervalUnit trialUnit;
 
+  /** Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`. */
+  @SerializedName("vertex_transaction_type")
+  @Expose
+  private String vertexTransactionType;
+
   /**
    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to
    * plan's code.
@@ -652,5 +657,18 @@ public class PlanUpdate extends Request {
   /** @param trialUnit Units for the plan's trial period. */
   public void setTrialUnit(final Constants.IntervalUnit trialUnit) {
     this.trialUnit = trialUnit;
+  }
+
+  /** Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`. */
+  public String getVertexTransactionType() {
+    return this.vertexTransactionType;
+  }
+
+  /**
+   * @param vertexTransactionType Used by Vertex for tax calculations. Possible values are `sale`,
+   *     `rental`, `lease`.
+   */
+  public void setVertexTransactionType(final String vertexTransactionType) {
+    this.vertexTransactionType = vertexTransactionType;
   }
 }

--- a/src/main/java/com/recurly/v3/resources/Plan.java
+++ b/src/main/java/com/recurly/v3/resources/Plan.java
@@ -224,6 +224,11 @@ public class Plan extends Resource {
   @Expose
   private DateTime updatedAt;
 
+  /** Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`. */
+  @SerializedName("vertex_transaction_type")
+  @Expose
+  private String vertexTransactionType;
+
   /**
    * Accounting code for invoice line items for the plan. If no value is provided, it defaults to
    * plan's code.
@@ -644,5 +649,18 @@ public class Plan extends Resource {
   /** @param updatedAt Last updated at */
   public void setUpdatedAt(final DateTime updatedAt) {
     this.updatedAt = updatedAt;
+  }
+
+  /** Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`. */
+  public String getVertexTransactionType() {
+    return this.vertexTransactionType;
+  }
+
+  /**
+   * @param vertexTransactionType Used by Vertex for tax calculations. Possible values are `sale`,
+   *     `rental`, `lease`.
+   */
+  public void setVertexTransactionType(final String vertexTransactionType) {
+    this.vertexTransactionType = vertexTransactionType;
   }
 }


### PR DESCRIPTION
This PR adds the ability to send a plan's `vertex_transaction_type` to vertex. 
 ```
vertex_transaction_type:
  type: string
  title: Vertex Transaction Type
  description: Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
```