### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -24392,11 +24392,11 @@ components:
         tax_details:
           type: array
           description: Provides additional tax details for Communications taxes when
-            Avalara for Communications is enabled or Canadian Sales Tax when there
-            is tax applied at both the country and province levels. This will only
-            be populated for the Invoice response when fetching a single invoice and
-            not for the InvoiceList or LineItemList. Only populated for a single LineItem
-            fetch when Avalara for Communications is enabled.
+            Avalara for Communications or Vertex Tax Breakdown is enabled or Canadian
+            Sales Tax. Tax details will only be populated for the Invoice response
+            when fetching a single invoice and not for the InvoiceList or LineItemList.
+            Only populated for a single LineItem fetch when Avalara for Communications
+            is enabled.
           items:
             "$ref": "#/components/schemas/TaxDetail"
     TaxDetail:
@@ -24407,8 +24407,8 @@ components:
           type: string
           title: Type
           description: Provides the tax type for the region or type of Comminications
-            tax when Avalara for Communications is enabled. For Canadian Sales Tax,
-            this will be GST, HST, QST or PST.
+            tax when Avalara for Communications or Vertex is enabled. For Canadian
+            Sales Tax, this will be GST, HST, QST or PST.
         region:
           type: string
           title: Region
@@ -24429,18 +24429,18 @@ components:
           type: string
           title: Name
           description: Provides the name of the Communications tax applied. Present
-            only when Avalara for Communications is enabled.
+            only when Avalara for Communications or Vertex is enabled.
         level:
           type: string
           title: Level
           description: Provides the jurisdiction level for the Communications tax
             applied. Example values include city, state and federal. Present only
-            when Avalara for Communications is enabled.
+            when Avalara for Communications or Vertex is enabled.
         billable:
           type: boolean
           title: Billable
           description: Whether or not the line item is taxable. Only populated for
-            a single LineItem fetch when Avalara for Communications is enabled.
+            a single LineItem fetch when Avalara for Communications or Vertex is enabled.
     Transaction:
       type: object
       properties:

--- a/src/main/java/com/recurly/v3/resources/TaxDetail.java
+++ b/src/main/java/com/recurly/v3/resources/TaxDetail.java
@@ -14,7 +14,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Whether or not the line item is taxable. Only populated for a single LineItem fetch when
-   * Avalara for Communications is enabled.
+   * Avalara for Communications or Vertex is enabled.
    */
   @SerializedName("billable")
   @Expose
@@ -22,7 +22,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the jurisdiction level for the Communications tax applied. Example values include
-   * city, state and federal. Present only when Avalara for Communications is enabled.
+   * city, state and federal. Present only when Avalara for Communications or Vertex is enabled.
    */
   @SerializedName("level")
   @Expose
@@ -30,7 +30,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the name of the Communications tax applied. Present only when Avalara for
-   * Communications is enabled.
+   * Communications or Vertex is enabled.
    */
   @SerializedName("name")
   @Expose
@@ -56,7 +56,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the tax type for the region or type of Comminications tax when Avalara for
-   * Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+   * Communications or Vertex is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
    */
   @SerializedName("type")
   @Expose
