### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -20276,6 +20276,8 @@ components:
           format: float
           title: Tax
           description: The total tax on this invoice.
+        reference_only_currency_conversion:
+          "$ref": "#/components/schemas/ReferenceOnlyCurrencyConversion"
         total:
           type: number
           format: float
@@ -22289,6 +22291,25 @@ components:
           title: Updated at
           format: date-time
           readOnly: true
+    ReferenceOnlyCurrencyConversion:
+      type: object
+      title: Reference Only Currency Conversion
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        subtotal_in_cents:
+          type: number
+          format: float
+          title: Subtotal In Cents
+          description: The subtotal converted to the currency.
+        tax_in_cents:
+          type: number
+          format: float
+          title: Tax In Cents
+          description: The tax converted to the currency.
     ShippingAddressCreate:
       type: object
       properties:

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -210,6 +210,11 @@ public class Invoice extends Resource {
   @Expose
   private String previousInvoiceId;
 
+  /** Reference Only Currency Conversion */
+  @SerializedName("reference_only_currency_conversion")
+  @Expose
+  private ReferenceOnlyCurrencyConversion referenceOnlyCurrencyConversion;
+
   /** The refundable amount on a charge invoice. It will be null for all other invoices. */
   @SerializedName("refundable_amount")
   @Expose
@@ -698,6 +703,17 @@ public class Invoice extends Resource {
    */
   public void setPreviousInvoiceId(final String previousInvoiceId) {
     this.previousInvoiceId = previousInvoiceId;
+  }
+
+  /** Reference Only Currency Conversion */
+  public ReferenceOnlyCurrencyConversion getReferenceOnlyCurrencyConversion() {
+    return this.referenceOnlyCurrencyConversion;
+  }
+
+  /** @param referenceOnlyCurrencyConversion Reference Only Currency Conversion */
+  public void setReferenceOnlyCurrencyConversion(
+      final ReferenceOnlyCurrencyConversion referenceOnlyCurrencyConversion) {
+    this.referenceOnlyCurrencyConversion = referenceOnlyCurrencyConversion;
   }
 
   /** The refundable amount on a charge invoice. It will be null for all other invoices. */

--- a/src/main/java/com/recurly/v3/resources/ReferenceOnlyCurrencyConversion.java
+++ b/src/main/java/com/recurly/v3/resources/ReferenceOnlyCurrencyConversion.java
@@ -1,0 +1,59 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.resources;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Resource;
+import java.math.BigDecimal;
+
+public class ReferenceOnlyCurrencyConversion extends Resource {
+
+  /** 3-letter ISO 4217 currency code. */
+  @SerializedName("currency")
+  @Expose
+  private String currency;
+
+  /** The subtotal converted to the currency. */
+  @SerializedName("subtotal_in_cents")
+  @Expose
+  private BigDecimal subtotalInCents;
+
+  /** The tax converted to the currency. */
+  @SerializedName("tax_in_cents")
+  @Expose
+  private BigDecimal taxInCents;
+
+  /** 3-letter ISO 4217 currency code. */
+  public String getCurrency() {
+    return this.currency;
+  }
+
+  /** @param currency 3-letter ISO 4217 currency code. */
+  public void setCurrency(final String currency) {
+    this.currency = currency;
+  }
+
+  /** The subtotal converted to the currency. */
+  public BigDecimal getSubtotalInCents() {
+    return this.subtotalInCents;
+  }
+
+  /** @param subtotalInCents The subtotal converted to the currency. */
+  public void setSubtotalInCents(final BigDecimal subtotalInCents) {
+    this.subtotalInCents = subtotalInCents;
+  }
+
+  /** The tax converted to the currency. */
+  public BigDecimal getTaxInCents() {
+    return this.taxInCents;
+  }
+
+  /** @param taxInCents The tax converted to the currency. */
+  public void setTaxInCents(final BigDecimal taxInCents) {
+    this.taxInCents = taxInCents;
+  }
+}


### PR DESCRIPTION
This PR adds `reference_only_currency_conversion` values to Invoice responses.

```json
  "reference_only_currency_conversion": {
    "currency": "str",
    "subtotal_in_cents": 0,
    "tax_in_cents": 0
  },
  ```