### PR TITLE
feat: allow request timeouts to be configured via ClientOptions

### DIFF
--- a/src/main/java/com/recurly/v3/BaseClient.java
+++ b/src/main/java/com/recurly/v3/BaseClient.java
@@ -35,11 +35,11 @@ public abstract class BaseClient {
   private String apiUrl;
 
   protected BaseClient(final String apiKey) {
-    this(apiKey, newHttpClient(validateApiKey(apiKey)), new ClientOptions());
+    this(apiKey, new ClientOptions());
   }
 
   protected BaseClient(final String apiKey, final ClientOptions clientOptions) {
-    this(apiKey, newHttpClient(validateApiKey(apiKey)), clientOptions);
+    this(apiKey, newHttpClient(validateApiKey(apiKey), clientOptions), clientOptions);
   }
 
   protected BaseClient(final String apiKey, final OkHttpClient client) {
@@ -59,9 +59,22 @@ public abstract class BaseClient {
     return apiKey;
   }
 
-  private static OkHttpClient newHttpClient(final String apiKey) {
+  static OkHttpClient newHttpClient(final String apiKey, final ClientOptions clientOptions) {
     final OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
-    
+
+    if (clientOptions.getConnectTimeout() != null) {
+      httpClientBuilder.connectTimeout(clientOptions.getConnectTimeout());
+    }
+    if (clientOptions.getReadTimeout() != null) {
+      httpClientBuilder.readTimeout(clientOptions.getReadTimeout());
+    }
+    if (clientOptions.getWriteTimeout() != null) {
+      httpClientBuilder.writeTimeout(clientOptions.getWriteTimeout());
+    }
+    if (clientOptions.getCallTimeout() != null) {
+      httpClientBuilder.callTimeout(clientOptions.getCallTimeout());
+    }
+
     final String authToken = Credentials.basic(apiKey, "");
     final HeaderInterceptor headerInterceptor =
         new HeaderInterceptor(authToken, Client.API_VERSION);

--- a/src/main/java/com/recurly/v3/ClientOptions.java
+++ b/src/main/java/com/recurly/v3/ClientOptions.java
@@ -1,4 +1,5 @@
 package com.recurly.v3;
+import java.time.Duration;
 import java.util.HashMap;
 
 public class ClientOptions {
@@ -15,6 +16,10 @@ public class ClientOptions {
   }
 
   private Regions region;
+  private Duration connectTimeout;
+  private Duration readTimeout;
+  private Duration writeTimeout;
+  private Duration callTimeout;
 
   public ClientOptions() {
     this.region = Regions.US;
@@ -27,5 +32,47 @@ public class ClientOptions {
   /** BaseUrl is determined by the region */
   public String getBaseUrl() {
     return regionsMap.get(this.region);
+  }
+
+  /** Connect timeout for the underlying HTTP client. Unset leaves the OkHttp default in place. */
+  public void setConnectTimeout(Duration connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
+
+  public Duration getConnectTimeout() {
+    return this.connectTimeout;
+  }
+
+  /**
+   * Read timeout for the underlying HTTP client. Unset leaves the OkHttp default in place. Raising
+   * this is how a caller tolerates a slow response instead of failing the request.
+   */
+  public void setReadTimeout(Duration readTimeout) {
+    this.readTimeout = readTimeout;
+  }
+
+  public Duration getReadTimeout() {
+    return this.readTimeout;
+  }
+
+  /** Write timeout for the underlying HTTP client. Unset leaves the OkHttp default in place. */
+  public void setWriteTimeout(Duration writeTimeout) {
+    this.writeTimeout = writeTimeout;
+  }
+
+  public Duration getWriteTimeout() {
+    return this.writeTimeout;
+  }
+
+  /**
+   * Timeout spanning the complete call, including redirects and retries. Unset leaves OkHttp's
+   * behaviour of applying no overall limit.
+   */
+  public void setCallTimeout(Duration callTimeout) {
+    this.callTimeout = callTimeout;
+  }
+
+  public Duration getCallTimeout() {
+    return this.callTimeout;
   }
 }

--- a/src/test/java/com/recurly/v3/BaseClientTest.java
+++ b/src/test/java/com/recurly/v3/BaseClientTest.java
@@ -22,6 +22,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 import org.apache.commons.io.IOUtils;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import org.junit.Assert;
@@ -501,6 +502,64 @@ public class BaseClientTest {
 
     final String interpolatedPath = client.interpolatePath(path, urlParams);
     assertEquals("/url_path/replacement", interpolatedPath);
+  }
+
+  @Test
+  public void testDefaultTimeoutsAreUnchangedWhenNoneAreConfigured() {
+    final OkHttpClient httpClient = BaseClient.newHttpClient("apiKey", new ClientOptions());
+
+    assertEquals(10_000, httpClient.connectTimeoutMillis());
+    assertEquals(10_000, httpClient.readTimeoutMillis());
+    assertEquals(10_000, httpClient.writeTimeoutMillis());
+    assertEquals(0, httpClient.callTimeoutMillis());
+  }
+
+  @Test
+  public void testConfiguredTimeoutsAreAppliedToTheHttpClient() {
+    final ClientOptions clientOptions = new ClientOptions();
+    clientOptions.setConnectTimeout(Duration.ofSeconds(5));
+    clientOptions.setReadTimeout(Duration.ofSeconds(30));
+    clientOptions.setWriteTimeout(Duration.ofSeconds(20));
+    clientOptions.setCallTimeout(Duration.ofSeconds(60));
+
+    final OkHttpClient httpClient = BaseClient.newHttpClient("apiKey", clientOptions);
+
+    assertEquals(5_000, httpClient.connectTimeoutMillis());
+    assertEquals(30_000, httpClient.readTimeoutMillis());
+    assertEquals(20_000, httpClient.writeTimeoutMillis());
+    assertEquals(60_000, httpClient.callTimeoutMillis());
+  }
+
+  @Test
+  public void testTimeoutsAreAppliedIndividually() {
+    final ClientOptions clientOptions = new ClientOptions();
+    clientOptions.setReadTimeout(Duration.ofSeconds(45));
+
+    final OkHttpClient httpClient = BaseClient.newHttpClient("apiKey", clientOptions);
+
+    assertEquals(45_000, httpClient.readTimeoutMillis());
+    assertEquals(10_000, httpClient.connectTimeoutMillis());
+    assertEquals(10_000, httpClient.writeTimeoutMillis());
+  }
+
+  @Test
+  public void testConfiguredTimeoutsSurviveClientConstruction() {
+    final ClientOptions clientOptions = new ClientOptions();
+    clientOptions.setReadTimeout(Duration.ofSeconds(30));
+
+    final Client client = new Client("apiKey", clientOptions);
+
+    assertEquals(30_000, httpClientOf(client).readTimeoutMillis());
+  }
+
+  private static OkHttpClient httpClientOf(final BaseClient client) {
+    try {
+      final Field field = BaseClient.class.getDeclaredField("client");
+      field.setAccessible(true);
+      return (OkHttpClient) field.get(client);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(e.getMessage(), e);
+    }
   }
 
   private static String getResponseJson() {


### PR DESCRIPTION
## Problem

`BaseClient` builds its `OkHttpClient` with no timeout overrides, so every caller gets the OkHttp defaults — **10s connect, 10s read, 10s write**, and no overall call timeout — with no supported way to change them:

- `Client` exposes only `Client(apiKey)` and `Client(apiKey, ClientOptions)`
- `ClientOptions` carries the region and nothing else
- `newHttpClient` is `private static`
- the `BaseClient` constructors that do accept an `OkHttpClient` are `protected`, and a `Client` subclass cannot reach them through `super(...)`

So the only routes available today are reflection over `BaseClient`'s `private final OkHttpClient client` field, or vendoring the SDK. Neither is something we want in a payments integration.

## Why 10s read is the painful one

For an integration whose Recurly calls are mostly writes, a 10s read timeout converts a slow-but-successful response into a failure whose **outcome the caller cannot determine**. A `createSubscription` that times out at 10s may well have been applied at Recurly — so the caller cannot simply retry, and instead has to reconcile by reading back the account's subscriptions and matching them against what it asked for.

We have production evidence of exactly that: a recent burst of timed-out subscription creates all took 10.7–10.8s, and in every case the write had in fact landed — confirmed by Recurly's own `new_subscription` and `successful_payment` webhooks arriving seconds later. The customer was charged and shown an error. Being able to raise the read timeout is a far smaller thing to own than the reconciliation logic it forces.

## Change

`ClientOptions` gains optional `connectTimeout`, `readTimeout`, `writeTimeout` and `callTimeout` (`java.time.Duration`), and `newHttpClient` applies each one that is set:

```java
ClientOptions options = new ClientOptions();
options.setReadTimeout(Duration.ofSeconds(30));
Client client = new Client(apiKey, options);
```

Anything left unset behaves exactly as before, so this is source- and behaviour-compatible. `newHttpClient` becomes package-private so the tests can assert on the client it builds; it is not part of the public surface either way.

## Tests

Four new cases in `BaseClientTest`:

- defaults unchanged when nothing is configured (pins the current 10s/10s/10s and no call timeout)
- all four timeouts applied when set
- timeouts applied individually, without disturbing the others
- a configured timeout surviving construction through the public `Client(apiKey, ClientOptions)` constructor

`mvn test` is green: **48 tests, 0 failures**, with the existing 26 `BaseClientTest` cases untouched. Reverting the wiring in `newHttpClient` fails exactly the three tests that assert configured values, so they do bind to the change.

I could not run `./scripts/format` — `bin/google-java-format-1.35.0-all-deps.jar` is not present in the repo — so the new code follows the surrounding style by hand and stays within 100 columns. Happy to reformat if CI disagrees.

## Notes

- `ClientOptions.java` and `BaseClient.java` both lack the "automatically created by Recurly's OpenAPI generation process" banner, so I have taken them to be hand-written and in scope for a PR per CONTRIBUTING.
- I could not find an existing issue requesting this, so there is nothing to link. Happy to open one first if you would rather discuss it there.
- Related: #261 and the guard in #338, which is the other half of what makes a timed-out write hard to reason about — the retry that follows a timeout can come back with a response the client cannot read.