@@ -64,7 +64,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Whether or not the line item is taxable. Only populated for a single LineItem fetch when
-   * Avalara for Communications is enabled.
+   * Avalara for Communications or Vertex is enabled.
    */
   public Boolean getBillable() {
     return this.billable;
@@ -72,7 +72,7 @@ public class TaxDetail extends Resource {
 
   /**
    * @param billable Whether or not the line item is taxable. Only populated for a single LineItem
-   *     fetch when Avalara for Communications is enabled.
+   *     fetch when Avalara for Communications or Vertex is enabled.
    */
   public void setBillable(final Boolean billable) {
     this.billable = billable;
@@ -80,7 +80,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the jurisdiction level for the Communications tax applied. Example values include
-   * city, state and federal. Present only when Avalara for Communications is enabled.
+   * city, state and federal. Present only when Avalara for Communications or Vertex is enabled.
    */
   public String getLevel() {
     return this.level;
@@ -88,7 +88,8 @@ public class TaxDetail extends Resource {
 
   /**
    * @param level Provides the jurisdiction level for the Communications tax applied. Example values
-   *     include city, state and federal. Present only when Avalara for Communications is enabled.
+   *     include city, state and federal. Present only when Avalara for Communications or Vertex is
+   *     enabled.
    */
   public void setLevel(final String level) {
     this.level = level;
@@ -96,7 +97,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the name of the Communications tax applied. Present only when Avalara for
-   * Communications is enabled.
+   * Communications or Vertex is enabled.
    */
   public String getName() {
     return this.name;
@@ -104,7 +105,7 @@ public class TaxDetail extends Resource {
 
   /**
    * @param name Provides the name of the Communications tax applied. Present only when Avalara for
-   *     Communications is enabled.
+   *     Communications or Vertex is enabled.
    */
   public void setName(final String name) {
     this.name = name;
@@ -149,7 +150,7 @@ public class TaxDetail extends Resource {
 
   /**
    * Provides the tax type for the region or type of Comminications tax when Avalara for
-   * Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+   * Communications or Vertex is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
    */
   public String getType() {
     return this.type;
@@ -157,7 +158,8 @@ public class TaxDetail extends Resource {
 
   /**
    * @param type Provides the tax type for the region or type of Comminications tax when Avalara for
-   *     Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.
+   *     Communications or Vertex is enabled. For Canadian Sales Tax, this will be GST, HST, QST or
+   *     PST.
    */
   public void setType(final String type) {
     this.type = type;

--- a/src/main/java/com/recurly/v3/resources/TaxInfo.java
+++ b/src/main/java/com/recurly/v3/resources/TaxInfo.java
@@ -29,11 +29,11 @@ public class TaxInfo extends Resource {
   private String region;
 
   /**
-   * Provides additional tax details for Communications taxes when Avalara for Communications is
-   * enabled or Canadian Sales Tax when there is tax applied at both the country and province
-   * levels. This will only be populated for the Invoice response when fetching a single invoice and
-   * not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when
-   * Avalara for Communications is enabled.
+   * Provides additional tax details for Communications taxes when Avalara for Communications or
+   * Vertex Tax Breakdown is enabled or Canadian Sales Tax. Tax details will only be populated for
+   * the Invoice response when fetching a single invoice and not for the InvoiceList or
+   * LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is
+   * enabled.
    */
   @SerializedName("tax_details")
   @Expose
@@ -79,11 +79,11 @@ public class TaxInfo extends Resource {
   }
 
   /**
-   * Provides additional tax details for Communications taxes when Avalara for Communications is
-   * enabled or Canadian Sales Tax when there is tax applied at both the country and province
-   * levels. This will only be populated for the Invoice response when fetching a single invoice and
-   * not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when
-   * Avalara for Communications is enabled.
+   * Provides additional tax details for Communications taxes when Avalara for Communications or
+   * Vertex Tax Breakdown is enabled or Canadian Sales Tax. Tax details will only be populated for
+   * the Invoice response when fetching a single invoice and not for the InvoiceList or
+   * LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is
+   * enabled.
    */
   public List<TaxDetail> getTaxDetails() {
     return this.taxDetails;
@@ -91,10 +91,10 @@ public class TaxInfo extends Resource {
 
   /**
    * @param taxDetails Provides additional tax details for Communications taxes when Avalara for
-   *     Communications is enabled or Canadian Sales Tax when there is tax applied at both the
-   *     country and province levels. This will only be populated for the Invoice response when
-   *     fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a
-   *     single LineItem fetch when Avalara for Communications is enabled.
+   *     Communications or Vertex Tax Breakdown is enabled or Canadian Sales Tax. Tax details will
+   *     only be populated for the Invoice response when fetching a single invoice and not for the
+   *     InvoiceList or LineItemList. Only populated for a single LineItem fetch when Avalara for
+   *     Communications is enabled.
    */
   public void setTaxDetails(final List<TaxDetail> taxDetails) {
     this.taxDetails = taxDetails;


### PR DESCRIPTION
This PR adds language to show that Vertex Tax Breakdown is supported on invoices.