### PR TITLE
ci: Remediate Node.js 20 deprecation in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on: [push]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 on: [push]
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,9 +13,9 @@ jobs:
       matrix:
         java: [8, 11, 16, 17]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         java: [8, 11, 16, 17]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,10 +9,13 @@ on:
       - main
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r7kamura/semgrepper@v0
         continue-on-error: true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,9 +9,6 @@ on:
       - main
       - master
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,6 +16,6 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.3
       - uses: r7kamura/semgrepper@v0
         continue-on-error: true


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions using Node.js 20 (or older) will be forced to Node.js 24 starting June 2, 2026, and will be fully removed from runners on September 16, 2026. The workflows in this repo referenced `actions/checkout@v3` and `actions/setup-java@v3`, both of which use Node.js 16.

### Fix
Upgraded all affected actions to their latest Node.js 24-native versions (runtime verified via `action.yml` before applying):

- `actions/checkout@v3` (node16) → `actions/checkout@v6.0.3` (node24)
- `actions/setup-java@v3` (node16) → `actions/setup-java@v5.2.0` (node24)

Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level to validate Node.js 24 execution in CI. This flag will be removed before merge.

The `r7kamura/semgrepper@v0` (docker) and `docker://agilepathway/pull-request-label-checker:latest` (docker) actions are not affected by this deprecation.

### Files Changed
- `.github/workflows/ci.yml` — `checkout@v3` → `v6.0.3`, `setup-java@v3` → `v5.2.0`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- `.github/workflows/semgrep.yml` — `checkout@v3` → `v6.0.3`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`

## Testing
CI runs with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` active — all Java matrix tests (8, 11, 16, 17), CodeQL, and Semgrep passed.