### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -544,6 +544,9 @@ public class Constants {
       @SerializedName("year")
       YEAR,
     
+      @SerializedName("billing_period")
+      BILLING_PERIOD,
+    
     };
   
     public enum FreeTrialUnit {
@@ -2528,6 +2531,23 @@ public class Constants {
     
       @SerializedName("merchant")
       MERCHANT,
+    
+    };
+  
+    public enum SourceRecordType {
+      UNDEFINED,
+    
+      @SerializedName("account")
+      ACCOUNT,
+    
+      @SerializedName("plan")
+      PLAN,
+    
+      @SerializedName("product")
+      PRODUCT,
+    
+      @SerializedName("subscription")
+      SUBSCRIPTION,
     
     };
   

--- a/src/main/java/com/recurly/v3/requests/Address.java
+++ b/src/main/java/com/recurly/v3/requests/Address.java
@@ -23,8 +23,8 @@ public class Address extends Request {
   private String country;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -76,16 +76,16 @@ public class Address extends Request {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/requests/CouponCreate.java
+++ b/src/main/java/com/recurly/v3/requests/CouponCreate.java
@@ -166,7 +166,8 @@ public class CouponCreate extends Request {
 
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by
-   * `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+   * `temporal_unit` to define the duration that the coupon will be applied to invoices for. When
+   * `temporal_unit` is "billing_period", this is the number of complete billing cycles.
    */
   @SerializedName("temporal_amount")
   @Expose
@@ -174,7 +175,8 @@ public class CouponCreate extends Request {
 
   /**
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define
-   * the duration that the coupon will be applied to invoices for.
+   * the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the
+   * coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
    */
   @SerializedName("temporal_unit")
   @Expose
@@ -502,7 +504,8 @@ public class CouponCreate extends Request {
 
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by
-   * `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+   * `temporal_unit` to define the duration that the coupon will be applied to invoices for. When
+   * `temporal_unit` is "billing_period", this is the number of complete billing cycles.
    */
   public Integer getTemporalAmount() {
     return this.temporalAmount;
@@ -511,7 +514,8 @@ public class CouponCreate extends Request {
   /**
    * @param temporalAmount If `duration` is "temporal" than `temporal_amount` is an integer which is
    *     multiplied by `temporal_unit` to define the duration that the coupon will be applied to
-   *     invoices for.
+   *     invoices for. When `temporal_unit` is "billing_period", this is the number of complete
+   *     billing cycles.
    */
   public void setTemporalAmount(final Integer temporalAmount) {
     this.temporalAmount = temporalAmount;
@@ -519,7 +523,8 @@ public class CouponCreate extends Request {
 
   /**
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define
-   * the duration that the coupon will be applied to invoices for.
+   * the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the
+   * coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
    */
   public Constants.TemporalUnit getTemporalUnit() {
     return this.temporalUnit;
@@ -528,6 +533,8 @@ public class CouponCreate extends Request {
   /**
    * @param temporalUnit If `duration` is "temporal" than `temporal_unit` is multiplied by
    *     `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+   *     Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires
+   *     `redemption_resource=subscription`.
    */
   public void setTemporalUnit(final Constants.TemporalUnit temporalUnit) {
     this.temporalUnit = temporalUnit;

--- a/src/main/java/com/recurly/v3/requests/CustomField.java
+++ b/src/main/java/com/recurly/v3/requests/CustomField.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -16,6 +17,22 @@ public class CustomField extends Request {
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The UUID of the record this custom field was automatically copied from. Only present when the
+   * field was copied from another record.
+   */
+  @SerializedName("source_record_id")
+  @Expose
+  private String sourceRecordId;
+
+  /**
+   * The type of record this custom field was automatically copied from. Only present when the field
+   * was copied from another record.
+   */
+  @SerializedName("source_record_type")
+  @Expose
+  private Constants.SourceRecordType sourceRecordType;
 
   /** Any values that resemble a credit card number or security code (CVV/CVC) will be rejected. */
   @SerializedName("value")
@@ -30,6 +47,38 @@ public class CustomField extends Request {
   /** @param name Fields must be created in the UI before values can be assigned to them. */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The UUID of the record this custom field was automatically copied from. Only present when the
+   * field was copied from another record.
+   */
+  public String getSourceRecordId() {
+    return this.sourceRecordId;
+  }
+
+  /**
+   * @param sourceRecordId The UUID of the record this custom field was automatically copied from.
+   *     Only present when the field was copied from another record.
+   */
+  public void setSourceRecordId(final String sourceRecordId) {
+    this.sourceRecordId = sourceRecordId;
+  }
+
+  /**
+   * The type of record this custom field was automatically copied from. Only present when the field
+   * was copied from another record.
+   */
+  public Constants.SourceRecordType getSourceRecordType() {
+    return this.sourceRecordType;
+  }
+
+  /**
+   * @param sourceRecordType The type of record this custom field was automatically copied from.
+   *     Only present when the field was copied from another record.
+   */
+  public void setSourceRecordType(final Constants.SourceRecordType sourceRecordType) {
+    this.sourceRecordType = sourceRecordType;
   }
 
   /** Any values that resemble a credit card number or security code (CVV/CVC) will be rejected. */

--- a/src/main/java/com/recurly/v3/requests/InvoiceAddress.java
+++ b/src/main/java/com/recurly/v3/requests/InvoiceAddress.java
@@ -33,8 +33,8 @@ public class InvoiceAddress extends Request {
   private String firstName;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -116,16 +116,16 @@ public class InvoiceAddress extends Request {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/requests/ShippingAddressCreate.java
+++ b/src/main/java/com/recurly/v3/requests/ShippingAddressCreate.java
@@ -34,8 +34,8 @@ public class ShippingAddressCreate extends Request {
   private String firstName;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -122,16 +122,16 @@ public class ShippingAddressCreate extends Request {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/requests/ShippingAddressUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/ShippingAddressUpdate.java
@@ -34,8 +34,8 @@ public class ShippingAddressUpdate extends Request {
   private String firstName;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -127,16 +127,16 @@ public class ShippingAddressUpdate extends Request {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/resources/Address.java
+++ b/src/main/java/com/recurly/v3/resources/Address.java
@@ -22,8 +22,8 @@ public class Address extends Resource {
   private String country;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -75,16 +75,16 @@ public class Address extends Resource {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/resources/AddressWithName.java
+++ b/src/main/java/com/recurly/v3/resources/AddressWithName.java
@@ -27,8 +27,8 @@ public class AddressWithName extends Resource {
   private String firstName;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -95,16 +95,16 @@ public class AddressWithName extends Resource {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/resources/Coupon.java
+++ b/src/main/java/com/recurly/v3/resources/Coupon.java
@@ -172,7 +172,8 @@ public class Coupon extends Resource {
 
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by
-   * `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+   * `temporal_unit` to define the duration that the coupon will be applied to invoices for. When
+   * `temporal_unit` is "billing_period", this is the number of complete billing cycles.
    */
   @SerializedName("temporal_amount")
   @Expose
@@ -180,7 +181,8 @@ public class Coupon extends Resource {
 
   /**
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define
-   * the duration that the coupon will be applied to invoices for.
+   * the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the
+   * coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
    */
   @SerializedName("temporal_unit")
   @Expose
@@ -524,7 +526,8 @@ public class Coupon extends Resource {
 
   /**
    * If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by
-   * `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+   * `temporal_unit` to define the duration that the coupon will be applied to invoices for. When
+   * `temporal_unit` is "billing_period", this is the number of complete billing cycles.
    */
   public Integer getTemporalAmount() {
     return this.temporalAmount;
@@ -533,7 +536,8 @@ public class Coupon extends Resource {
   /**
    * @param temporalAmount If `duration` is "temporal" than `temporal_amount` is an integer which is
    *     multiplied by `temporal_unit` to define the duration that the coupon will be applied to
-   *     invoices for.
+   *     invoices for. When `temporal_unit` is "billing_period", this is the number of complete
+   *     billing cycles.
    */
   public void setTemporalAmount(final Integer temporalAmount) {
     this.temporalAmount = temporalAmount;
@@ -541,7 +545,8 @@ public class Coupon extends Resource {
 
   /**
    * If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define
-   * the duration that the coupon will be applied to invoices for.
+   * the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the
+   * coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
    */
   public Constants.TemporalUnit getTemporalUnit() {
     return this.temporalUnit;
@@ -550,6 +555,8 @@ public class Coupon extends Resource {
   /**
    * @param temporalUnit If `duration` is "temporal" than `temporal_unit` is multiplied by
    *     `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+   *     Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires
+   *     `redemption_resource=subscription`.
    */
   public void setTemporalUnit(final Constants.TemporalUnit temporalUnit) {
     this.temporalUnit = temporalUnit;

--- a/src/main/java/com/recurly/v3/resources/CustomField.java
+++ b/src/main/java/com/recurly/v3/resources/CustomField.java
@@ -7,6 +7,7 @@ package com.recurly.v3.resources;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Resource;
 
 public class CustomField extends Resource {
@@ -15,6 +16,22 @@ public class CustomField extends Resource {
   @SerializedName("name")
   @Expose
   private String name;
+
+  /**
+   * The UUID of the record this custom field was automatically copied from. Only present when the
+   * field was copied from another record.
+   */
+  @SerializedName("source_record_id")
+  @Expose
+  private String sourceRecordId;
+
+  /**
+   * The type of record this custom field was automatically copied from. Only present when the field
+   * was copied from another record.
+   */
+  @SerializedName("source_record_type")
+  @Expose
+  private Constants.SourceRecordType sourceRecordType;
 
   /** Any values that resemble a credit card number or security code (CVV/CVC) will be rejected. */
   @SerializedName("value")
@@ -29,6 +46,38 @@ public class CustomField extends Resource {
   /** @param name Fields must be created in the UI before values can be assigned to them. */
   public void setName(final String name) {
     this.name = name;
+  }
+
+  /**
+   * The UUID of the record this custom field was automatically copied from. Only present when the
+   * field was copied from another record.
+   */
+  public String getSourceRecordId() {
+    return this.sourceRecordId;
+  }
+
+  /**
+   * @param sourceRecordId The UUID of the record this custom field was automatically copied from.
+   *     Only present when the field was copied from another record.
+   */
+  public void setSourceRecordId(final String sourceRecordId) {
+    this.sourceRecordId = sourceRecordId;
+  }
+
+  /**
+   * The type of record this custom field was automatically copied from. Only present when the field
+   * was copied from another record.
+   */
+  public Constants.SourceRecordType getSourceRecordType() {
+    return this.sourceRecordType;
+  }
+
+  /**
+   * @param sourceRecordType The type of record this custom field was automatically copied from.
+   *     Only present when the field was copied from another record.
+   */
+  public void setSourceRecordType(final Constants.SourceRecordType sourceRecordType) {
+    this.sourceRecordType = sourceRecordType;
   }
 
   /** Any values that resemble a credit card number or security code (CVV/CVC) will be rejected. */

--- a/src/main/java/com/recurly/v3/resources/Invoice.java
+++ b/src/main/java/com/recurly/v3/resources/Invoice.java
@@ -79,6 +79,14 @@ public class Invoice extends Resource {
   private String currency;
 
   /**
+   * A list of custom fields that were on the account at the time of invoice creation and were
+   * marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
+   */
+  @SerializedName("custom_fields")
+  @Expose
+  private List<CustomField> customFields;
+
+  /**
    * This will default to the Customer Notes text specified on the Invoice Settings. Specify custom
    * notes to add or override Customer Notes.
    */
@@ -443,6 +451,23 @@ public class Invoice extends Resource {
   /** @param currency 3-letter ISO 4217 currency code. */
   public void setCurrency(final String currency) {
     this.currency = currency;
+  }
+
+  /**
+   * A list of custom fields that were on the account at the time of invoice creation and were
+   * marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
+   */
+  public List<CustomField> getCustomFields() {
+    return this.customFields;
+  }
+
+  /**
+   * @param customFields A list of custom fields that were on the account at the time of invoice
+   *     creation and were marked to be displayed on invoices. Read-only; cannot be set directly on
+   *     the invoice.
+   */
+  public void setCustomFields(final List<CustomField> customFields) {
+    this.customFields = customFields;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/InvoiceAddress.java
+++ b/src/main/java/com/recurly/v3/resources/InvoiceAddress.java
@@ -32,8 +32,8 @@ public class InvoiceAddress extends Resource {
   private String firstName;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -115,16 +115,16 @@ public class InvoiceAddress extends Resource {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;

--- a/src/main/java/com/recurly/v3/resources/ShippingAddress.java
+++ b/src/main/java/com/recurly/v3/resources/ShippingAddress.java
@@ -44,8 +44,8 @@ public class ShippingAddress extends Resource {
   private String firstName;
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   @SerializedName("geo_code")
   @Expose
@@ -167,16 +167,16 @@ public class ShippingAddress extends Resource {
   }
 
   /**
-   * Code that represents a geographic entity (location or object). Only returned for Sling Vertex
-   * Integration
+   * Code that represents a geographic entity (location or object). Only returned when Vertex or
+   * Avalara for Communications is enabled.
    */
   public String getGeoCode() {
     return this.geoCode;
   }
 
   /**
-   * @param geoCode Code that represents a geographic entity (location or object). Only returned for
-   *     Sling Vertex Integration
+   * @param geoCode Code that represents a geographic entity (location or object). Only returned
+   *     when Vertex or Avalara for Communications is enabled.
    */
   public void setGeoCode(final String geoCode) {
     this.geoCode = geoCode;


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).