### PR TITLE
Migration to new maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,14 +204,13 @@
               </executions>
             </plugin>
             <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <version>1.6.13</version>
+              <groupId>org.sonatype.central</groupId>
+              <artifactId>central-publishing-maven-plugin</artifactId>
+              <version>0.8.0</version>
               <extensions>true</extensions>
               <configuration>
-                <serverId>ossrh</serverId>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
               </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
ossrh is deprecated and we need to use sonatype.central