### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -255,6 +255,7 @@ x-tagGroups:
   - automated_exports
   - general_ledger_account
   - performance_obligations
+  - invoice_templates
 - name: App Management
   tags:
   - external_subscriptions
@@ -264,12 +265,87 @@ x-tagGroups:
   - external_product_references
   - external_payment_phases
 tags:
-- name: site
-  x-displayName: Site
-- name: custom_field_definition
-  x-displayName: Custom Field Definition
-  description: Describes the fields that can be used as custom fields on accounts,
-    items, line-items (one time charges), plans, or subscriptions.
+- name: account
+  x-displayName: Account
+  description: Accounts are core to managing your customers inside of Recurly. The
+    account object stores the entire Recurly history of your customer and acts as
+    the entry point for working with a customer's billing information, subscription
+    data, transactions, invoices and more.
+- name: note
+  x-displayName: Account Note
+  description: Account notes allow your team to leave notes on an account to add context,
+    e.g. the reason for a refund, customer requests, and/or complaints. These notes
+    are internal and not exposed to your customers.
+- name: account_acquisition
+  x-displayName: Account Acquisition Info
+  description: Recurly offers the ability to record marketing data on customer accounts
+    to match this data with revenue and billing data events in Recurly.
+- name: billing_info
+  x-displayName: Billing Info
+  description: Without the premium Wallet feature, an account can only have one stored
+    payment method at a time. Examples include credit cards, PayPal, or bank accounts.
+    Billing info is filled out by the customer upon purchase or when they update their
+    information.
+- name: billing_infos
+  x-displayName: Billing Infos
+  description: If the premium Wallet feature is enabled, an account can have multiple
+    payment methods stored. Examples include credit cards, PayPal, or bank accounts.
+    Primary or backup billing infos can be designated from these endpoints.
+- name: coupon_redemption
+  x-displayName: Coupon Redemption
+  description: Coupon redemptions are created when a coupon is applied to an account
+    or subscription. This allows you to track your promotions.
+- name: subscription
+  x-displayName: Subscription
+  description: Subscriptions are created when your customers subscribe to one of your
+    plans. The customer's subscription tells Recurly when and how much to bill the
+    customer.
+- name: subscription_change
+  x-displayName: Subscription Change
+  description: Subscription changes alter subscription in a way that might affect
+    the invoiced amount, such as changing the plan, add-ons, quantities, or shipping
+    address. Changes can be made immediately in the current billing cycle or scheduled
+    to take place at the next renewal.
+- name: usage
+  x-displayName: Usage
+  description: Send Recurly your customer usage and we will automatically bill them
+    in arrears at the end of the billing cycle. For more info on usage-based billing,
+    [click here](https://docs.recurly.com/docs/usage-based-billing).
+- name: shipping_address
+  x-displayName: Shipping Address
+  description: Shipping addresses are tied to a customer's account. Each account can
+    have up to 20 different shipping addresses, and if you have enabled multiple subscriptions
+    per account, you can associate different shipping addresses to each subscription.
+- name: purchase
+  x-displayName: Purchase
+  description: A purchase is a checkout containing at least one or more subscriptions
+    or one-time charges (line items) and supports both coupon and gift card redemptions.
+    All items purchased will be on one invoice and paid for with one transaction.
+    The purchases endpoint can also be used to immediately create a credit invoice
+    on an account, when Credit Invoices is enabled on your site.
+- name: invoice
+  x-displayName: Invoice
+  description: An invoice relates charges, credits, and payments together. When a
+    subscription is created or renewed or a charge is created on the account, Recurly
+    will sum the charges, discount or tax as appropriate, and send the invoice out
+    for collection.
+- name: line_item
+  x-displayName: Line Item
+  description: Line items are the charges and credits on your customer's invoices.
+- name: credit_payment
+  x-displayName: Credit Payment
+- name: transaction
+  x-displayName: Transaction
+  description: Purchasing information is sent to your payment gateway in an action
+    called a transaction. This includes the customer's billing information and the
+    amount of money to be charged, voided, or refunded.
+- name: revenue_recovery
+  x-displayName: Revenue Recovery
+  description: Revenue recovery
+- name: gift_cards
+  x-displayName: Gift Cards
+  description: Add gift card purchases to your checkout and allow gift card recipients
+    to redeem the gift card for credit towards any of your products.
 - name: item
   x-displayName: Item
   description: |-
@@ -290,139 +366,35 @@ tags:
   description: A measured unit describes a usage-based add-on's usage. If different
     usage-based add-ons share the same measured unit, you can report on customer usage
     for those add-ons at the aggregated measured unit level.
-- name: account
-  x-displayName: Account
-  description: Accounts are core to managing your customers inside of Recurly. The
-    account object stores the entire Recurly history of your customer and acts as
-    the entry point for working with a customer's billing information, subscription
-    data, transactions, invoices and more.
-- name: note
-  x-displayName: Account Note
-  description: Account notes allow your team to leave notes on an account to add context,
-    e.g. the reason for a refund, customer requests, and/or complaints. These notes
-    are internal and not exposed to your customers.
-- name: account_acquisition
-  x-displayName: Account Acquisition Info
-  description: Recurly offers the ability to record marketing data on customer accounts
-    to match this data with revenue and billing data events in Recurly.
-- name: price_segment
-  x-displayName: Price Segment
-- name: billing_info
-  x-displayName: Billing Info
-  description: Without the premium Wallet feature, an account can only have one stored
-    payment method at a time. Examples include credit cards, PayPal, or bank accounts.
-    Billing info is filled out by the customer upon purchase or when they update their
-    information.
-- name: billing_infos
-  x-displayName: Billing Infos
-  description: If the premium Wallet feature is enabled, an account can have multiple
-    payment methods stored. Examples include credit cards, PayPal, or bank accounts.
-    Primary or backup billing infos can be designated from these endpoints.
-- name: subscription
-  x-displayName: Subscription
-  description: Subscriptions are created when your customers subscribe to one of your
-    plans. The customer's subscription tells Recurly when and how much to bill the
-    customer.
-- name: subscription_change
-  x-displayName: Subscription Change
-  description: Subscription changes alter subscription in a way that might affect
-    the invoiced amount, such as changing the plan, add-ons, quantities, or shipping
-    address. Changes can be made immediately in the current billing cycle or scheduled
-    to take place at the next renewal.
-- name: shipping_address
-  x-displayName: Shipping Address
-  description: Shipping addresses are tied to a customer's account. Each account can
-    have up to 20 different shipping addresses, and if you have enabled multiple subscriptions
-    per account, you can associate different shipping addresses to each subscription.
-- name: invoice
-  x-displayName: Invoice
-  description: An invoice relates charges, credits, and payments together. When a
-    subscription is created or renewed or a charge is created on the account, Recurly
-    will sum the charges, discount or tax as appropriate, and send the invoice out
-    for collection.
-- name: revenue_recovery
-  x-displayName: Revenue Recovery
-  description: Revenue recovery
-- name: line_item
-  x-displayName: Line Item
-  description: Line items are the charges and credits on your customer's invoices.
-- name: credit_payment
-  x-displayName: Credit Payment
-- name: purchase
-  x-displayName: Purchase
-  description: A purchase is a checkout containing at least one or more subscriptions
-    or one-time charges (line items) and supports both coupon and gift card redemptions.
-    All items purchased will be on one invoice and paid for with one transaction.
-    The purchases endpoint can also be used to immediately create a credit invoice
-    on an account, when Credit Invoices is enabled on your site.
-- name: usage
-  x-displayName: Usage
-  description: Send Recurly your customer usage and we will automatically bill them
-    in arrears at the end of the billing cycle. For more info on usage-based billing,
-    [click here](https://docs.recurly.com/docs/usage-based-billing).
-- name: transaction
-  x-displayName: Transaction
-  description: Purchasing information is sent to your payment gateway in an action
-    called a transaction. This includes the customer's billing information and the
-    amount of money to be charged, voided, or refunded.
 - name: coupon
   x-displayName: Coupon
   description: Coupons can either be single codes that easily allow mass distribution
     by many customers or bulk coupons that can generate many unique coupons that can
     allow for individual delivery and tracking.
-- name: coupon_redemption
-  x-displayName: Coupon Redemption
-  description: Coupon redemptions are created when a coupon is applied to an account
-    or subscription. This allows you to track your promotions.
 - name: unique_coupon_code
   x-displayName: Unique Coupon Code
   description: Unique coupon codes are generated from bulk coupons.
+- name: price_segment
+  x-displayName: Price Segment
+- name: site
+  x-displayName: Site
+- name: custom_field_definition
+  x-displayName: Custom Field Definition
+  description: Describes the fields that can be used as custom fields on accounts,
+    items, line-items (one time charges), plans, or subscriptions.
 - name: shipping_method
   x-displayName: Shipping Method
   description: Shipping methods offered to send products to customers.
-- name: automated_exports
-  x-displayName: Automated Exports
-  description: Automated exports of customer data.
 - name: dunning_campaigns
   x-displayName: Dunning Campaigns
   description: Settings used when attempting to dun customers whose payments are declined.
-- name: external_subscriptions
-  x-displayName: External Subscription
-  description: A subscription from an external resource that is not managed by the
-    Recurly platform and instead is managed by third-party platforms like Apple App
-    Store and Google Play Store.
-- name: external_invoices
-  x-displayName: External Invoice
-  description: An invoice from an external resource that is not managed by the Recurly
-    platform and instead is managed by third-party platforms like Apple App Store
-    and Google Play Store.
-- name: external_products
-  x-displayName: External Product
-  description: A product from an external resource that is not managed by the Recurly
-    platform and instead is managed by third-party platforms like Apple App Store
-    and Google Play Store.
-- name: external_product_references
-  x-displayName: External Product Reference
-  description: Associates an external product to a corresponding resource on an external
-    platform like the Apple App Store or Google Play Store.
-- name: external_payment_phases
-  x-displayName: External Payment Phase
-  description: Details of payments in the lifecycle of a subscription from an external
-    resource that is not managed by the Recurly platform, e.g. App Store or Google
-    Play Store.
-- name: gift_cards
-  x-displayName: Gift Cards
-  description: Add gift card purchases to your checkout and allow gift card recipients
-    to redeem the gift card for credit towards any of your products.
-- name: external_accounts
-  x-displayName: External Account
-  description: An account from an external resource that is not managed by the Recurly
-    platform and instead is managed by third-party platforms like Apple App Store
-    and Google Play Store.
 - name: business_entities
   x-displayName: Business Entities
   description: Describes the business address that will be used for invoices and taxes
     depending on settings and subscriber location.
+- name: automated_exports
+  x-displayName: Automated Exports
+  description: Automated exports of customer data.
 - name: general_ledger_account
   x-displayName: General Ledger Account
   description: |
@@ -472,6 +444,37 @@ tags:
       - The customer receives and consumes the benefits of the goods or services as they are provided
       by the entity (routine, recurring services like a cleaning service are an example of a series of
       services that are substantially the same and have the same pattern of transfer)
+- name: invoice_templates
+  x-displayName: Invoice Templates
+- name: external_subscriptions
+  x-displayName: External Subscription
+  description: A subscription from an external resource that is not managed by the
+    Recurly platform and instead is managed by third-party platforms like Apple App
+    Store and Google Play Store.
+- name: external_invoices
+  x-displayName: External Invoice
+  description: An invoice from an external resource that is not managed by the Recurly
+    platform and instead is managed by third-party platforms like Apple App Store
+    and Google Play Store.
+- name: external_products
+  x-displayName: External Product
+  description: A product from an external resource that is not managed by the Recurly
+    platform and instead is managed by third-party platforms like Apple App Store
+    and Google Play Store.
+- name: external_accounts
+  x-displayName: External Account
+  description: An account from an external resource that is not managed by the Recurly
+    platform and instead is managed by third-party platforms like Apple App Store
+    and Google Play Store.
+- name: external_product_references
+  x-displayName: External Product Reference
+  description: Associates an external product to a corresponding resource on an external
+    platform like the Apple App Store or Google Play Store.
+- name: external_payment_phases
+  x-displayName: External Payment Phase
+  description: Details of payments in the lifecycle of a subscription from an external
+    resource that is not managed by the Recurly platform, e.g. App Store or Google
+    Play Store.
 paths:
   "/sites":
     get:
@@ -571,6 +574,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, site := range sites.Data()
           {\n\t\tfmt.Printf(\"Site %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tsite.Id,\n\t\t\tsite.Subdomain,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const sites = client.listSites({ params: { limit: 200 } })
+
+            for await (const site of sites.each()) {
+              console.log(site.subdomain)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            sites = client.list_sites(params=params).items()
+            for site in sites:
+                print(site.subdomain)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListSitesParams()
+            {
+                Limit = 200
+            };
+            var sites = client.ListSites(optionalParams);
+            foreach(Site site in sites)
+            {
+                Console.WriteLine(site.Subdomain);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            sites = @client.list_sites(params: params)
+            sites.each do |site|
+              puts "Site: #{site.subdomain}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListSitesParams params = new ListSitesParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Site> sites = client.listSites(params);
+
+            for (Site site : sites) {
+                System.out.println(site.getSubdomain());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $sites = $client->listSites($options);
+
+            foreach($sites as $site) {
+              echo 'Site: ' . $site->getSubdomain() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListSitesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"asc\"),\n\tLimit: recurly.Int(200),\n}\n\nsites, err
+            := client.ListSites(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor sites.HasMore() {\n\terr := sites.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, site := range sites.Data()
+            {\n\t\tfmt.Printf(\"Site %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tsite.Id,\n\t\t\tsite.Subdomain,\n\t\t)\n\t}\n}"
+          name: Go
   "/sites/{site_id}":
     get:
       operationId: get_site
@@ -687,6 +761,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Site:
           %s\", site.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const site = await client.getSite(siteId)
+              console.log('Fetched site: ', site)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                site = client.get_site(site_id)
+                print("Got Site %s" % site)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Site site = client.GetSite(siteId);
+                Console.WriteLine($"Fetched site {site.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              site = @client.get_site(site_id: site_id)
+              puts "Got Site #{site}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Site site = client.getSite(siteId);
+                System.out.println("Fetched site: " + site.getId());
+              } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $site = $client->getSite($site_id);
+
+                echo 'Got Site:' . PHP_EOL;
+                var_dump($site);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "site, err := client.GetSite(siteID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Site:
+            %s\", site.Id)"
+          name: Go
   "/accounts":
     get:
       tags:
@@ -793,6 +964,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, account := range accounts.Data()
           {\n\t\tfmt.Printf(\"Account %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taccount.Id,\n\t\t\taccount.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const accounts = client.listAccounts({ params: { limit: 200 } })
+
+            for await (const account of accounts.each()) {
+              console.log(account.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            accounts = client.list_accounts(params=params).items()
+            for account in accounts:
+                print(account.code)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListAccountsParams()
+            {
+                Limit = 200
+            };
+            var accounts = client.ListAccounts(optionalParams);
+            foreach(Account account in accounts)
+            {
+                Console.WriteLine(account.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            accounts = @client.list_accounts(params: params)
+            accounts.each do |account|
+              puts "Account: #{account.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountsParams params = new ListAccountsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            Pager<Account> accounts = client.listAccounts(params);
+
+            for (Account acct : accounts) {
+                System.out.println(acct.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $accounts = $client->listAccounts($options);
+
+            foreach($accounts as $account) {
+              echo 'Account code: ' . $account->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naccounts, err
+            := client.ListAccounts(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor accounts.HasMore() {\n\terr := accounts.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, account := range accounts.Data()
+            {\n\t\tfmt.Printf(\"Account %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taccount.Id,\n\t\t\taccount.Code,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - account
@@ -1049,6 +1291,227 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Account:
           %s\", account.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const accountCreate = {
+                code: accountCode,
+                firstName: 'Benjamin',
+                lastName: 'Du Monde',
+                preferredTimeZone: 'America/Chicago',
+                address: {
+                  street1: '900 Camp St',
+                  city: 'New Orleans',
+                  region: 'LA',
+                  postalCode: '70115',
+                  country: 'US'
+                }
+              }
+              const account = await client.createAccount(accountCreate)
+              console.log('Created Account: ', account.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                account_create = {
+                    "code": account_code,
+                    "first_name": "Benjamin",
+                    "last_name": "Du Monde",
+                    "preferred_time_zone": "America/Chicago",
+                    "acquisition": {
+                        "campaign": "podcast-marketing",
+                        "channel": "social_media",
+                        "subchannel": "twitter",
+                        "cost": {"currency": "USD", "amount": 0.50},
+                    },
+                    "shipping_addresses": [
+                        {
+                            "nickname": "Home",
+                            "street1": "1 Tchoupitoulas St",
+                            "city": "New Orleans",
+                            "region": "LA",
+                            "country": "US",
+                            "postal_code": "70115",
+                            "first_name": "Aaron",
+                            "last_name": "Du Monde",
+                        }
+                    ],
+                }
+                account = client.create_account(account_create)
+                print("Created Account %s" % account)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var accountReq = new AccountCreate()
+                {
+                    Code = accountCode,
+                    FirstName = "Benjamin",
+                    LastName = "Du Monde",
+                    PreferredTimeZone = "America/Chicago",
+                    Address = new Address()
+                    {
+                        City = "New Orleans",
+                        Region = "LA",
+                        Country = "US",
+                        PostalCode = "70115",
+                        Street1 = "900 Camp St."
+                    }
+                };
+                Account account = client.CreateAccount(accountReq);
+                Console.WriteLine($"Created account {account.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              account_create = {
+                code: account_code,
+                first_name: "Benjamin",
+                last_name: "Du Monde",
+                preferred_time_zone: "America/Chicago",
+                acquisition: {
+                  campaign: "podcast-marketing",
+                  channel: "social_media",
+                  subchannel: "twitter",
+                  cost: {
+                    currency: "USD",
+                    amount: 0.50
+                  }
+                },
+                shipping_addresses: [
+                  {
+                    nickname: "Home",
+                    street1: "1 Tchoupitoulas St",
+                    city: "New Orleans",
+                    region: "LA",
+                    country: "US",
+                    postal_code: "70115",
+                    first_name: "Benjamin",
+                    last_name: "Du Monde"
+                  }
+                ]
+              }
+              account = @client.create_account(body: account_create)
+              puts "Created Account #{account}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                AccountCreate accountReq = new AccountCreate();
+                Address address = new Address();
+
+                accountReq.setCode(accountCode);
+                accountReq.setFirstName("Aaron");
+                accountReq.setLastName("Du Monde");
+                accountReq.setPreferredTimeZone("America/Chicago");
+
+                address.setStreet1("900 Camp St.");
+                address.setCity("New Orleans");
+                address.setRegion("LA");
+                address.setCountry("US");
+                address.setPostalCode("70115");
+
+                accountReq.setAddress(address);
+
+                Account account = client.createAccount(accountReq);
+                System.out.println("Created account " + account.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $account_create = [
+                    "code" => $account_code,
+                    "first_name" => "Douglas",
+                    "last_name" => "DuMonde",
+                    "preferred_time_zone" => "America/Chicago",
+                    "shipping_addresses" => [
+                        [
+                            "first_name" => "Douglas",
+                            "last_name" => "DuMonde",
+                            "nickname" => "nola",
+                            "street1" => "1 Tchoupitoulas",
+                            "city" => "New Orleans",
+                            "postal_code" => "70130",
+                            "country" => "US"
+                        ]
+                    ]
+                ];
+
+                $account = $client->createAccount($account_create);
+
+                echo 'Created Account:' . PHP_EOL;
+                var_dump($account);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "accountReq := &recurly.AccountCreate{\n\tCode:      &accountCode,\n\tFirstName:
+            recurly.String(\"Isaac\"),\n\tLastName:  recurly.String(\"Du Monde\"),\n\tEmail:
+            \    recurly.String(\"isaac@example.com\"),\n\tPreferredTimeZone: recurly.String(\"America/Los_Angeles\"),\n\tBillingInfo:
+            &recurly.BillingInfoCreate{\n\t\tFirstName: recurly.String(\"Isaac\"),\n\t\tLastName:
+            \ recurly.String(\"Du Monde\"),\n\t\tAddress: &recurly.AddressCreate{\n\t\t\tPhone:
+            \     recurly.String(\"415-555-5555\"),\n\t\t\tStreet1:    recurly.String(\"400
+            Alabama St.\"),\n\t\t\tCity:       recurly.String(\"San Francisco\"),\n\t\t\tPostalCode:
+            recurly.String(\"94110\"),\n\t\t\tCountry:    recurly.String(\"US\"),\n\t\t\tRegion:
+            \    recurly.String(\"CA\"),\n\t\t},\n\t\tNumber: recurly.String(\"4111111111111111\"),\n\t\tMonth:
+            \ recurly.String(\"12\"),\n\t\tYear:   recurly.String(\"30\"),\n\t\tCvv:
+            \   recurly.String(\"123\"),\n\t},\n}\n\naccount, err := client.CreateAccount(accountReq)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Account:
+            %s\", account.Id)"
+          name: Go
   "/accounts/{account_id}":
     parameters:
     - "$ref": "#/components/parameters/account_id"
@@ -1159,6 +1622,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Println(\"Fetched Account
           \", account.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const account = await client.getAccount(accountId)
+              console.log('Fetched account: ', account.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                account = client.get_account(account_id)
+                print("Got Account %s" % account)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Account account = client.GetAccount(accountId);
+                Console.WriteLine($"Fetched account {account.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              account = @client.get_account(account_id: account_id)
+              puts "Got Account #{account}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Account account = client.getAccount(accountId);
+                System.out.println("Fetched account: " + account.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $account = $client->getAccount($account_id);
+
+                echo 'Got Account:' . PHP_EOL;
+                var_dump($account);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "account, err := client.GetAccount(accountID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Println(\"Fetched Account
+            \", account.Id)"
+          name: Go
     put:
       tags:
       - account
@@ -1321,6 +1881,133 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Account:
           %s\", account.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const accountUpdate = {
+                firstName: 'Aaron',
+                lastName: 'Du Monde'
+              }
+              const account = await client.updateAccount(accountId, accountUpdate)
+              console.log('Updated account: ', account)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                account_update = {"first_name": "Aaron", "last_name": "Du Monde"}
+                account = client.update_account(account_id, account_update)
+                print("Updated Account %s" % account)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var accountReq = new AccountUpdate() {
+                    FirstName = "Aaron",
+                    LastName = "Du Monde"
+                };
+                Account account = client.UpdateAccount(accountId, accountReq);
+                Console.WriteLine(account.FirstName);
+                Console.WriteLine(account.LastName);
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              account_update = {
+                first_name: "Aaron",
+                last_name: "Du Monde",
+              }
+              account = @client.update_account(
+                account_id: account_id,
+                body: account_update
+              )
+              puts "Updated Account #{account}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AccountUpdate accountUpdate = new AccountUpdate();
+                accountUpdate.setFirstName("Aaron");
+                accountUpdate.setLastName("Du Monde");
+
+                final Account account = client.updateAccount(accountId, accountUpdate);
+                System.out.println("Updated account: " + account.getCode());
+                System.out.println(account.getFirstName());
+                System.out.println(account.getLastName());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $account_update = [
+                    "first_name" => "Douglas",
+                    "last_name" => "Du Monde",
+                ];
+
+                $account = $client->updateAccount($account_id, $account_update);
+
+                echo 'Updated Account:' . PHP_EOL;
+                var_dump($account);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.AccountUpdate{\n\tFirstName: recurly.String(\"Joanna\"),\n\tLastName:
+            \ recurly.String(\"DuMonde\"),\n}\naccount, err := client.UpdateAccount(accountID,
+            updateReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Account:
+            %s\", account.Id)"
+          name: Go
     delete:
       tags:
       - account
@@ -1446,6 +2133,102 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Deactivated
           Account: %s\", account.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const account = await client.deactivateAccount(accountId)
+              console.log('Deleted account: ', account.code)
+            } catch (err) {
+              if (err && err.type === 'not-found') {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              }
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              throw err
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                account = client.deactivate_account(account_id)
+                print("Deactivated Account %s" % account)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Account account = client.DeactivateAccount(accountId);
+                Console.WriteLine($"Deactivated account {account.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              account = @client.deactivate_account(account_id: account_id)
+              puts "Deactivated Account #{account}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                Account account = client.deactivateAccount(accountId);
+                System.out.println("deactivated account " + account.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $account = $client->deactivateAccount($account_id);
+
+                echo 'Deactivated Account:' . PHP_EOL;
+                var_dump($account);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "account, err := client.DeactivateAccount(accountID)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Deactivated
+            Account: %s\", account.Id)"
+          name: Go
   "/accounts/{account_id}/redact":
     parameters:
     - "$ref": "#/components/parameters/account_id"
@@ -1596,6 +2379,103 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
           Acquisition: %v\", accountAcq.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const acquisition = await client.getAccountAcquisition(accountId)
+              console.log('Fetched account acquisition: ', acquisition.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                acquisition = client.get_account_acquisition(account_id)
+                print("Got AccountAcquisition %s" % acquisition)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                AccountAcquisition acquisition = client.GetAccountAcquisition(accountId);
+                Console.WriteLine($"Fetched account acquisition {acquisition.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              @client.get_account_acquisition(account_id: account_id)
+              puts "Got AccountAcquisition"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AccountAcquisition acquisition = client.getAccountAcquisition(accountId);
+                System.out.println("Fetched account acquisition " + acquisition.getId());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $acquisition = $client->getAccountAcquisition($account_id);
+
+                echo 'Got Account Acquisition:' . PHP_EOL;
+                var_dump($acquisition);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "accountAcq, err := client.GetAccountAcquisition(accountID)\nif e,
+            ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
+            Acquisition: %v\", accountAcq.Id)"
+          name: Go
     put:
       tags:
       - account_acquisition
@@ -1763,6 +2643,145 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Account
           Acquisition: %s\", account.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const acquisitionUpdate = {
+                campaign: "big-event-campaign",
+                channel: "social_media",
+                subchannel: "twitter"
+              }
+              const accountAcquisition = await client.updateAccountAcquisition(accountId, acquisitionUpdate)
+              console.log('Edited Account Acquisition: ', accountAcquisition)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                acquisition_update = {
+                    "campaign": "podcast-marketing",
+                    "channel": "social_media",
+                    "subchannel": "twitter",
+                    "cost": {"currency": "USD", "amount": 0.50},
+                }
+                acquisition = client.update_account_acquisition(account_id, acquisition_update)
+                print("Updated AccountAcquisition %s" % acquisition)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var acquisitionReq = new AccountAcquisitionUpdate()
+                {
+                    Campaign = "big-event-campaign",
+                    Channel = Channel.SocialMedia,
+                    Subchannel = "twitter"
+                };
+                AccountAcquisition accountAcquisition = client.UpdateAccountAcquisition(accountId, acquisitionReq);
+                Console.WriteLine(accountAcquisition);
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              acquisition_update = {
+                campaign: "podcast-marketing",
+                channel: "social_media",
+                subchannel: "twitter",
+                cost: {
+                  currency: "USD",
+                  amount: 0.50
+                }
+              }
+              acquisition = @client.update_account_acquisition(
+                account_id: account_id,
+                body: acquisition_update
+              )
+              puts "Updated AccountAcqusition #{acquisition}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AccountAcquisitionUpdate acqUpdate = new AccountAcquisitionUpdate();
+                acqUpdate.setCampaign("big-event-campaign");
+                acqUpdate.setChannel(Constants.Channel.SOCIAL_MEDIA);
+                acqUpdate.setSubchannel("twitter");
+
+                final AccountAcquisition accountAcquisition = client.updateAccountAcquisition(accountId, acqUpdate);
+                System.out.println(accountAcquisition);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $acquisition_update = [
+                    "campaign" => "big-event-campaign",
+                    "channel" => "social_media",
+                    "subchannel" => "twitter"
+                ];
+                $acquisition = $client->updateAccountAcquisition($account_id, $acquisition_update);
+
+                echo 'Updated AccountAcquisition:' . PHP_EOL;
+                var_dump($acquisition);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.AccountAcquisitionUpdate{\n\tCampaign:   recurly.String(\"big-event-campaign\"),\n\tChannel:
+            \   recurly.String(\"social_media\"),\n\tSubchannel: recurly.String(\"twitter\"),\n}\naccount,
+            err := client.UpdateAccountAcquisition(accountID, updateReq)\nif e, ok
+            := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Account
+            Acquisition: %s\", account.Id)"
+          name: Go
     delete:
       tags:
       - account_acquisition
@@ -1864,6 +2883,101 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Removed Account
           Acquisition: %s\", accountAcquisition.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              await client.removeAccountAcquisition(accountId)
+              console.log('Removed account acquisition from account: ', accountId)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.remove_account_acquisition(account_id)
+                print("Removed AccountAcquisition for Account id=%s" % account_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                client.RemoveAccountAcquisition(accountId);
+                Console.WriteLine($"Removed account acquisition from account {accountId}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              acquisition = @client.remove_account_acquisition(account_id: account_id)
+              puts "Removed AccountAcqusition #{acquisition}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                client.removeAccountAcquisition(accountId);
+                System.out.println("Removed account acquisition from account " + accountId);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $client->removeAccountAcquisition($account_id);
+                echo "Removed Account Acquisition:" . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "client.RemoveAccountAcquisition(accountID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Removed Account
+            Acquisition: %s\", accountAcquisition.Id)"
+          name: Go
   "/accounts/{account_id}/reactivate":
     parameters:
     - "$ref": "#/components/parameters/account_id"
@@ -1987,6 +3101,102 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
           Account: %s\", account.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const account = await client.reactivateAccount(accountId)
+              console.log('Reactivated account: ', account.code)
+            } catch (err) {
+              if (err && err.type === 'not_found') {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              }
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              throw err
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                account = client.reactivate_account(account_id)
+                print("Reactivated Account %s" % account)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Account account = client.ReactivateAccount(accountId);
+                Console.WriteLine($"Reactivated account {account.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              account = @client.reactivate_account(account_id: account_id)
+              puts "Reactivated account #{account}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Account account = client.reactivateAccount(accountId);
+                System.out.println("Reactivated account: " + account.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $account = $client->reactivateAccount($account_id);
+
+                echo 'Reactivated Account:' . PHP_EOL;
+                var_dump($account);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "account, err := client.ReactivateAccount(accountID)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
+            Account: %s\", account.Id)"
+          name: Go
   "/accounts/{account_id}/balance":
     parameters:
     - "$ref": "#/components/parameters/account_id"
@@ -2103,6 +3313,103 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
           Balance: %v\", accountBalance)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const balance = await client.getAccountBalance(accountId)
+              console.log('Fetched account balance: ', balance.balances)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                balance = client.get_account_balance(account_id)
+                print("Got AccountBalance %s" % balance)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                AccountBalance balance = client.GetAccountBalance(accountId);
+                Console.WriteLine($"Fetched account balance {balance.Balances}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              balance = @client.get_account_balance(account_id: account_id)
+              puts "Got AccountBalance #{balance}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AccountBalance balance = client.getAccountBalance(accountId);
+                System.out.println("Fetched account balance " + balance.getBalances());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $balance = $client->getAccountBalance($account_id);
+
+                echo 'Got Account Balance:' . PHP_EOL;
+                var_dump($balance);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "accountBalance, err := client.GetAccountBalance(accountID)\nif e,
+            ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
+            Balance: %v\", accountBalance)"
+          name: Go
   "/accounts/{account_id}/billing_info":
     get:
       tags:
@@ -2220,6 +3527,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Billing
           Info: %v\", billingInfo)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const billingInfo = await client.getBillingInfo(accountId)
+              console.log('Fetched Billing Info: ', billingInfo.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                binfo = client.get_billing_info(account_id)
+                print("Got BillingInfo %s" % binfo)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                BillingInfo billingInfo = client.GetBillingInfo(accountId);
+                Console.WriteLine($"Fetched billing info {billingInfo.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              billing = @client.get_billing_info(account_id: account_id)
+              puts "Got BillingInfo #{billing}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final BillingInfo billingInfo = client.getBillingInfo(accountId);
+                System.out.println("Fetched billing info " + billingInfo.getId());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $binfo = $client->getBillingInfo($account_id);
+
+                echo 'Got BillingInfo:' . PHP_EOL;
+                var_dump($binfo);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "billingInfo, err := client.GetBillingInfo(accountID)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Billing Info: %v\", billingInfo)"
+          name: Go
     put:
       tags:
       - billing_info
@@ -2393,6 +3797,129 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Billing
           Info: %s\", billingInfo)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const billingInfoUpdate = {
+                firstName: 'Aaron',
+                lastName: 'Du Monde',
+              }
+              const billingInfo = await client.updateBillingInfo(accountId, billingInfoUpdate)
+              console.log('Updated billing info: ', billingInfo.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                billing_update = {"first_name": "Aaron", "last_name": "Du Monde"}
+                billing = client.update_billing_info(account_id, billing_update)
+                print("Updated BillingInfo %s" % billing)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var billingReq = new BillingInfoCreate() {
+                    FirstName = "Benjamin",
+                    LastName = "Du Monde"
+                };
+                BillingInfo billingInfo = client.UpdateBillingInfo(accountId, billingReq);
+                Console.WriteLine($"Updated billing info {billingInfo.Id}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              billing_update = {
+                first_name: "Aaron",
+                last_name: "Du Monde",
+              }
+              billing = @client.update_billing_info(
+                account_id: account_id,
+                body: billing_update
+              )
+              puts "Updated BillingInfo #{billing}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final BillingInfoCreate billingUpdate = new BillingInfoCreate();
+                billingUpdate.setFirstName("Aaron");
+                billingUpdate.setLastName("Du Monde");
+
+                final BillingInfo billingInfo = client.updateBillingInfo(accountId, billingUpdate);
+                System.out.println("Updated billing info " + billingInfo.getId());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $binfo_update = [
+                    "first_name" => "Douglas",
+                    "last_name" => "Du Monde",
+                ];
+                $binfo = $client->updateBillingInfo($account_id, $binfo_update);
+
+                echo 'Updated BillingInfo:' . PHP_EOL;
+                var_dump($binfo);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.BillingInfoCreate{\n\tFirstName: recurly.String(\"Joanna\"),\n\tLastName:
+            \ recurly.String(\"DuMonde\"),\n}\nbillingInfo, err := client.UpdateBillingInfo(accountID,
+            updateReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Billing
+            Info: %s\", billingInfo)"
+          name: Go
     delete:
       tags:
       - billing_info
@@ -2500,6 +4027,101 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Billing
           Info: %v\", billingInfo)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              client.removeBillingInfo(accountId)
+              console.log('Removed billing info from account: ', accountId)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.remove_billing_info(account_id)
+                print("Removed BillingInfo for Account id=%s" % account_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                client.RemoveBillingInfo(accountId);
+                Console.WriteLine($"Removed billing info from account {accountId}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              @client.remove_billing_info(account_id: account_id)
+              puts "Removed BillingInfo #{account_id}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                client.removeBillingInfo(accountId);
+                System.out.println("Removed billing info from account " + accountId);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $client->removeBillingInfo($account_id);
+                echo "Removed Billing Info: " . $account_id . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "billingInfo, err := client.RemoveBillingInfo(accountID)\nif e, ok
+            := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed
+            Billing Info: %v\", billingInfo)"
+          name: Go
   "/accounts/{account_id}/billing_info/verify":
     post:
       tags:
@@ -2631,6 +4253,104 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const transaction = await client.verifyBillingInfo(accountId)
+              console.log('Fetched Transaction: ', transaction.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                transaction = client.verify_billing_info(account_id)
+                print("Got Transaction %s" % transaction)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Transaction transaction = client.VerifyBillingInfo(accountId);
+                Console.WriteLine($"Fetched transaction {transaction.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              transaction = @client.verify_billing_info(account_id: account_id)
+              puts "Got Transaction #{transaction}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Transaction transaction = client.verifyBillingInfo(accountId);
+                System.out.println("Fetched transaction " + transaction.getId());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $transaction = $client->verifyBillingInfo($account_id);
+
+                echo 'Got Transaction:' . PHP_EOL;
+                var_dump($transaction);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "verifyBillingInfoParams := &recurly.VerifyBillingInfoParams{}\ntransaction,
+            err := client.VerifyBillingInfo(accountID, verifyBillingInfoParams)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Transaction: %v\", transaction)"
+          name: Go
   "/accounts/{account_id}/billing_info/verify_cvv":
     post:
       tags:
@@ -3064,6 +4784,76 @@ paths:
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, couponRedemption := range
           accountCouponRedemptions.Data() {\n\t\tfmt.Printf(\"Account Coupon Redemption
           %3d: %s\\n\",\n\t\t\ti,\n\t\t\tcouponRedemption.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const redemptions = client.listAccountCouponRedemptions(accountId, { params: { limit: 200 } })
+
+            for await (const redemption of redemptions.each()) {
+              console.log(redemption.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            redemptions = client.list_account_coupon_redemptions(account_id, params=params).items()
+            for redemption in redemptions:
+                print(redemption.id)
+          name: Python
+        - language: csharp
+          code: |
+            var redemptions = client.ListAccountCouponRedemptions(accountId);
+            foreach(CouponRedemption redemption in redemptions)
+            {
+                Console.WriteLine(redemption.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            redemptions = @client.list_account_coupon_redemptions(
+              account_id: account_id,
+              params: params
+            )
+            redemptions.each do |redemption|
+              puts "CouponRedemption: #{redemption.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountCouponRedemptionsParams params = new ListAccountCouponRedemptionsParams();
+            final Pager<CouponRedemption> redemptions = client.listAccountCouponRedemptions(accountId, params);
+
+            for (CouponRedemption redemption : redemptions) {
+                System.out.println(redemption.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $account_coupon_redemptions = $client->listAccountCouponRedemptions($account->getId(), $options);
+
+            foreach($account_coupon_redemptions as $coupon_redemption) {
+              echo 'Coupon redemption: ' . $coupon_redemption->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountCouponRedemptionsParams{\n\tSort:
+            recurly.String(\"created_at\"),\n}\naccountCouponRedemptions, err := client.ListAccountCouponRedemptions(accountID,
+            listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected error: %v\",
+            err)\n\treturn\n}\n\nfor accountCouponRedemptions.HasMore() {\n\terr :=
+            accountCouponRedemptions.Fetch()\n\tif e, ok := err.(*recurly.Error);
+            ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, couponRedemption := range accountCouponRedemptions.Data() {\n\t\tfmt.Printf(\"Account
+            Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tcouponRedemption.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/accounts/{account_id}/coupon_redemptions/active":
     get:
       tags:
@@ -3149,6 +4939,68 @@ paths:
           foreach($redemptions as $redemption) {
               echo 'Got Redemption: ' . $redemption->getId() . PHP_EOL;
           }
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const redemptions = await client.listActiveCouponRedemptions(accountId, { params: { limit: 200 } })
+
+            for await (const redemption of redemptions.each()) {
+              console.log('Fetched coupon redemption: ', redemption.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            redemptions = client.list_active_coupon_redemptions(account_id, params=params).items()
+            for redemption in redemptions:
+                print(redemption.id)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var redemptions = client.ListActiveCouponRedemptions(accountId);
+                foreach(CouponRedemption redemption in redemptions)
+                {
+                    Console.WriteLine($"Fetched coupon redemption {redemption.Id}");
+                }
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            redemptions = @client.list_active_coupon_redemptions(account_id: account_id, params: params)
+            redemptions.each do |redemption|
+              puts "Redemption: #{redemption.id}"
+            end
+          name: Ruby
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $redemptions = $client->listActiveCouponRedemptions($account_id, $options);
+
+            foreach($redemptions as $redemption) {
+                echo 'Got Redemption: ' . $redemption->getId() . PHP_EOL;
+            }
+          name: PHP
     post:
       tags:
       - coupon_redemption
@@ -3279,6 +5131,106 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Coupon
           Redemption: %v\", couponRedemption)"
+      x-readme:
+        code-samples:
+        - language: python
+          code: |
+            try:
+                redemption_create = {"currency": "USD", "coupon_id": coupon_id}
+                redemption = client.create_coupon_redemption(account_id, redemption_create)
+                print("Created Redemption %s" % redemption)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |-
+            try {
+              var redemptionReq = new CouponRedemptionCreate()
+              {
+                CouponId = couponId,
+              };
+              var redemption = client.CreateCouponRedemption(accountId, redemptionReq);
+              Console.WriteLine($"Created coupon redemption: {redemption.Id}");
+
+            } catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              redemption_create = {
+                currency: 'USD',
+                coupon_id: coupon_id
+              }
+              redemption = @client.create_coupon_redemption(
+                account_id: account_id,
+                body: redemption_create
+              )
+              puts "Created CouponRedemption #{redemption}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                CouponRedemptionCreate coupRedCreate = new CouponRedemptionCreate();
+                coupRedCreate.setCouponId(couponId);
+
+                CouponRedemption redemption = client.createCouponRedemption(accountId, coupRedCreate);
+                System.out.println("Created coupon redemption " + redemption.getId());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $redemption_create = [
+                    "currency" => "USD",
+                    "coupon_id" => "code-$coupon_code"
+                ];
+                $redemption = $client->createCouponRedemption($account_id, $redemption_create);
+                echo "Created Redemption:" . PHP_EOL;
+                var_dump($redemption);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "redemptionReq := &recurly.CouponRedemptionCreate{\n\tCouponId: recurly.String(couponID),\n\tCurrency:
+            recurly.String(\"USD\"),\n}\n\ncouponRedemption, err := client.CreateCouponRedemption(accountID,
+            redemptionReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type ==
+            recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed validation: %v\",
+            e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected Recurly error:
+            %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Coupon Redemption:
+            %v\", couponRedemption)"
+          name: Go
     delete:
       tags:
       - coupon_redemption
@@ -3392,6 +5344,101 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Coupon
           Redemption: %v\", couponRedemption.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const redemption = await client.removeCouponRedemption(accountId)
+              console.log('Removed coupon redemption: ', redemption.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.remove_coupon_redemption(account_id)
+                print("Removed Redemption from Account id=%s" % account_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |-
+            try {
+              var redemption = client.RemoveCouponRedemption(accountId);
+              Console.WriteLine($"Removed coupon redemption from account: {redemption.Id}");
+
+            } catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              @client.remove_coupon_redemption(account_id: account_id)
+              puts "Removed CouponRedemption #{account_id}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final CouponRedemption redemption = client.removeCouponRedemption(accountId);
+                System.out.println("Removed coupon redemption " + redemption.getId());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $redemption = $client->removeCouponRedemption($account_id);
+                echo "Removed Active Coupon Redemption:" . PHP_EOL;
+                var_dump($redemption);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "couponRedemption, err := client.RemoveCouponRedemption(accountID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed
+            Coupon Redemption: %v\", couponRedemption.Id)"
+          name: Go
   "/accounts/{account_id}/coupon_redemptions/{coupon_redemption_id}":
     get:
       tags:
@@ -3563,6 +5610,81 @@ paths:
           := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve next
           page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, creditPayment := range creditPayments.Data()
           {\n\t\tfmt.Printf(\"Account Credit Payment %3d: %s\\n\",\n\t\t\ti,\n\t\t\tcreditPayment.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const payments = client.listAccountCreditPayments(accountId, { params: { limit: 200 } })
+
+            for await (const payment of payments.each()) {
+              console.log(payment.uuid)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            payments = client.list_account_credit_payments(account_id, params=params).items()
+            for payment in payments:
+                print(payment.id)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListAccountCreditPaymentsParams()
+            {
+                Limit = 200
+            };
+            var payments = client.ListAccountCreditPayments(accountId, optionalParams);
+            foreach(CreditPayment payment in payments)
+            {
+                Console.WriteLine(payment.Uuid);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            payments = @client.list_account_credit_payments(
+              account_id: account_id,
+              params: params
+            )
+            payments.each do |payment|
+              puts "CreditPayment: #{payment.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountCreditPaymentsParams params = new ListAccountCreditPaymentsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            Pager<CreditPayment> payments = client.listAccountCreditPayments(accountId, params);
+
+            for (CreditPayment payment : payments) {
+                System.out.println(payment.getUuid());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $credit_payments = $client->listAccountCreditPayments($account->getId(), $options);
+
+            foreach($credit_payments as $payment) {
+              echo 'Credit Payment: ' . $payment->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountCreditPaymentsParams{\n\tSort:
+            \ recurly.String(\"created_at\"),\n\tOrder: recurly.String(\"desc\"),\n\tLimit:
+            recurly.Int(200),\n}\ncreditPayments, err := client.ListAccountCreditPayments(accountID,
+            listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected error: %v\",
+            err)\n\treturn\n}\n\nfor creditPayments.HasMore() {\n\terr := creditPayments.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, creditPayment := range creditPayments.Data()
+            {\n\t\tfmt.Printf(\"Account Credit Payment %3d: %s\\n\",\n\t\t\ti,\n\t\t\tcreditPayment.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/accounts/{account_id}/external_accounts":
     parameters:
     - "$ref": "#/components/parameters/account_id"
@@ -3904,6 +6026,76 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, invoice := range accountInvoices.Data() {\n\t\tfmt.Printf(\"Account Invoice
           %3d: %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const invoices = client.listAccountInvoices(accountId, { params: { limit: 200 } })
+
+            for await (const invoice of invoices.each()) {
+              console.log(invoice.number)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            invoices = client.list_account_invoices(account_id, params=params).items()
+            for invoice in invoices:
+                print(invoice.number)
+          name: Python
+        - language: csharp
+          code: |
+            var invoices = client.ListAccountInvoices(accountId);
+            foreach(Invoice invoice in invoices)
+            {
+                Console.WriteLine(invoice.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            invoices = @client.list_account_invoices(
+              account_id: account_id,
+              params: params
+            )
+            invoices.each do |invoice|
+              puts "Invoice: #{invoice.number}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountInvoicesParams params = new ListAccountInvoicesParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Invoice> invoices = client.listAccountInvoices(accountId, params);
+
+            for (Invoice invoice : invoices) {
+                System.out.println(invoice.getNumber());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $invoices = $client->listAccountInvoices($account->getId(), $options);
+            foreach($invoices as $invoice) {
+              echo 'Account invoice: ' . $invoice->getNumber() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountInvoicesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naccountInvoices,
+            err := client.ListAccountInvoices(accountID, listParams)\nif err != nil
+            {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor accountInvoices.HasMore()
+            {\n\terr := accountInvoices.Fetch()\n\tif e, ok := err.(*recurly.Error);
+            ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, invoice := range accountInvoices.Data() {\n\t\tfmt.Printf(\"Account
+            Invoice %3d: %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - invoice
@@ -4073,6 +6265,138 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Invoice
           Collection: %v\", collection)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let invoiceCreate = {
+                currency: 'USD',
+                collectionMethod: 'automatic'
+              }
+              let invoiceCollection = await client.createInvoice(accountId, invoiceCreate)
+              console.log('Created Invoice')
+              console.log('Charge Invoice: ', invoiceCollection.chargeInvoice)
+              console.log('Credit Invoices: ', invoiceCollection.creditInvoices)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice_create = {"currency": "USD", "collection_method": "automatic"}
+                invoice_collection = client.create_invoice(account_id, invoice_create)
+                print("Created InvoiceCollection %s" % invoice_collection)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                // creates an invoice based on pending charges or credits on account
+                var collection = client.CreateInvoice(accountId, new InvoiceCreate()
+                {
+                    Currency = "USD",
+                    CollectionMethod = CollectionMethod.Automatic
+                });
+                Console.WriteLine("Created Invoice");
+                Console.WriteLine(collection.ChargeInvoice);
+                Console.WriteLine(collection.CreditInvoices);
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice_create = {
+                currency: 'USD',
+                collection_method: 'automatic'
+              }
+              collection = @client.create_invoice(
+                account_id: account_id,
+                body: invoice_create
+              )
+              puts "Created InvoiceCollection #{collection}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                InvoiceCreate invoiceCreate = new InvoiceCreate();
+                invoiceCreate.setCurrency("USD");
+                invoiceCreate.setCollectionMethod(Constants.CollectionMethod.AUTOMATIC);
+
+                InvoiceCollection collection = client.createInvoice(accountId, invoiceCreate);
+                System.out.println("Created Invoice");
+                System.out.println(collection.getChargeInvoice());
+                System.out.println(collection.getCreditInvoices());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $invoice_create = [
+                    "currency" => "USD",
+                    "collection_method" => "automatic"
+                ];
+                $invoice_collection = $client->createInvoice(
+                    $account_id,
+                    $invoice_create
+                );
+                echo "Created Invoice:" . PHP_EOL;
+                var_dump($invoice_collection);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "invoiceReq := &recurly.InvoiceCreate{\n\tCurrency:         recurly.String(\"USD\"),\n\tCollectionMethod:
+            recurly.String(\"automatic\"),\n}\n\ncollection, err := client.CreateInvoice(accountID,
+            invoiceReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Invoice
+            Collection: %v\", collection)"
+          name: Go
   "/accounts/{account_id}/invoices/preview":
     post:
       tags:
@@ -4242,6 +6566,138 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Preview Invoice
           %v\", collection.ChargeInvoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const collection = await client.previewInvoice(accountId, {
+                currency: "USD",
+                collectionMethod: "automatic"
+              })
+              console.log(`Previewed invoice due at ${collection.chargeInvoice.dueAt}`)
+              console.log(collection.chargeInvoice)
+              console.log(collection.creditInvoices)
+            } catch(err) {
+
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice_preview = {"currency": "USD", "collection_method": "automatic"}
+                invoice_collection = client.preview_invoice(account_id, invoice_preview)
+                print("Preview InvoiceCollection %s" % invoice_collection)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                // creates a preview invoice based on pending charges or credits on account
+                var collection = client.PreviewInvoice(accountId, new InvoiceCreate()
+                {
+                    Currency = "USD",
+                    CollectionMethod = CollectionMethod.Automatic
+                });
+                Console.WriteLine($"Previewed invoice DueAt {collection.ChargeInvoice.DueAt}");
+                Console.WriteLine(collection.ChargeInvoice);
+                Console.WriteLine(collection.CreditInvoices);
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice_preview = {
+                currency: "USD",
+                collection_method: "automatic"
+              }
+              collection = @client.create_invoice(
+                account_id: account_id,
+                body: invoice_preview
+              )
+              puts "Created InvoiceCollection #{collection}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                InvoiceCreate invoiceCreate = new InvoiceCreate();
+                invoiceCreate.setCurrency("USD");
+                invoiceCreate.setCollectionMethod(Constants.CollectionMethod.AUTOMATIC);
+
+                InvoiceCollection collection = client.previewInvoice(accountId, invoiceCreate);
+                System.out.println("Previewed Invoice due at " + collection.getChargeInvoice().getDueAt());
+                System.out.println(collection.getChargeInvoice());
+                System.out.println(collection.getCreditInvoices());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $invoice_preview = [
+                    "currency" => "USD",
+                    "collection_method" => "automatic"
+                ];
+                $invoice_collection = $client->previewInvoice(
+                    $account_id,
+                    $invoice_preview
+                );
+                echo "Previewed Invoice:" . PHP_EOL;
+                var_dump($invoice_collection);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "invoiceReq := &recurly.InvoiceCreate{\n\tCurrency: recurly.String(\"USD\"),\n}\n\ncollection,
+            err := client.PreviewInvoice(accountID, invoiceReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Preview Invoice
+            %v\", collection.ChargeInvoice)"
+          name: Go
   "/accounts/{account_id}/line_items":
     get:
       tags:
@@ -4349,6 +6805,77 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, lineItem := range accountLineItems.Data() {\n\t\tfmt.Printf(\"Account
           Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const lineItems = client.listAccountLineItems(accountId, { params: { limit: 200 } })
+
+            for await (const lineItem of lineItems.each()) {
+              console.log(lineItem.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            line_items = client.list_account_line_items(account_id, params=params).items()
+            for line_item in line_items:
+                print(line_item.id)
+          name: Python
+        - language: csharp
+          code: |
+            var lineItems = client.ListAccountLineItems(accountId);
+            foreach(LineItem lineItem in lineItems)
+            {
+                Console.WriteLine(lineItem.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            line_items = @client.list_account_line_items(
+              account_id: account_id,
+              params: params
+            )
+            line_items.each do |line_item|
+              puts "LineItem: #{line_item.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountLineItemsParams params = new ListAccountLineItemsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<LineItem> lineItems = client.listAccountLineItems(accountId, params);
+
+            for (LineItem lineItem : lineItems) {
+                System.out.println(lineItem.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $account_line_items = $client->listAccountLineItems($account_id, $options);
+
+            foreach($account_line_items as $line_item) {
+              echo 'Account line item: ' . $line_item->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountLineItemsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naccountLineItems,
+            err := client.ListAccountLineItems(accountID, listParams)\nif err != nil
+            {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor accountLineItems.HasMore()
+            {\n\terr := accountLineItems.Fetch()\n\tif e, ok := err.(*recurly.Error);
+            ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, lineItem := range accountLineItems.Data() {\n\t\tfmt.Printf(\"Account
+            Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - line_item
@@ -4518,6 +7045,143 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Line
           Item: %v\", lineItem)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let lineItemReq = {
+                currency: 'USD',
+                unitAmount: 1000,
+                type: 'charge' // choose "credit" for a credit
+              }
+              let lineItem = await client.createLineItem(accountId, lineItemReq)
+              console.log('Created Line Item: ', lineItem.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                line_item_create = {
+                    "currency": "USD",
+                    "unit_amount": 1000,
+                    "type": "charge",  # choose "credit" for a credit
+                }
+                line_item = client.create_line_item(account_id, line_item_create)
+                print("Created LineItem %s" % line_item)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                // creates a pending charge or credit on the account
+                var lineItemReq = new LineItemCreate()
+                {
+                    Currency = "USD",
+                    UnitAmount = 1000,
+                    Type = LineItemType.Charge // choose "credit" for a credit
+                };
+                LineItem lineItem = client.CreateLineItem(accountId, lineItemReq);
+                Console.WriteLine($"Created line item {lineItem.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              line_item_create = {
+                currency: 'USD',
+                unit_amount: 1_000,
+                type: :charge
+              }
+              line_item = @client.create_line_item(
+                account_id: account_id,
+                body: line_item_create
+              )
+              puts "Created LineItem #{line_item}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                LineItemCreate lineItemCreate = new LineItemCreate();
+                lineItemCreate.setCurrency("USD");
+                lineItemCreate.setUnitAmount(new BigDecimal("1000.0"));
+                lineItemCreate.setType(Constants.LineItemType.CHARGE); // choose "credit" for a credit
+
+                LineItem lineItem = client.createLineItem(accountId, lineItemCreate);
+                System.out.println("Created line item " + lineItem.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $line_item_create = [
+                    'currency' => 'USD',
+                    'unit_amount' => 1000,
+                    'type' => 'charge'
+                ];
+                $line_item = $client->createLineItem(
+                    $account->getId(),
+                    $line_item_create
+                );
+                echo 'Created Line Item:' . PHP_EOL;
+                var_dump($line_item);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "lineItemReq := &recurly.LineItemCreate{\n\tCurrency:   recurly.String(\"USD\"),\n\tUnitAmount:
+            recurly.Float(1000),\n\tType:       recurly.String(\"charge\"),\n}\n\nlineItem,
+            err := client.CreateLineItem(accountID, lineItemReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Line
+            Item: %v\", lineItem)"
+          name: Go
   "/accounts/{account_id}/notes":
     get:
       tags:
@@ -4605,6 +7269,71 @@ paths:
           accountNotes.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, note := range
           accountNotes.Data() {\n\t\tfmt.Printf(\"Account Note %3d: %s\\n\",\n\t\t\ti,\n\t\t\tnote.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const notes = client.listAccountNotes(accountId, { params: { limit: 200 } })
+
+            for await (const note of notes.each()) {
+              console.log(note.message)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            line_items = client.list_account_line_items(account_id, params=params).items()
+            for line_item in line_items:
+                print(line_item.id)
+          name: Python
+        - language: csharp
+          code: |
+            var notes = client.ListAccountNotes(accountId);
+            foreach(AccountNote note in notes)
+            {
+                Console.WriteLine(note.Message);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            account_notes = @client.list_account_notes(account_id: account_id, params: params)
+            account_notes.each do |note|
+              puts "AccountNote: #{note.message}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountNotesParams params = new ListAccountNotesParams();
+            final Pager<AccountNote> notes = client.listAccountNotes(accountId, params);
+
+            for (AccountNote note : notes) {
+                System.out.println(note.getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $account_notes = $client->listAccountNotes($account_id, $options);
+
+            foreach($account_notes as $note) {
+              echo 'Account note: ' . $note->getMessage() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountNotesParams{}\naccountNotes, err
+            := client.ListAccountNotes(accountID, listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor accountNotes.HasMore() {\n\terr
+            := accountNotes.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
+            to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, note := range
+            accountNotes.Data() {\n\t\tfmt.Printf(\"Account Note %3d: %s\\n\",\n\t\t\ti,\n\t\t\tnote.Id,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - note
@@ -4771,6 +7500,107 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
           Note: %v\", accountNote)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              console.log(accountId)
+              const note = await client.getAccountNote(accountId, accountNoteId)
+              console.log('Fetched account note: ', note.message)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                note = client.get_account_note(account_id, note_id)
+                print("Got AccountNote %s" % note)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                AccountNote note = client.GetAccountNote(accountId, accountNoteId);
+                Console.WriteLine($"Fetched account note: {note.Message}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              note = @client.get_account_note(
+                account_id: account_id,
+                account_note_id: note_id
+              )
+              puts "Got AccountNote #{note}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AccountNote note = client.getAccountNote(accountId, accountNoteId);
+                System.out.println("Fetched account note: " + note.getMessage());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $note = $client->getAccountNote($account_id, $account_node_id);
+
+                echo 'Got Account Note:' . PHP_EOL;
+                var_dump($note);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "accountNote, err := client.GetAccountNote(accountID, accountNoteID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
+            Note: %v\", accountNote)"
+          name: Go
     delete:
       tags:
       - note
@@ -4892,6 +7722,77 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, shippingAddress := range shippingAddresses.Data() {\n\t\tfmt.Printf(\"Shipping
           Address %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tshippingAddress.Id,\n\t\t\tshippingAddress.Street1,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const addresses = client.listShippingAddresses(accountId, { params: { limit: 200 } })
+
+            for await (const address of addresses.each()) {
+              console.log(address.street1)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            shipping_addresses = client.list_shipping_addresses(account_id).items()
+            for shipping_address in shipping_addresses:
+                print(shipping_address.id)
+          name: Python
+        - language: csharp
+          code: |
+            var addresses = client.ListShippingAddresses(accountId);
+            foreach(ShippingAddress address in addresses)
+            {
+                Console.WriteLine(address.Street1);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            shipping_addresses = @client.list_shipping_addresses(
+              account_id: account_id,
+              params: params
+            )
+            shipping_addresses.each do |addr|
+              puts "ShippingAddress: #{addr.nickname} - #{addr.street1}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListShippingAddressesParams params = new ListShippingAddressesParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<ShippingAddress> addresses = client.listShippingAddresses(accountId, params);
+
+            for (ShippingAddress address : addresses) {
+                System.out.println(address.getStreet1());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $shippingAddresses = $client->listShippingAddresses($account_id, $options);
+
+            foreach($shippingAddresses as $address) {
+              echo 'Shipping Address: ' . $address->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListShippingAddressesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nshippingAddresses,
+            err := client.ListShippingAddresses(accountID, listParams)\nif err !=
+            nil {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor
+            shippingAddresses.HasMore() {\n\terr := shippingAddresses.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, shippingAddress := range
+            shippingAddresses.Data() {\n\t\tfmt.Printf(\"Shipping Address %3d: %s,
+            %s\\n\",\n\t\t\ti,\n\t\t\tshippingAddress.Id,\n\t\t\tshippingAddress.Street1,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - shipping_address
@@ -5080,6 +7981,164 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Shipping
           Address: %v\", shippingAddress.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const shippingAddressCreate = {
+                firstName: 'Aaron',
+                lastName: 'Du Monde',
+                street1: '900 Camp St.',
+                city: 'New Orleans',
+                region: 'LA',
+                postalCode: '70115',
+                country: 'US'
+              }
+              const address = await client.createShippingAddress(accountId, shippingAddressCreate)
+              console.log('Created shipping address: ', address.street1)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                shipping_addr_create = {
+                    "first_name": "Aaron",
+                    "last_name": "Du Monde",
+                    "street1": "900 Camp St.",
+                    "city": "New Orleans",
+                    "postal_code": "70115",
+                    "country": "US",
+                }
+                shad = client.create_shipping_address(account_id, shipping_addr_create)
+                print("Created ShippingAddress %s" % shad)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var addrReq = new ShippingAddressCreate()
+                {
+                    FirstName = "Benjamin",
+                    LastName = "Du Monde",
+                    Street1 = "900 Camp St.",
+                    City = "New Orleans",
+                    Region = "LA",
+                    PostalCode = "70115",
+                    Country = "US",
+                };
+                ShippingAddress address = client.CreateShippingAddress(accountId, addrReq);
+                Console.WriteLine($"Created shipping address {address.Street1}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              shipping_address_create = {
+                nickname: 'Work',
+                street1: '900 Camp St',
+                city: 'New Orleans',
+                region: 'LA',
+                country: 'US',
+                postal_code: '70115',
+                first_name: 'Joanna',
+                last_name: 'Du Monde'
+              }
+              shipping_address = @client.create_shipping_address(account_id: account_id, body: shipping_address_create)
+              puts "Created Shipping Address #{shipping_address}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                ShippingAddressCreate shippingAddressCreate = new ShippingAddressCreate();
+                shippingAddressCreate.setFirstName("Aaron");
+                shippingAddressCreate.setLastName("Du Monde");
+                shippingAddressCreate.setStreet1("900 Camp St");
+                shippingAddressCreate.setCity("New Orleans");
+                shippingAddressCreate.setRegion("LA");
+                shippingAddressCreate.setPostalCode("70115");
+                shippingAddressCreate.setCountry("US");
+
+                ShippingAddress shippingAddress = client.createShippingAddress(accountId, shippingAddressCreate);
+                System.out.println("Created shipping address " + shippingAddress.getStreet1());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $address_create = [
+                    "nickname" => "Work",
+                    "street1" => "900 Camp St",
+                    "city" => "New Orleans",
+                    "region" => "LA",
+                    "country" => "US",
+                    "postal_code" => "70115",
+                    "first_name" => "Douglas",
+                    "last_name" => "Du Monde"
+                ];
+                $shipping_address = $client->createShippingAddress($account_id, $address_create);
+
+                echo "Created Shpping Address:" . PHP_EOL;
+                var_dump($shipping_address);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don"t know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "shippingReq := &recurly.ShippingAddressCreate{\n\tNickname:   recurly.String(\"Home\"),\n\tStreet1:
+            \   recurly.String(\"1 Tchoupitoulas St\"),\n\tCity:       recurly.String(\"New
+            Orleans\"),\n\tRegion:     recurly.String(\"LA\"),\n\tCountry:    recurly.String(\"US\"),\n\tPostalCode:
+            recurly.String(\"70115\"),\n\tFirstName:  recurly.String(\"Aaron\"),\n\tLastName:
+            \  recurly.String(\"Du Monde\"),\n}\n\nshippingAddress, err := client.CreateShippingAddress(accountID,
+            shippingReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Shipping
+            Address: %v\", shippingAddress.Id)"
+          name: Go
   "/accounts/{account_id}/shipping_addresses/{shipping_address_id}":
     get:
       tags:
@@ -5200,6 +8259,106 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Shipping
           Address: %v\", shippingAddress)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const address = await client.getShippingAddress(accountId, shippingAddressId)
+              console.log('Fetched shipping address: ', address.street1)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.get_shipping_address(account_id, shipping_address_id)
+                print("Got ShippingAddress %s" % shipping_address_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                ShippingAddress address = client.GetShippingAddress(accountId, shippingAddressId);
+                Console.WriteLine($"Fetched shipping address {address.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              address = @client.get_shipping_address(
+                account_id: account_id,
+                shipping_address_id: shipping_address_id
+              )
+              puts "Got ShippingAddress #{address}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final ShippingAddress address = client.getShippingAddress(accountId, shippingAddressId);
+                System.out.println("Fetched shipping address " + address.getId());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $shipping_address = $client->getShippingAddress($account_id, $shipping_address_id);
+
+                echo 'Got Shipping Address:' . PHP_EOL;
+                var_dump($shipping_address);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "shippingAddress, err := client.GetShippingAddress(accountID, shippingAddressID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Shipping
+            Address: %v\", shippingAddress)"
+          name: Go
     put:
       tags:
       - shipping_address
@@ -5370,6 +8529,139 @@ paths:
           %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected Recurly error:
           %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Shipping Address: %v\",
           shippingAddress)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const shadUpdate = {
+                firstName: "Benjamin",
+                lastName: "Du Monde"
+              }
+              const address = await client.updateShippingAddress(accountId, shippingAddressId, shadUpdate)
+              console.log('Updated shipping address: ', address.street1)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                address_update = {
+                    "first_name": "Aaron",
+                    "last_name": "Du Monde",
+                    "postal_code": "70130",
+                }
+                address = client.update_shipping_address(
+                    account_id, shipping_address_id, address_update
+                )
+                print("Updated ShippingAddress %s" % address)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var shadReq = new ShippingAddressUpdate()
+                {
+                    FirstName = "Aaron",
+                    LastName = "Du Monde"
+                };
+                ShippingAddress address = client.UpdateShippingAddress(accountId, shippingAddressId, shadReq);
+                Console.WriteLine($"Updated shipping address {address.Street1}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              address_update = {
+                first_name: "Aaron",
+                last_name: "Du Monde",
+                postal_code: "70130"
+              }
+              address = @client.update_shipping_address(
+                account_id: account_id,
+                shipping_address_id: shipping_address_id,
+                body: address_update
+              )
+              puts "Updated ShippingAddress #{address}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final ShippingAddressUpdate shadUpdate = new ShippingAddressUpdate();
+                shadUpdate.setFirstName("Aaron");
+                shadUpdate.setLastName("Du Monde");
+
+                final ShippingAddress address = client.updateShippingAddress(accountId, shippingAddressId, shadUpdate);
+                System.out.println("Updated shipping address " + address.getStreet1());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $shad_update = [
+                    "first_name" => "Douglas",
+                    "last_name" => "Du Monde",
+                ];
+                $shad = $client->updateShippingAddress($account_id, $shipping_address_id, $shad_update);
+
+                echo 'Updated Shipping Address:' . PHP_EOL;
+                var_dump($shad);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.ShippingAddressUpdate{\n\tFirstName: recurly.String(\"Joanna\"),\n\tLastName:
+            \ recurly.String(\"DuMonde\"),\n}\nshippingAddress, err := client.UpdateShippingAddress(accountID,
+            shippingAddressID, updateReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif
+            e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource not found:
+            %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected Recurly
+            error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Shipping Address:
+            %v\", shippingAddress)"
+          name: Go
     delete:
       tags:
       - shipping_address
@@ -5477,6 +8769,104 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Shipping
           Address: %v\", shippingAddress)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              await client.removeShippingAddress(accountId, shippingAddress.id)
+              console.log('Removed shipping address: ', shippingAddress.street1)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.remove_shipping_address(account_id, shipping_address_id)
+                print("Removed ShippingAddress %s" % shipping_address_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                client.RemoveShippingAddress(accountId, shippingAddressId);
+                Console.WriteLine($"Removed shipping address {shippingAddressId}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              @client.remove_shipping_address(
+                account_id: account_id,
+                shipping_address_id: shipping_address_id
+              )
+              puts "Removed ShippingAddress #{shipping_address_id}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                client.removeShippingAddress(accountId, shippingAddressId);
+                System.out.println("Removed shipping address " + shippingAddressId);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |-
+            try {
+                $client->removeShippingAddress($account_id, $shipping_address_id);
+                echo "Removed Shipping Address:" . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "shippingAddress, err := client.RemoveShippingAddress(accountID, shippingAddressID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed
+            Shipping Address: %v\", shippingAddress)"
+          name: Go
   "/accounts/{account_id}/subscriptions":
     get:
       tags:
@@ -5581,6 +8971,76 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, sub := range accountSubscriptions.Data()
           {\n\t\tfmt.Printf(\"Account Subscription %3d: %s\\n\",\n\t\t\ti,\n\t\t\tsub.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const subscriptions = client.listAccountSubscriptions(accountId, { params: { limit: 200 } })
+
+            for await (const subscription of subscriptions.each()) {
+              console.log(subscription.uuid)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            subscriptions = client.list_account_subscriptions(account.id, params=params).items()
+            for subscription in subscriptions:
+                print(subscription.uuid)
+          name: Python
+        - language: csharp
+          code: |
+            var subscriptions = client.ListAccountSubscriptions(accountId);
+            foreach(Subscription subscription in subscriptions) {
+              Console.WriteLine(subscription.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            subscriptions = @client.list_account_subscriptions(
+              account_id: account_id,
+              params: params
+            )
+            subscriptions.each do |subscription|
+              puts "Subscription: #{subscription.uuid}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountSubscriptionsParams params = new ListAccountSubscriptionsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Subscription> subscriptions = client.listAccountSubscriptions(accountId, params);
+
+            for (Subscription subscription : subscriptions) {
+                System.out.println(subscription.getUuid());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $account_subscriptions = $client->listAccountSubscriptions($account_id, $options);
+
+            foreach($account_subscriptions as $sub) {
+              echo 'Account subscription: ' . $sub->getUuid() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountSubscriptionsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naccountSubscriptions,
+            err := client.ListAccountSubscriptions(accountID, listParams)\nif err
+            != nil {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor
+            accountSubscriptions.HasMore() {\n\terr := accountSubscriptions.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, sub := range accountSubscriptions.Data()
+            {\n\t\tfmt.Printf(\"Account Subscription %3d: %s\\n\",\n\t\t\ti,\n\t\t\tsub.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/accounts/{account_id}/transactions":
     get:
       tags:
@@ -5687,6 +9147,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, transaction := range accountTransactions.Data()
           {\n\t\tfmt.Printf(\"Account Transaction %3d: %s\\n\",\n\t\t\ti,\n\t\t\ttransaction.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const transactions = client.listAccountTransactions(accountId, { params: { limit: 200 } })
+
+            for await (const transaction of transactions.each()) {
+              console.log(transaction.uuid)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            transactions = client.list_account_transactions(account_id, params=params).items()
+            for transaction in transactions:
+                print("Transaction %s" % transaction.id)
+          name: Python
+        - language: csharp
+          code: |
+            var transactions = client.ListAccountTransactions(accountId);
+            foreach(Transaction transaction in transactions)
+            {
+                Console.WriteLine(transaction.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            transactions = @client.list_account_transactions(
+              account_id: account_id,
+              params: params
+            )
+            transactions.each do |transaction|
+              puts "Transaction: #{transaction.uuid}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountTransactionsParams params = new ListAccountTransactionsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Transaction> transactions = client.listAccountTransactions(accountId, params);
+
+            for (Transaction transaction : transactions) {
+                System.out.println(transaction.getUuid());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $account_transactions = $client->listAccountTransactions($account_id, $options);
+
+            foreach($account_transactions as $transaction) {
+              echo 'Account transactions: ' . $transaction->getUuid() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountTransactionsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naccountTransactions,
+            err := client.ListAccountTransactions(accountID, listParams)\nif err !=
+            nil {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor
+            accountTransactions.HasMore() {\n\terr := accountTransactions.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, transaction := range accountTransactions.Data()
+            {\n\t\tfmt.Printf(\"Account Transaction %3d: %s\\n\",\n\t\t\ti,\n\t\t\ttransaction.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/accounts/{account_id}/accounts":
     get:
       tags:
@@ -5770,6 +9301,50 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, account := range accounts.Data()
           {\n\t\tfmt.Printf(\"Child Account %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taccount.Id,\n\t\t\taccount.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: python
+          code: |
+            params = {"limit": 200}
+            child_accounts = client.list_child_accounts(account_id, params=params).items()
+            for account in child_accounts:
+                print("Child Account %s" % account.code)
+          name: Python
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            child_accounts = @client.list_child_accounts(
+              account_id: account_id,
+              params: params
+            )
+            child_accounts.each do |child|
+              puts "Account: #{child.code}"
+            end
+          name: Ruby
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $child_accounts = $client->listChildAccounts($account_id, $options);
+
+            foreach($child_accounts as $child_account) {
+              echo 'Child Account: ' . $child_account->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListChildAccountsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naccounts, err
+            := client.ListChildAccounts(accountID, listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor accounts.HasMore() {\n\terr := accounts.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, account := range accounts.Data()
+            {\n\t\tfmt.Printf(\"Child Account %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taccount.Id,\n\t\t\taccount.Code,\n\t\t)\n\t}\n}"
+          name: Go
   "/acquisitions":
     get:
       tags:
@@ -5869,6 +9444,74 @@ paths:
           := accountAcquisition.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, a := range accountAcquisition.Data()
           {\n\t\tfmt.Printf(\"Account Acquisition %3d: %s\\n\",\n\t\t\ti,\n\t\t\ta.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const acquisitions = client.listAccountAcquisition({ params: { limit: 200 } })
+
+            for await (const acquisition of acquisitions.each()) {
+              console.log(acquisition.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            acquisitions = client.list_account_acquisition(params=params).items()
+            for acquisition in acquisitions:
+                print(acquisition.id)
+          name: Python
+        - language: csharp
+          code: |
+            var acquisitions = client.ListAccountAcquisition();
+            foreach(AccountAcquisition acquisition in acquisitions)
+            {
+                Console.WriteLine(acquisition.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            acquisitions = @client.list_account_acquisition(params: params)
+            acquisitions.each do |acquisition|
+              puts "AccountAcquisition: #{acquisition.cost}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAccountAcquisitionParams params = new ListAccountAcquisitionParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<AccountAcquisition> acquisitions = client.listAccountAcquisition(params);
+
+            for (AccountAcquisition acquisition : acquisitions) {
+                System.out.println(acquisition.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $account_acquisition = $client->listAccountAcquisition($options);
+
+            foreach($account_acquisition as $aa) {
+              echo 'Account acquisition: ' . $aa->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAccountAcquisitionParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"asc\"),\n\tLimit: recurly.Int(200),\n}\naccountAcquisition,
+            err := client.ListAccountAcquisition(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor accountAcquisition.HasMore() {\n\terr
+            := accountAcquisition.Fetch()\n\tif e, ok := err.(*recurly.Error); ok
+            {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, a := range accountAcquisition.Data() {\n\t\tfmt.Printf(\"Account Acquisition
+            %3d: %s\\n\",\n\t\t\ti,\n\t\t\ta.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/coupons":
     get:
       tags:
@@ -5972,6 +9615,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, coupon := range coupons.Data()
           {\n\t\tfmt.Printf(\"Coupon %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tcoupon.Id,\n\t\t\tcoupon.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const coupons = client.listCoupons({ params: { limit: 200 } })
+
+            for await (const coupon of coupons.each()) {
+              console.log(coupon.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            coupons = client.list_coupons(params=params).items()
+            for coupon in coupons:
+                print(coupon.code)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListCouponsParams()
+            {
+                Limit = 200
+            };
+            var coupons = client.ListCoupons(optionalParams);
+            foreach(Coupon coupon in coupons)
+            {
+                Console.WriteLine(coupon.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            coupons = @client.list_coupons(params: params)
+            coupons.each do |coupon|
+              puts "coupon: #{coupon.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListCouponsParams params = new ListCouponsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Coupon> coupons = client.listCoupons(params);
+
+            for (Coupon coupon : coupons) {
+                System.out.println(coupon.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $coupons = $client->listCoupons($options);
+
+            foreach($coupons as $coupon) {
+              echo 'Coupon: ' . $coupon->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListCouponsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\ncoupons, err
+            := client.ListCoupons(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor coupons.HasMore() {\n\terr := coupons.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, coupon := range coupons.Data()
+            {\n\t\tfmt.Printf(\"Coupon %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tcoupon.Id,\n\t\t\tcoupon.Code,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - coupon
@@ -6169,6 +9883,169 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Coupon:
           %v\", coupon.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const couponCreate = {
+                name: "Promotional Coupon",
+                code: couponCode,
+                discount_type: "fixed",
+                currencies: [{"currency": "USD", "discount": 10}],
+              }
+              const coupon = await client.createCoupon(couponCreate)
+              console.log('Created coupon: ', coupon.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                coupon_create = {
+                    "name": "Promotional Coupon",
+                    "code": coupon_code,
+                    "discount_type": "fixed",
+                    "currencies": [{"currency": "USD", "discount": 10000}],
+                }
+                coupon = client.create_coupon(coupon_create)
+                print("Created Coupon %s" % coupon)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var couponReq = new CouponCreate()
+                {
+                    Name = "Promotional Coupon",
+                    Code = couponCode,
+                    DiscountType = DiscountType.Fixed,
+                    Currencies = new List<CouponPricing>() {
+                      new CouponPricing() {
+                        Currency = "USD",
+                        Discount = 1000
+                      }
+                    }
+                };
+                Coupon coupon = client.CreateCoupon(couponReq);
+                Console.WriteLine($"Created coupon {coupon.Id}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              coupon_create = {
+                name: "Promotional Coupon",
+                code: coupon_code,
+                discount_type: 'fixed',
+                currencies: [
+                  {
+                    currency: 'USD',
+                    discount: 10_000
+                  }
+                ]
+              }
+              coupon = @client.create_coupon(
+                body: coupon_create
+              )
+              puts "Created Coupon #{coupon}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                CouponCreate couponCreate = new CouponCreate();
+
+                couponCreate.setName("Promotional Coupon");
+                couponCreate.setCode(couponCode);
+
+                List<CouponPricing> currencies = new ArrayList<CouponPricing>();
+                CouponPricing couponPrice = new CouponPricing();
+                couponPrice.setCurrency("USD");
+                couponPrice.setDiscount(new BigDecimal("10.0"));
+                currencies.add(couponPrice);
+
+                couponCreate.setCurrencies(currencies);
+                couponCreate.setDiscountType(Constants.DiscountType.FIXED);
+
+                Coupon coupon = client.createCoupon(couponCreate);
+                System.out.println("Created coupon " + coupon.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $coupon_create = [
+                    "name" => "Promotional Coupon",
+                    "code" => $coupon_code,
+                    "discount_type" => "fixed",
+                    "currencies" => [
+                        "currency" => "USD",
+                        "discount" => 10
+                    ]
+                ];
+
+                $coupon = $client->createCoupon($coupon_create);
+
+                echo 'Created Coupon:' . PHP_EOL;
+                var_dump($coupon);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "couponReq := &recurly.CouponCreate{\n\tName:                     recurly.String(\"Promotional
+            Coupon\"),\n\tMaxRedemptions:           recurly.Int(50),\n\tMaxRedemptionsPerAccount:
+            recurly.Int(1),\n\tCode:                     recurly.String(genUuid()),\n\tDiscountType:
+            \            recurly.String(\"percent\"),\n\tDiscountPercent:          recurly.Int(25),\n}\n\ncoupon,
+            err := client.CreateCoupon(couponReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Coupon:
+            %v\", coupon.Id)"
+          name: Go
   "/coupons/{coupon_id}":
     get:
       tags:
@@ -6285,6 +10162,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Coupon:
           %v\", coupon.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const coupon = await client.getCoupon(couponId)
+              console.log('Fetched coupon: ', coupon.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                coupon = client.get_coupon(coupon_id)
+                print("Got Coupon %s" % coupon)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Coupon coupon = client.GetCoupon(couponId);
+                Console.WriteLine($"Fetched coupon {coupon.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              coupon = @client.get_coupon(coupon_id: coupon_id)
+              puts "Got Coupon #{coupon}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Coupon coupon = client.getCoupon(couponId);
+                System.out.println("Fetched coupon " + coupon.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $coupon = $client->getCoupon($coupon_id);
+
+                echo 'Got Coupon:' . PHP_EOL;
+                var_dump($coupon);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "coupon, err := client.GetCoupon(couponID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Coupon: %v\", coupon.Id)"
+          name: Go
     put:
       tags:
       - coupon
@@ -6438,6 +10412,123 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Updated Coupon:
           %v\", coupon.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const couponUpdate = {
+                name: "New Coupon Name"
+              }
+              const coupon = await client.updateCoupon(couponId, couponUpdate)
+              console.log('Updated coupon: ', coupon)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                coupon_update = {
+                  "name": "New Coupon Name",
+                }
+                coupon = client.update_coupon(coupon_id, coupon_update)
+                print("Updated Coupon %s" % coupon)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var couponReq = new CouponUpdate() {
+                    Name = "New Coupon Name"
+                };
+                Coupon coupon = client.UpdateCoupon(couponId, couponReq);
+                Console.WriteLine($"Updated Coupon: {coupon.Id}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              coupon_update = {
+                name: "New Coupon Name"
+              }
+              coupon = @client.update_coupon(coupon_id: coupon_id, body: coupon_update)
+              puts "Updated Coupon #{coupon}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+              final CouponUpdate couponUpdate = new CouponUpdate();
+              couponUpdate.setName("New Coupon Name");
+
+              final Coupon coupon = client.updateCoupon(couponId, couponUpdate);
+              System.out.println("Updated coupon: " + coupon.getCode());
+              System.out.println(coupon.getName());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $coupon_update = [
+                    "name" => "New Coupon Name"
+                ];
+                $coupon = $client->updateCoupon($coupon_id, $coupon_update);
+
+                echo 'Updated Coupon:' . PHP_EOL;
+                var_dump($coupon);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.CouponUpdate{\n\tName: recurly.String(\"New
+            Coupon Name\"),\n}\ncoupon, err := client.UpdateCoupon(couponID, updateReq)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Updated
+            Coupon: %v\", coupon.Id)"
+          name: Go
     delete:
       tags:
       - coupon
@@ -6542,6 +10633,96 @@ paths:
               // Something bad happened... tell the user so that they can fix it?
               echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
           }
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const coupon = await client.deactivateCoupon(couponId)
+              console.log('Deactivated coupon: ', coupon.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                coupon = client.deactivate_coupon(coupon_id)
+                print("Deactivated Coupon %s" % coupon)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Coupon coupon = client.DeactivateCoupon(couponId);
+                Console.WriteLine($"Deactivated coupon {coupon.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              coupon = @client.deactivate_coupon(coupon_id: coupon_id)
+              puts "Deactivated Coupon #{coupon}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Coupon coupon = client.deactivateCoupon(couponId);
+                System.out.println("Deactivated coupon " + coupon.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $coupon = $client->deactivateCoupon($coupon_id);
+
+                echo 'Deactivated Coupon:' . PHP_EOL;
+                var_dump($coupon);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
   "/coupons/{coupon_id}/generate":
     post:
       tags:
@@ -6820,6 +11001,78 @@ paths:
           := creditPayments.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, creditPayment
           := range creditPayments.Data() {\n\t\tfmt.Printf(\"Credit Payment %3d: %s\\n\",\n\t\t\ti,\n\t\t\tcreditPayment.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const payments = client.listCreditPayments({ params: { limit: 200 } })
+
+            for await (const payment of payments.each()) {
+              console.log(payment.uuid)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            payments = client.list_credit_payments(params=params).items()
+            for payment in payments:
+                print("Credit Payment %s" % payment.id)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListCreditPaymentsParams()
+            {
+                Limit = 200
+            };
+            var payments = client.ListCreditPayments(optionalParams);
+            foreach(CreditPayment payment in payments)
+            {
+                Console.WriteLine(payment.Uuid);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            payments = @client.list_credit_payments(params: params)
+            payments.each do |payment|
+              puts "CreditPayment: #{payment.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListCreditPaymentsParams params = new ListCreditPaymentsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<CreditPayment> payments = client.listCreditPayments(params);
+
+            for (CreditPayment payment : payments) {
+                System.out.println(payment.getUuid());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $credit_payments = $client->listCreditPayments($options);
+
+            foreach($credit_payments as $payment) {
+              echo 'Credit Payment: ' . $payment->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListCreditPaymentsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\ncreditPayments,
+            err := client.ListCreditPayments(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor creditPayments.HasMore() {\n\terr
+            := creditPayments.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
+            to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, creditPayment
+            := range creditPayments.Data() {\n\t\tfmt.Printf(\"Credit Payment %3d:
+            %s\\n\",\n\t\t\ti,\n\t\t\tcreditPayment.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/credit_payments/{credit_payment_id}":
     get:
       tags:
@@ -6957,6 +11210,78 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, definition := range customFieldDefinitions.Data()
           {\n\t\tfmt.Printf(\"Custom Field Definition %3d: %s\\n\",\n\t\t\ti,\n\t\t\tdefinition.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const definitions = client.listCustomFieldDefinitions({ params: { limit: 200 } })
+
+            for await (const definition of definitions.each()) {
+              console.log(definition.displayName)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            custom_fields = client.list_custom_field_definitions(params=params).items()
+            for custom_field in custom_fields:
+                print(custom_field.name)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListCustomFieldDefinitionsParams()
+            {
+                Limit = 200
+            };
+            var fields = client.ListCustomFieldDefinitions(optionalParams);
+            foreach(CustomFieldDefinition def in fields)
+            {
+                Console.WriteLine(def.DisplayName);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            custom_fields = @client.list_custom_field_definitions(params: params)
+            custom_fields.each do |field|
+              puts "CustomFieldDefinition: #{field.name}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListCustomFieldDefinitionsParams params = new ListCustomFieldDefinitionsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<CustomFieldDefinition> fields = client.listCustomFieldDefinitions(params);
+
+            for (CustomFieldDefinition field : fields) {
+                System.out.println(field.getDisplayName());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $custom_field_definitions = $client->listCustomFieldDefinitions($options);
+
+            foreach($custom_field_definitions as $definition) {
+              echo 'Custom Field Definition: ' . $definition->getName() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListCustomFieldDefinitionsParams{\n\tSort:
+            \ recurly.String(\"created_at\"),\n\tOrder: recurly.String(\"desc\"),\n\tLimit:
+            recurly.Int(200),\n}\ncustomFieldDefinitions, err := client.ListCustomFieldDefinitions(listParams)\nif
+            err != nil {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor
+            customFieldDefinitions.HasMore() {\n\terr := customFieldDefinitions.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, definition := range customFieldDefinitions.Data()
+            {\n\t\tfmt.Printf(\"Custom Field Definition %3d: %s\\n\",\n\t\t\ti,\n\t\t\tdefinition.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/custom_field_definitions/{custom_field_definition_id}":
     get:
       tags:
@@ -7073,6 +11398,103 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Custom
           Field Definition: %s\", definition.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const definition = await client.getCustomFieldDefinition(definitionId)
+              console.log('Fetched custom field definition: ', definition.displayName)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                custom_field_definition = client.get_custom_field_definition(custom_field_definition_id)
+                print("Custom Field Definition %s" % custom_field_definition)
+            except recurly.errors.NotFoundError as e:
+                print("Invoice not found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                CustomFieldDefinition definition = client.GetCustomFieldDefinition(definitionId);
+                Console.WriteLine($"Fetched custom field definition {definition.DisplayName}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              custom_field_definition = @client.get_custom_field_definition(
+                custom_field_definition_id: custom_field_definition_id
+              )
+              puts "Got Custom Field Definition #{custom_field_definition}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final CustomFieldDefinition definition = client.getCustomFieldDefinition(definitionId);
+                System.out.println("Fetched custom field definition " + definition.getDisplayName());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $custom_field_def = $client->getCustomFieldDefinition($definition_id);
+
+                echo 'Got CustomFieldDefinition:' . PHP_EOL;
+                var_dump($custom_field_def);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "definition, err := client.GetCustomFieldDefinition(customFieldDefinitionID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Custom
+            Field Definition: %s\", definition.Id)"
+          name: Go
   "/general_ledger_accounts":
     post:
       tags:
@@ -7366,6 +11788,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, item := range items.Data()
           {\n\t\tfmt.Printf(\"Item %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\titem.Id,\n\t\t\titem.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const items = client.listItems({ params: { limit: 200 } })
+
+            for await (const item of items.each()) {
+              console.log(item.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            items = client.list_items(params=params).items()
+            for item in items:
+                print(item.code)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListItemsParams()
+            {
+                Limit = 200
+            };
+            var items = client.ListItems(optionalParams);
+            foreach(Item item in items)
+            {
+                Console.WriteLine(item.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            items = @client.list_items(params: params)
+            items.each do |item|
+              puts "Item: #{item.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListItemsParams params = new ListItemsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            Pager<Item> items = client.listItems(params);
+
+            for (Item item : items) {
+                System.out.println(item.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $items = $client->listItems($options);
+
+            foreach($items as $item) {
+              echo 'Item: ' . $item->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListItemsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nitems, err :=
+            client.ListItems(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor items.HasMore() {\n\terr := items.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, item := range items.Data()
+            {\n\t\tfmt.Printf(\"Item %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\titem.Id,\n\t\t\titem.Code,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - item
@@ -7576,6 +12069,182 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Item:
           %v\", item.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const itemCreate = {
+                code: itemCode,
+                name: "Item Name",
+                description: "Item Description",
+                external_sku: "a35JE-44",
+                accounting_code: "item-code-127",
+                revenue_schedule_type: "at_range_end",
+                custom_fields: [{
+                  name: "custom-field-1",
+                  value: "Custom Field 1 value"
+                }]
+              }
+              const item = await client.createItem(itemCreate)
+              console.log('Created Item: ', item.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                item_create = {
+                    "code": item_code,
+                    "name": "Item Name",
+                    "description": "Item Description",
+                    "external_sku": "a35JE-44",
+                    "accounting_code": "item-code-127",
+                    "revenue_schedule_type": "at_range_end",
+                    "custom_fields": [{
+                        "name": "custom-field-1",
+                        "value": "Custom Field 1 value"
+                    }]
+                }
+                item = client.create_item(item_create)
+                print("Created Item %s" % item)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var itemReq = new ItemCreate()
+                {
+                    Code = itemCode,
+                    Name = "Item Name",
+                    Description = "Item Description",
+                    ExternalSku = "a35JE-44",
+                    AccountingCode = "item-code-127",
+                    RevenueScheduleType = RevenueScheduleType.AtRangeEnd,
+                    CustomFields = new List<CustomField>() {
+                        new CustomField() {
+                            Name = "custom-field-1",
+                            Value = "Custom Field 1 value"
+                        }
+                    }
+                };
+                Item item = client.CreateItem(itemReq);
+                Console.WriteLine($"Created item {item.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              item_create = {
+                code: item_code,
+                name: "Item Name",
+                description: "Item Description",
+                external_sku: "a35JE-44",
+                accounting_code: "item-code-127",
+                revenue_schedule_type: "at_range_end",
+                custom_fields: [{
+                  name: "custom-field-1",
+                  value: "Custom Field 1 value"
+                }]
+              }
+              item = @client.create_item(body: item_create)
+              puts "Created Item #{item}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                ItemCreate itemReq = new ItemCreate();
+
+                itemReq.setCode(itemCode);
+                itemReq.setName("Item Name");
+                itemReq.setDescription("Item Description");
+                itemReq.setExternalSku("a35JE-44");
+                itemReq.setAccountingCode("item-code-127");
+                itemReq.setRevenueScheduleType(Constants.RevenueScheduleType.AT_RANGE_END);
+
+                List<CustomField> customFields = new ArrayList<>();
+                CustomField customField = new CustomField();
+                customField.setName("custom-field-1");
+                customField.setValue("Custom Field 1 value");
+                customFields.add(customField);
+
+                itemReq.setCustomFields(customFields);
+
+
+                Item item = client.createItem(itemReq);
+                System.out.println("Created item " + item.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $item_create = [
+                    "code" => $item_code,
+                    "name" => "Coffee Grinder",
+                    "description" => "A professional-grade bean grinder."
+                ];
+                $item = $client->createItem($item_create);
+
+                echo 'Created Item:' . PHP_EOL;
+                var_dump($item);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "itemReq := &recurly.ItemCreate{\n\tCode:                &itemCode,\n\tName:
+            \               recurly.String(\"Item Name\"),\n\tDescription:         recurly.String(\"Item
+            Description\"),\n\tExternalSku:         recurly.String(\"a35JE-44\"),\n\tAccountingCode:
+            \     recurly.String(\"item-code-127\"),\n\tRevenueScheduleType: recurly.String(\"at_range_end\"),\n}\n\nitem,
+            err := client.CreateItem(itemReq)\nif e, ok := err.(*recurly.Error); ok
+            {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Item:
+            %v\", item.Id)"
+          name: Go
   "/items/{item_id}":
     get:
       tags:
@@ -7692,6 +12361,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Item:
           %v\", item.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const item = await client.getItem(itemId)
+              console.log('Fetched item: ', item.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                item = client.get_item(item_id)
+                print("Got Item %s" % item)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Item item = client.GetItem(itemId);
+                Console.WriteLine($"Fetched item {item.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              item = @client.get_item(item_id: item_id)
+              puts "Got Item #{item}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Item item = client.getItem(itemId);
+                System.out.println("Fetched item: " + item.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $item = $client->getItem($item_id);
+
+                echo 'Got Item:' . PHP_EOL;
+                var_dump($item);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "item, err := client.GetItem(itemID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Item: %v\", item.Id)"
+          name: Go
     put:
       tags:
       - item
@@ -7858,6 +12624,136 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Updated Item:
           %v\", item.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const itemUpdate = {
+                name: 'New Item Name',
+                description: 'New Item Description'
+              }
+              const item = await client.updateItem(itemId, itemUpdate)
+              console.log('Updated item: ', item)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                item_update = {
+                    "name": "New Item Name",
+                    "description": "New Item Description",
+                }
+                item = client.update_item(item_id, item_update)
+                print("Updated Item %s" % item)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var itemReq = new ItemUpdate() {
+                    Name = "New Item Name",
+                    Description = "New Item Description",
+                };
+                Item item = client.UpdateItem(itemId, itemReq);
+                Console.WriteLine(item.Name);
+                Console.WriteLine(item.Description);
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              item_update = {
+                name: "New Item Name",
+                description: "New Item Description"
+              }
+              item = @client.update_item(
+                item_id: item_id,
+                body: item_update
+              )
+              puts "Updated Item #{item}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final ItemUpdate itemUpdate = new ItemUpdate();
+                itemUpdate.setName("New Item Name");
+                itemUpdate.setDescription("New Item Description");
+
+                final Item item = client.updateItem(itemId, itemUpdate);
+                System.out.println("Updated item: " + item.getCode());
+                System.out.println(item.getName());
+                System.out.println(item.getDescription());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $item_update = [
+                    "name" => "Dark Roast Coffee Beans",
+                    "description" => "A special dark roast version.",
+                ];
+                $item = $client->updateItem($item_id, $item_update);
+
+                echo 'Updated Item:' . PHP_EOL;
+                var_dump($item);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.ItemUpdate{\n\tName:        recurly.String(\"Pothos
+            Plant\"),\n\tDescription: recurly.String(\"A sturdy houseplant\"),\n}\nitem,
+            err := client.UpdateItem(itemID, updateReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Updated
+            Item: %v\", item.Id)"
+          name: Go
     delete:
       tags:
       - item
@@ -7974,6 +12870,102 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Item deactivated:
           %s\", deactivatedItem.Code)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const item = await client.deactivateItem(itemId)
+              console.log('Deleted item: ', item.code)
+            } catch (err) {
+              if (err && err.type === 'not-found') {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              }
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              throw err
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                item = client.deactivate_item(item_id)
+                print("Deactivated Item %s" % item)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Item item = client.DeactivateItem(itemId);
+                Console.WriteLine($"Deactivated item {item.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              item = @client.deactivate_item(item_id: item_id)
+              puts "Deactivated Item #{item}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                Item item = client.deactivateItem(itemId);
+                System.out.println("deactivated item " + item.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $item = $client->deactivateItem($item_id);
+
+                echo 'Deactivated Item:' . PHP_EOL;
+                var_dump($item);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "deactivatedItem, err := client.DeactivateItem(itemID)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Item deactivated:
+            %s\", deactivatedItem.Code)"
+          name: Go
   "/items/{item_id}/reactivate":
     parameters:
     - "$ref": "#/components/parameters/item_id"
@@ -8097,6 +13089,102 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
           Item: %s\", item.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const item = await client.reactivateItem(itemId)
+              console.log('Reactivated item: ', item.code)
+            } catch (err) {
+              if (err && err.type === 'not_found') {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              }
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              throw err
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                item = client.reactivate_item(item_id)
+                print("Reactivated Item %s" % item)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Item item = client.ReactivateItem(itemId);
+                Console.WriteLine($"Reactivated item {item.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              item = @client.reactivate_item(item_id: item_id)
+              puts "Reactivated Item #{item}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Item item = client.reactivateItem(itemId);
+                System.out.println("Reactivated item: " + item.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $item = $client->reactivateItem($item_id);
+
+                echo 'Reactivate Item:' . PHP_EOL;
+                var_dump($item);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "item, err := client.ReactivateItem(itemID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
+            Item: %s\", item.Id)"
+          name: Go
   "/measured_units":
     get:
       tags:
@@ -8873,6 +13961,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, invoice := range invoices.Data()
           {\n\t\tfmt.Printf(\"Invoice %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t\tinvoice.Number,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const invoices = client.listInvoices({ params: { limit: 200 } })
+
+            for await (const invoice of invoices.each()) {
+              console.log(invoice.number)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            invoices = client.list_invoices(params=params).items()
+            for invoice in invoices:
+                print(invoice.number)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListInvoicesParams()
+            {
+                Limit = 200
+            };
+            var invoices = client.ListInvoices(optionalParams);
+            foreach(Invoice invoice in invoices)
+            {
+                Console.WriteLine(invoice.Number);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            invoices = @client.list_invoices(params: params)
+            invoices.each do |invoice|
+              puts "Invoice: #{invoice.number}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListInvoicesParams params = new ListInvoicesParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Invoice> invoices = client.listInvoices(params);
+
+            for (Invoice invoice : invoices) {
+                System.out.println(invoice.getNumber());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $invoices = $client->listInvoices($options);
+
+            foreach($invoices as $invoice) {
+              echo 'Invoice: ' . $invoice->getNumber() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListInvoicesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\ninvoices, err
+            := client.ListInvoices(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor invoices.HasMore() {\n\terr := invoices.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, invoice := range invoices.Data()
+            {\n\t\tfmt.Printf(\"Invoice %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t\tinvoice.Number,\n\t\t)\n\t}\n}"
+          name: Go
   "/invoices/{invoice_id}":
     get:
       tags:
@@ -8989,6 +14148,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Invoice:
           %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.getInvoice(invoiceId)
+              console.log('Fetched Invoice: ', invoice.number)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.get_invoice(invoice_id)
+                print("Got Invoice %s" % invoice)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Invoice invoice = client.GetInvoice(invoiceId);
+                Console.WriteLine($"Fetched invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.get_invoice(invoice_id: invoice_id)
+              puts "Got invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Invoice invoice = client.getInvoice(invoiceId);
+                System.out.println("Fetched invoice " + invoice.getNumber());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->getInvoice($invoice_id);
+
+                echo 'Got Invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "invoice, err := client.GetInvoice(invoiceID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Invoice: %v\", invoice)"
+          name: Go
     put:
       tags:
       - invoice
@@ -9139,6 +14395,132 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Invoice:
           %s\", invoice.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoiceUpdate = {
+                customerNotes: "New notes",
+                termsAndConditions: "New terms and conditions"
+              }
+
+              const invoice = await client.updateInvoice(invoiceId, invoiceUpdate)
+              console.log('Edited invoice: ', invoice.number)
+            } catch(err) {
+
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice_update = {
+                  "customer_notes": "New Notes",
+                  "terms_and_conditions": "New Terms and Conditions",
+                }
+                invoice = client.update_invoice(invoice_id, invoice_update)
+                print("Updated Invoice %s" % invoice.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var invoiceReq = new InvoiceUpdate()
+                {
+                    CustomerNotes = "New Notes",
+                    TermsAndConditions = "New Terms and Conditions"
+                };
+                Invoice invoice = client.UpdateInvoice(invoiceId, invoiceReq);
+                Console.WriteLine($"Edited invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice_update = {
+                customer_notes: "New Notes",
+                terms_and_conditions: "New Terms and Conditions"
+              }
+              invoice = @client.update_invoice(invoice_id: invoice_id, body: invoice_update)
+              puts "Updated invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final InvoiceUpdate invoiceUpdate = new InvoiceUpdate();
+                invoiceUpdate.setCustomerNotes("New notes");
+                invoiceUpdate.setTermsAndConditions("New terms and conditions");
+
+                final Invoice invoice = client.updateInvoice(invoiceId, invoiceUpdate);
+                System.out.println("Edited invoice " + invoice.getNumber());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice_update =  [
+                  "customer_notes" => "New Notes",
+                  "terms_and_conditions" => "New terms and conditions",
+                ];
+                $invoice = $client->updateInvoice($invoice_id, $invoice_update);
+
+                echo 'Updated Invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.InvoiceUpdate{\n\tCustomerNotes:      recurly.String(\"New
+            Notes\"),\n\tTermsAndConditions: recurly.String(\"New Terms and Conditions\"),\n}\ninvoice,
+            err := client.UpdateInvoice(invoiceID, updateReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Invoice:
+            %s\", invoice.Id)"
+          name: Go
   "/invoices/{invoice_id}.pdf":
     get:
       tags:
@@ -9276,6 +14658,123 @@ paths:
               // Something bad happened... tell the user so that they can fix it?
               echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
           }
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.getInvoicePdf(invoiceId)
+              console.log('Fetched Invoice: ', invoice)
+              const filename = `${downloadDirectory}/nodeinvoice-${invoiceId}.pdf`
+              await fs.writeFile(filename, invoice.data, 'binary', (err) => {
+                // throws an error, you could also catch it here
+                if (err) throw err;
+
+                // success case, the file was saved
+                console.log('Saved Invoice PDF to', filename)
+              })
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.get_invoice_pdf(invoice_id)
+                print("Got Invoice %s" % invoice)
+                filename = "%s/pythoninvoice-%s.pdf" % (download_directory, invoice_id)
+                with open(filename, 'wb') as file:
+                    file.write(invoice.data)
+                    print("Saved Invoice PDF to %s" % filename)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                BinaryFile invoice = client.GetInvoicePdf(invoiceId);
+                string filename = $"{downloadDirectory}/dotnetinvoice-{invoiceId}.pdf";
+                System.IO.File.WriteAllBytes(filename, invoice.Data);
+                Console.WriteLine($"Saved Invoice PDF to {filename}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.get_invoice_pdf(invoice_id: invoice_id)
+              puts "Got invoice #{invoice}"
+              filename = "#{download_directory}/rubyinvoice-#{invoice_id}.pdf"
+              IO.write(filename, invoice.data)
+              puts "Saved Invoice PDF to #{filename}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final BinaryFile invoice = client.getInvoicePdf(invoiceId);
+                //System.out.println("Fetched invoice " + invoice.getData());
+                String filename = downloadDirectory + "/javainvoice-" + invoiceId + ".pdf";
+
+                FileOutputStream fos = new FileOutputStream(filename);
+                fos.write(invoice.getData());
+                fos.close();
+                System.out.println("Saved Invoice PDF to " + filename);
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            } catch (java.io.IOException e) {
+                System.out.println("Unexpected File Writing Error: " + e.toString());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->getInvoicePdf($invoice_id);
+                echo 'Got Invoice PDF:' . PHP_EOL;
+                var_dump($invoice);
+                $invoice_fp = fopen("php-invoice-" . $invoice_id . ".pdf", "w");
+                fwrite($invoice_fp, $invoice->getData());
+                fclose($invoice_fp);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
   "/invoices/{invoice_id}/apply_credit_balance":
     put:
       tags:
@@ -9402,6 +14901,103 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Applied credit
           balance to invoice: %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.applyCreditBalance(invoiceId)
+              console.log('Applied credit balance to invoice: ', invoice)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.apply_credit_balance(invoice_id)
+                print("Applied credit balance to invoice %s" % invoice.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Invoice invoice = client.ApplyCreditBalance(invoiceId);
+                Console.WriteLine($"Applied credit balance to invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.apply_credit_balance(invoice_id: invoice_id)
+              puts "Applied credit balance to invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+              final Invoice invoice = client.applyCreditBalance(invoiceId);
+              System.out.println("Applied credit balance to invoice " + invoice.getId());
+            } catch (final ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (final ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->applyCreditBalance($invoice_id);
+
+                echo 'Applied credit balance to invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "invoice, err := client.ApplyCreditBalance(invoiceID)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Applied
+            credit balance to invoice: %v\", invoice)"
+          name: Go
   "/invoices/{invoice_id}/collect":
     put:
       tags:
@@ -9532,6 +15128,103 @@ paths:
           == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed validation: %v\",
           e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected Recurly error: %v\",
           e)\n\treturn nil, err\n}\nfmt.Printf(\"Collected Invoice: %v\", collectedInvoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.collectInvoice(invoiceId)
+              console.log('Collected invoice: ', invoice.number)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.collect_invoice(invoice_id)
+                print("Collected Invoice %s" % invoice)
+            except recurly.errors.NotFoundError as e:
+                print("Invoice not found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Invoice invoice = client.CollectInvoice(invoiceId);
+                Console.WriteLine($"Collected invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.collect_invoice(invoice_id: invoice_id)
+              puts "Collected invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Invoice invoice = client.collectInvoice(invoiceId);
+                System.out.println("Collected invoice: " + invoice.getNumber());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->collectInvoice($invoice_id);
+
+                echo 'Collected Invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "collectInvoiceParams := &recurly.CollectInvoiceParams{\n\tBody: &recurly.InvoiceCollect{\n\t\tTransactionType:
+            recurly.String(\"moto\"),\n\t},\n}\n\ncollectedInvoice, err := client.CollectInvoice(invoiceID,
+            collectInvoiceParams)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type
+            == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed validation:
+            %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected Recurly
+            error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Collected Invoice:
+            %v\", collectedInvoice)"
+          name: Go
   "/invoices/{invoice_id}/mark_failed":
     put:
       tags:
@@ -9658,6 +15351,103 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Invoice failed:
           %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.markInvoiceFailed(invoiceId)
+              console.log('Failed invoice: ', invoice.number)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.mark_invoice_failed(invoice_id)
+                print("Failed Invoice %s" % invoice.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Invoice invoice = client.MarkInvoiceFailed(invoiceId);
+                Console.WriteLine($"Failed invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.mark_invoice_failed(invoice_id: invoice_id)
+              puts "Failed invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Invoice invoice = client.markInvoiceFailed(invoiceId);
+                System.out.println("Failed invoice: " + invoice.getNumber());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->markInvoiceFailed($invoice_id);
+
+                echo 'Failed Invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "invoice, err := client.MarkInvoiceFailed(invoiceID)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Invoice failed:
+            %v\", invoice)"
+          name: Go
   "/invoices/{invoice_id}/mark_successful":
     put:
       tags:
@@ -9787,6 +15577,106 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Marked Invoice
           Successful: %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.markInvoiceSuccessful(invoiceId)
+              console.log(`Marked invoice #${invoice.number} successful`)
+            } catch(err) {
+
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                params = {"limit": 200}
+                invoice = client.mark_invoice_successful(invoice_id, params=params)
+                print("Marked Invoice successful %s" % invoice)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Invoice invoice = client.MarkInvoiceSuccessful(invoiceId);
+                Console.WriteLine($"Marked invoice #{invoice.Number} successful");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.mark_invoice_successful(invoice_id: invoice_id)
+              puts "Marked invoice sucessful #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Invoice invoice = client.markInvoiceSuccessful(invoiceId);
+                System.out.println("Marked invoice " + invoice.getNumber() + " successful");
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->markInvoiceSuccessful($invoice_id);
+
+                echo 'Marked Invoice Successful:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "invoice, err := client.MarkInvoiceSuccessful(invoiceID)\nif e, ok
+            := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Marked Invoice
+            Successful: %v\", invoice)"
+          name: Go
   "/invoices/{invoice_id}/reopen":
     put:
       tags:
@@ -9910,6 +15800,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Reopened Invoice:
           %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.reopenInvoice(invoiceId)
+              console.log('Reopened invoice: ', invoice.number)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.reopen_invoice(invoice_id)
+                print("Reopened Invoice %s" % invoice.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Invoice invoice = client.ReopenInvoice(invoiceId);
+                Console.WriteLine($"Reopened invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.reopen_invoice(invoice_id: invoice_id)
+              puts "Reopened invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Invoice invoice = client.reopenInvoice(invoiceId);
+                System.out.println("Reopened invoice: " + invoice.getNumber());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->reopenInvoice($invoice_id);
+
+                echo 'Reopened Invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "invoice, err := client.ReopenInvoice(invoiceID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Reopened
+            Invoice: %v\", invoice)"
+          name: Go
   "/invoices/{invoice_id}/void":
     put:
       tags:
@@ -10016,6 +16003,84 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Voided Invoice:
           %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoice = await client.voidInvoice(invoiceId)
+              console.log('Voided invoice: ', invoice)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice = client.void_invoice(invoice_id)
+                print("Voided Invoice %s" % invoice.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: ruby
+          code: |
+            begin
+              invoice = @client.void_invoice(invoice_id: invoice_id)
+              puts "Voided invoice #{invoice}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+              final Invoice invoice = client.voidInvoice(invoiceId);
+              System.out.println("Voided invoice " + invoice.getId());
+            } catch (final ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (final ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoice = $client->voidInvoice($invoice_id);
+
+                echo 'Voided Invoice:' . PHP_EOL;
+                var_dump($invoice);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "invoice, err := client.VoidInvoice(invoiceID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Voided Invoice:
+            %v\", invoice)"
+          name: Go
   "/invoices/{invoice_id}/transactions":
     post:
       tags:
@@ -10080,6 +16145,30 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const externalTrx = {
+                description: "A check collected outside of Recurly",
+                amount: 10.0,
+                payment_method: 'check'
+              }
+              const transaction = await client.recordExternalTransaction(invoiceId, externalTrx)
+              console.log('External Transaction: ', transaction)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
   "/invoices/{invoice_id}/line_items":
     get:
       tags:
@@ -10190,6 +16279,81 @@ paths:
           {\n\terr := lineItems.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, lineItem := range
           lineItems.Data() {\n\t\tfmt.Printf(\"Invoice Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const lineItems = client.listInvoiceLineItems(invoiceId, { params: { limit: 200 } })
+
+            for await (const lineItem of lineItems.each()) {
+              console.log(lineItem.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                params = {"limit": 200}
+                line_items = client.list_invoice_line_items(invoice_id, params=params).items()
+                for item in line_items:
+                    print("Invoice Line Items %s" % item.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            var lineItems = client.ListInvoiceLineItems(invoiceId);
+            foreach(LineItem lineItem in lineItems)
+            {
+                Console.WriteLine(lineItem.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            line_items = @client.list_invoice_line_items(
+              invoice_id: invoice_id,
+              params: params
+            )
+            line_items.each do |line_item|
+              puts "Line Item: #{line_item.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListInvoiceLineItemsParams params = new ListInvoiceLineItemsParams();
+            params.setLimit(200);
+            Pager<LineItem> lineItems = client.listInvoiceLineItems(invoiceId, params);
+
+            for (LineItem lineItem : lineItems) {
+              System.out.println(lineItem.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $invoice_line_items = $client->listInvoiceLineItems($invoice_id, $options);
+
+            foreach($invoice_line_items as $line_item) {
+              echo 'Invoice Line Item: ' . $line_item->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListInvoiceLineItemsParams{\n\tSort: recurly.String(\"created_at\"),\n}\nlineItems,
+            err := client.ListInvoiceLineItems(invoiceID, listParams)\nif err != nil
+            {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor lineItems.HasMore()
+            {\n\terr := lineItems.Fetch()\n\tif e, ok := err.(*recurly.Error); ok
+            {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, lineItem := range lineItems.Data() {\n\t\tfmt.Printf(\"Invoice Line
+            Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/invoices/{invoice_id}/coupon_redemptions":
     get:
       tags:
@@ -10284,6 +16448,75 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, redemption := range redemptions.Data() {\n\t\tfmt.Printf(\"Invoice Coupon
           Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const redemptions = client.listInvoiceCouponRedemptions(invoiceId, { params: { limit: 200 } })
+
+            for await (const redemption of redemptions.each()) {
+              console.log(redemption.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            redemptions = client.list_invoice_coupon_redemptions(invoice_id, params=params).items()
+            for redemption in redemptions:
+                print("Invoice Coupon Redemption %s" % redemption)
+          name: Python
+        - language: csharp
+          code: |
+            var couponRedemptions = client.ListInvoiceCouponRedemptions(invoiceId);
+            foreach(CouponRedemption redemption in couponRedemptions)
+            {
+                Console.WriteLine(redemption.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            coupon_redemptions = @client.list_invoice_coupon_redemptions(
+              invoice_id: invoice_id,
+              params: params
+            )
+            coupon_redemptions.each do |redemption|
+              puts "CouponRedemption: #{redemption.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListInvoiceCouponRedemptionsParams params = new ListInvoiceCouponRedemptionsParams();
+            final Pager<CouponRedemption> redemptions = client.listInvoiceCouponRedemptions(invoiceId, params);
+
+            for (CouponRedemption redemption : redemptions) {
+                System.out.println(redemption.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $invoice_coupon_redemptions = $client->listInvoiceCouponRedemptions($invoice_id, $options);
+
+            foreach($invoice_coupon_redemptions as $redemption) {
+              echo 'Invoice Coupon Redemption: ' . $redemption->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListInvoiceCouponRedemptionsParams{\n\tSort:
+            recurly.String(\"created_at\"),\n}\nredemptions, err := client.ListInvoiceCouponRedemptions(invoiceID,
+            listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected error: %v\",
+            err)\n\treturn\n}\n\nfor redemptions.HasMore() {\n\terr := redemptions.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range redemptions.Data()
+            {\n\t\tfmt.Printf(\"Invoice Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/invoices/{invoice_id}/related_invoices":
     get:
       tags:
@@ -10377,6 +16610,73 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, invoice := range invoices.Data() {\n\t\tfmt.Printf(\"Related Invoice
           %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t\tinvoice.Number,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const invoices = client.listRelatedInvoices(invoiceId, { params: { limit: 200 } })
+
+            for await (const invoice of invoices.each()) {
+              console.log(invoice.number)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                params = {"limit": 200}
+                related_invoices = client.list_related_invoices(invoice_id, params=params).items()
+                for invoice in related_invoices:
+                    print("Related invoice %s" % invoice.id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            var invoices = client.ListRelatedInvoices(invoiceId);
+            foreach(Invoice invoice in invoices)
+            {
+                Console.WriteLine(invoice.Number);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            invoices = @client.list_related_invoices(
+              invoice_id: invoice_id,
+              params: params
+            )
+            invoices.each do |invoice|
+              puts "Invoice: #{invoice.number}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            final Pager<Invoice> invoices = client.listRelatedInvoices(invoiceId);
+
+            for (Invoice invoice : invoices) {
+                System.out.println(invoice.getNumber());
+            }
+          name: Java
+        - language: php
+          code: |
+            $related_invoices = $client->listRelatedInvoices($invoice_id);
+
+            foreach($related_invoices as $invoice) {
+              echo 'Related Invoice: ' . $invoice->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "invoices, err := client.ListRelatedInvoices(invoiceID)\nif err !=
+            nil {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor
+            invoices.HasMore() {\n\terr := invoices.Fetch()\n\tif e, ok := err.(*recurly.Error);
+            ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, invoice := range invoices.Data() {\n\t\tfmt.Printf(\"Related Invoice
+            %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t\tinvoice.Number,\n\t\t)\n\t}\n}"
+          name: Go
   "/invoices/{invoice_id}/refund":
     post:
       tags:
@@ -10544,6 +16844,135 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Refunded Invoice:
           %v\", invoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoiceRefund = {
+                creditCustomerNotes: "Notes on credits",
+                type: "amount", // could also be "line_items"
+                amount: 100
+              }
+
+              const invoice = await client.refundInvoice(invoiceId, invoiceRefund)
+              console.log('Refunded invoice: ', invoice.number)
+            } catch(err) {
+
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice_refund = {"type": "amount", "amount": 100}
+                invoice = client.refund_invoice(invoice_id, invoice_refund)
+                print("Refunded Invoice %s" % invoice)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var refundReq = new InvoiceRefund() {
+                    CreditCustomerNotes = "Notes on credits",
+                    Type = InvoiceRefundType.Amount, // could also be "line_items"
+                    Amount = 100
+                };
+                Invoice invoice = client.RefundInvoice(invoiceId, refundReq);
+                Console.WriteLine($"Refunded Invoice #{invoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice_refund = {
+                type: "amount",
+                amount: 100,
+              }
+              invoice = @client.refund_invoice(
+                invoice_id: invoice_id,
+                body: invoice_refund
+              )
+              puts "Refunded invoice #{invoice}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final InvoiceRefund invoiceRefund = new InvoiceRefund();
+                invoiceRefund.setCreditCustomerNotes("Notes on credits");
+                invoiceRefund.setType(Constants.InvoiceRefundType.AMOUNT); // could also be "line_items"
+                invoiceRefund.setAmount(new BigDecimal("100"));
+
+                final Invoice invoice = client.refundInvoice(invoiceId, invoiceRefund);
+                System.out.println("Refunded invoice " + invoice.getNumber());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $refund = [
+                    "type" => "amount",
+                    "amount" => 1
+                ];
+                $invoice_collection = $client->refundInvoice($invoice_id, $refund);
+
+                echo 'Refunded Invoice:' . PHP_EOL;
+                var_dump($invoice_collection);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "refundReq := &recurly.InvoiceRefund{\n\tType:   recurly.String(\"amount\"),\n\tAmount:
+            recurly.Float(1),\n\tExternalRefund: &recurly.ExternalRefund{\n\t\tPaymentMethod:
+            recurly.String(\"credit_card\"),\n\t},\n}\ninvoice, err := client.RefundInvoice(invoiceID,
+            refundReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Refunded
+            Invoice: %v\", invoice)"
+          name: Go
   "/invoices/recovery":
     post:
       tags:
@@ -10697,6 +17126,79 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, lineItem := range lineItems.Data()
           {\n\t\tfmt.Printf(\"Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const lineItems = client.listLineItems({ params: { limit: 200 } })
+
+            for await (const item of lineItems.each()) {
+              console.log(`Item ${item.id} for ${item.amount}`)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            line_items = client.list_line_items(params=params).items()
+            for line_item in line_items:
+                print(line_item.id)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListLineItemsParams()
+            {
+                Limit = 200
+            };
+            var lineItems = client.ListLineItems(optionalParams);
+            foreach(LineItem item in lineItems)
+            {
+                Console.WriteLine($"Item {item.Uuid} for {item.Amount}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            line_items = @client.list_line_items(
+              params: params
+            )
+            line_items.each do |line_item|
+              puts "LineItem: #{line_item.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListLineItemsParams params = new ListLineItemsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<LineItem> lineItems = client.listLineItems(params);
+
+            for (LineItem lineItem : lineItems) {
+                System.out.println("Item " + lineItem.getUuid() + " for " + lineItem.getAmount());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $line_items = $client->listLineItems($options);
+
+            foreach($line_items as $line_item) {
+              echo 'Line item: ' . $line_item->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListLineItemsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nlineItems, err
+            := client.ListLineItems(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor lineItems.HasMore() {\n\terr :=
+            lineItems.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
+            to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, lineItem :=
+            range lineItems.Data() {\n\t\tfmt.Printf(\"Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/line_items/{line_item_id}":
     get:
       tags:
@@ -10813,6 +17315,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Line
           Item: %v\", lineItem)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const lineItem = await client.getLineItem(lineItemId)
+              console.log('Fetched line item: ', lineItem.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                line_item = client.get_line_item(line_item_id)
+                print("Got LineItem %s" % line_item)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                LineItem lineItem = client.GetLineItem(lineItemId);
+                Console.WriteLine($"Fetched line item {lineItem.Uuid}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              line_item = @client.get_line_item(line_item_id: line_item_id)
+              puts "Got LineItem #{line_item}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final LineItem lineItem = client.getLineItem(lineItemId);
+                System.out.println("Fetched line item " + lineItem.getUuid());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $line_item = $client->getLineItem($line_item_id);
+
+                echo 'Got LineItem:' . PHP_EOL;
+                var_dump($line_item);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "lineItem, err := client.GetLineItem(lineItemID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Line
+            Item: %v\", lineItem)"
+          name: Go
     delete:
       tags:
       - line_item
@@ -10930,6 +17529,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Removed Line
           Item: %v\", lineItem)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              await client.removeLineItem(lineItemId)
+              console.log('Removed line item: ', lineItemId)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.remove_line_item(line_item_id)
+                print("Removed LineItem %s" % line_item_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                client.RemoveLineItem(lineItemId);
+                Console.WriteLine($"Removed line item {lineItemId}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              @client.remove_line_item(
+                line_item_id: line_item_id
+              )
+              puts "Removed LineItem #{line_item_id}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                client.removeLineItem(lineItemId);
+                System.out.println("Removed line item " + lineItemId);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $client->removeLineItem($line_item_id);
+                echo 'Removed LineItem: ' . $line_item_id . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "lineItem, err := client.RemoveLineItem(lineItemID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Removed Line
+            Item: %v\", lineItem)"
+          name: Go
   "/plans":
     get:
       tags:
@@ -11034,6 +17730,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, plan := range plans.Data()
           {\n\t\tfmt.Printf(\"Plan %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tplan.Id,\n\t\t\tplan.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const plans = client.listPlans({ params: { limit: 200 } })
+
+            for await (const plan of plans.each()) {
+              console.log(plan.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            plans = client.list_plans(params=params).items()
+            for plan in plans:
+                print(plan.code)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListPlansParams()
+            {
+                Limit = 200
+            };
+            var plans = client.ListPlans(optionalParams);
+            foreach(Plan plan in plans)
+            {
+                Console.WriteLine(plan.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            plans = @client.list_plans(params: params)
+            plans.each do |plan|
+              puts "Plan: #{plan.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListPlansParams params = new ListPlansParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Plan> plans = client.listPlans(params);
+
+            for (Plan plan : plans) {
+                System.out.println(plan.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $plans = $client->listPlans($options);
+
+            foreach($plans as $plan) {
+              echo 'Plan: ' . $plan->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListPlansParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nplans, err :=
+            client.ListPlans(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor plans.HasMore() {\n\terr := plans.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, plan := range plans.Data()
+            {\n\t\tfmt.Printf(\"Plan %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tplan.Id,\n\t\t\tplan.Code,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - plan
@@ -11230,6 +17997,174 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Plan:
           %v\", plan.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const planCreate = {
+                name: 'Monthly Coffee Subscription',
+                code: planCode,
+                currencies: [
+                  {
+                    currency: 'USD',
+                    unitAmount: 10000
+                  }
+                ]
+              }
+              const plan = await client.createPlan(planCreate)
+              console.log('Created Plan: ', plan.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                plan_create = {
+                    "name": "Monthly Coffee Subscription",
+                    "code": plan_code,
+                    "currencies": [{"currency": "USD", "unit_amount": 10000}],
+                }
+                plan = client.create_plan(plan_create)
+                print("Created Plan %s" % plan)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var planReq = new PlanCreate()
+                {
+                    Name = "Monthly Coffee Subscription",
+                    Code = planCode,
+                    Currencies = new List<PlanPricing>() {
+                        new PlanPricing() {
+                            Currency = "USD",
+                            UnitAmount = 10000
+                        }
+                    }
+                };
+                Plan plan = client.CreatePlan(planReq);
+                Console.WriteLine($"Created plan {plan.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              plan_create = {
+                code: plan_code,
+                name: plan_name,
+                currencies: [
+                  currency: "USD",
+                  setup_fee: 1_000
+                ],
+                add_ons: [
+                  {
+                    name: 'Extra User',
+                    code: 'extra_user',
+                    currencies: [
+                      { currency: 'USD', unit_amount: 10_000 }
+                    ]
+                  }
+                ]
+              }
+              plan = @client.create_plan(body: plan_create)
+              puts "Created Plan #{plan}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                PlanCreate planCreate = new PlanCreate();
+
+                planCreate.setName("Monthly Coffee Subscription");
+                planCreate.setCode(planCode);
+
+                List<PlanPricing> currencies = new ArrayList<PlanPricing>();
+                PlanPricing planPrice = new PlanPricing();
+                planPrice.setCurrency("USD");
+                planPrice.setUnitAmount(new BigDecimal("10000"));
+                currencies.add(planPrice);
+
+                planCreate.setCurrencies(currencies);
+
+                Plan plan = client.createPlan(planCreate);
+                System.out.println("Created Plan " + planCode);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $plan_create = [
+                    "name" => "Monthly Coffee Subscription",
+                    "code" => $plan_code,
+                    "currencies" => [
+                        [
+                            "currency" => "USD",
+                            "unit_amount" => 10000
+                        ]
+                    ]
+                ];
+
+                $plan = $client->createPlan($plan_create);
+
+                echo 'Created Plan:' . PHP_EOL;
+                var_dump($plan);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "planReq := &recurly.PlanCreate{\n\tCode: &planCode,\n\tName: recurly.String(\"Monthly
+            Coffee Subscription\"),\n\tCurrencies: &[]recurly.PlanPricingCreate{\n\t\t{\n\t\t\tCurrency:
+            \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10000),\n\t\t},\n\t},\n}\n\nplan,
+            err := client.CreatePlan(planReq)\nif e, ok := err.(*recurly.Error); ok
+            {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Plan:
+            %v\", plan.Id)"
+          name: Go
   "/plans/{plan_id}":
     get:
       tags:
@@ -11346,6 +18281,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Plan:
           %s\", plan.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const plan = await client.getPlan(planId)
+              console.log('Fetched plan: ', plan.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                plan = client.get_plan(plan_id)
+                print("Got Plan %s" % plan)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Plan plan = client.GetPlan(planId);
+                Console.WriteLine($"Fetched plan {plan.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              plan = @client.get_plan(plan_id: plan_id)
+              puts "Got plan #{plan}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Plan plan = client.getPlan(planId);
+                System.out.println("Fetched plan " + plan.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $plan = $client->getPlan($plan_id);
+
+                echo 'Got Plan:' . PHP_EOL;
+                var_dump($plan);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "plan, err := client.GetPlan(planID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Plan: %s\", plan.Id)"
+          name: Go
     put:
       tags:
       - plan
@@ -11492,6 +18524,122 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Updated Plan:
           %s\", plan.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const planUpdate = {
+                name: 'New monthly coffee subscription'
+              }
+              const plan = await client.updatePlan(planId, planUpdate)
+              console.log('Updated plan: ', plan.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                plan_update = {
+                  "name": "Monthly Kombucha Subscription",
+                }
+                plan = client.update_plan(plan_id, plan_update)
+                print("Updated Plan %s" % plan)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var planReq = new PlanUpdate() {
+                    Name = "New Monthly Coffee Subscription"
+                };
+                Plan plan = client.UpdatePlan(planId, planReq);
+                Console.WriteLine($"Updated plan {plan.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              plan_update = {
+                name: "Monthly Kombucha Subscription"
+              }
+              plan = @client.update_plan(plan_id: plan_id, body: plan_update)
+              puts "Updated plan #{plan}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final PlanUpdate planUpdate = new PlanUpdate();
+                planUpdate.setName("New Monthly Coffee Subscription");
+
+                final Plan plan = client.updatePlan(planId, planUpdate);
+                System.out.println("Updated plan " + plan.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $plan_update = [
+                    "name" => "Monthly Tea Subscription"
+                ];
+                $plan = $client->updatePlan($plan_id, $plan_update);
+
+                echo 'Updated Plan:' . PHP_EOL;
+                var_dump($plan);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.PlanUpdate{\n\tName: recurly.String(\"Monthly
+            Houseplant Subscription\"),\n}\nplan, err := client.UpdatePlan(planID,
+            updateReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Updated
+            Plan: %s\", plan.Id)"
+          name: Go
     delete:
       tags:
       - plan
@@ -11599,6 +18747,101 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Plan:
           %s\", plan.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const plan = await client.removePlan(planId)
+              console.log('Removed plan: ', plan.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                plan = client.remove_plan(plan_id)
+                print("Removed Plan %s" % plan)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Plan plan = client.RemovePlan(planId);
+                Console.WriteLine($"Removed plan {plan.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              plan = @client.remove_plan(plan_id: plan_id)
+              puts "Removed plan #{plan}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Plan plan = client.removePlan(planId);
+                System.out.println("Removed plan " + plan.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $plan = $client->removePlan($plan_id);
+                echo 'Removed Plan: ' . $plan_id . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "plan, err := client.RemovePlan(planID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed
+            Plan: %s\", plan.Id)"
+          name: Go
   "/plans/{plan_id}/add_ons":
     get:
       tags:
@@ -11703,6 +18946,76 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, addOn := range addOns.Data()
           {\n\t\tfmt.Printf(\"Add-On %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taddOn.Id,\n\t\t\taddOn.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const addOns = client.listPlanAddOns(planId, { params: { limit: 200 } })
+
+            for await (const addOn of addOns.each()) {
+              console.log(addOn.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            add_ons = client.list_plan_add_ons(plan_id, params=params).items()
+            for add_on in add_ons:
+                print(add_on.code)
+          name: Python
+        - language: csharp
+          code: |
+            var addOns = client.ListPlanAddOns(planId);
+            foreach(AddOn addOn in addOns)
+            {
+                Console.WriteLine(addOn.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            add_ons = @client.list_plan_add_ons(
+              plan_id: plan_id,
+              params: params
+            )
+            add_ons.each do |add_on|
+              puts "AddOn: #{add_on.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListPlanAddOnsParams params = new ListPlanAddOnsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<AddOn> addOns = client.listPlanAddOns(planId, params);
+
+            for (AddOn addOn : addOns) {
+                System.out.println(addOn.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $plan_add_ons = $client->listPlanAddOns($plan_id, $options);
+
+            foreach($plan_add_ons as $add_on) {
+              echo 'Plan add-on: ' . $add_on->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListPlanAddOnsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naddOns, err
+            := client.ListPlanAddOns(planID, listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor addOns.HasMore() {\n\terr := addOns.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, addOn := range addOns.Data()
+            {\n\t\tfmt.Printf(\"Add-On %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taddOn.Id,\n\t\t\taddOn.Code,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - add-on
@@ -11899,6 +19212,172 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Plan
           Add-On: %v\", planAddOn.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const addOnCreate = {
+                code: 'coffee_grinder',
+                name: 'A quality grinder for your beans',
+                defaultQuantity: 1,
+                currencies: [
+                  {
+                    currency: 'USD',
+                    unitAmount: 10000
+                  }
+                ]
+              }
+
+              const addOn = await client.createPlanAddOn(planId, addOnCreate)
+              console.log('Created add-on: ', addOn.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                add_on_create = {
+                    "code": "coffee_grinder",
+                    "name": "A quality grinder for your beans",
+                    "default_quantity": 1,
+                    "currencies": [{"currency": "USD", "unit_amount": 10000}],
+                }
+                add_on = client.create_plan_add_on(plan_id, add_on_create)
+                print("Created PlanAddOn %s" % add_on)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var addOnReq = new AddOnCreate() {
+                    Code = "coffee_grinder",
+                    Name = "A quality grinder for your beans",
+                    DefaultQuantity = 1,
+                    Currencies = new List<AddOnPricing>() {
+                        new AddOnPricing() {
+                            Currency = "USD",
+                            UnitAmount = 10000
+                        }
+                    }
+                };
+                AddOn addOn = client.CreatePlanAddOn(planId, addOnReq);
+                Console.WriteLine($"Created add-on {addOn.Code}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              new_add_on = {
+                code: 'coffee_grinder',
+                name: 'A quality grinder for your beans',
+                default_quantity: 1,
+                currencies: [
+                  {
+                    currency: 'USD',
+                    unit_amount: 10_000
+                  }
+                ]
+              }
+              add_on = @client.create_plan_add_on(plan_id: plan_id, body: new_add_on)
+              puts "Created plan add-on #{add_on}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                AddOnCreate addOnCreate = new AddOnCreate();
+
+                addOnCreate.setCode("coffee-grinder");
+                addOnCreate.setName("A quality grinder for your beans");
+                addOnCreate.setDefaultQuantity(1);
+
+                List<AddOnPricing> currencies = new ArrayList<AddOnPricing>();
+                AddOnPricing addOnPrice = new AddOnPricing();
+                addOnPrice.setCurrency("USD");
+                addOnPrice.setUnitAmount(new BigDecimal("10000.0"));
+                currencies.add(addOnPrice);
+
+                addOnCreate.setCurrencies(currencies);
+
+                AddOn addOn = client.createPlanAddOn(planId, addOnCreate);
+                System.out.println("Created add-on " + addOn.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $add_on_create = [
+                    "code" => $add_on_code,
+                    "name" => "Fresh beans shipped monthly",
+                    "currencies" => [
+                        [
+                            "currency" => "USD",
+                            "unit_amount" => 10
+                        ]
+                    ]
+                ];
+
+                $add_on = $client->createPlanAddOn($plan_id, $add_on_create);
+
+                echo 'Created Plan:' . PHP_EOL;
+                var_dump($plan);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
+            beans shipped monthly\"),\n\tCurrencies: &[]recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
+            \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
+            err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Plan
+            Add-On: %v\", planAddOn.Id)"
+          name: Go
   "/plans/{plan_id}/add_ons/{add_on_id}":
     get:
       tags:
@@ -12018,6 +19497,105 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Plan
           Add-On: %v\", planAddOn)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const addOn = await client.getPlanAddOn(planId, addOnId)
+              console.log('Fetched add-on: ', addOn.code)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                add_on = client.get_plan_add_on(plan_id, add_on_id)
+                print("Got Plan Add-On %s" % add_on)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                AddOn addOn = client.GetPlanAddOn(planId, addOnId);
+                Console.WriteLine($"Fetched add-on {addOn.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              add_on = @client.get_plan_add_on(
+                plan_id: plan_id, add_on_id: add_on_id
+              )
+              puts "Got plan add-on #{add_on}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AddOn addOn = client.getPlanAddOn(planId, addOnId);
+                System.out.println("Fetched add-on " + addOn.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $add_on = $client->getPlanAddOn($plan_id, $add_on_id);
+
+                echo 'Got Plan Add-On:' . PHP_EOL;
+                var_dump($add_on);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "planAddOn, err := client.GetPlanAddOn(planID, planAddOnID)\nif e,
+            ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Plan
+            Add-On: %v\", planAddOn)"
+          name: Go
     put:
       tags:
       - add-on
@@ -12160,6 +19738,117 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Plan
           Add-On: %v\", planAddOn)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const addOnUpdate = {
+                name: 'New AddOn Name',
+              }
+              const addOn = await client.updatePlanAddOn(planId, addOnId, addOnUpdate)
+              console.log('Updated add-on: ', addOn)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                add_on_update = {
+                  "name": "New Add-On Name",
+                }
+                add_on = client.update_plan_add_on(plan_id, add_on_id, add_on_update)
+                print("Updated Plan Add-On %s" % add_on)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var addOnReq = new AddOnUpdate {
+                  Name = "New Add-On Name"
+                };
+                AddOn addOn = client.UpdatePlanAddOn(planId, planAddOnId, addOnReq);
+                Console.WriteLine($"Updated add-on: {addOn.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: "begin\n  add_on_update = {\n    name: \"A quality grinder for your
+            finest beans\"\n  }\n  add_on = @client.update_plan_add_on(\n    plan_id:
+            plan_id, \n    add_on_id: add_on_id, \n    body: add_on_update\n  )\n
+            \ puts \"Updated add-on #{add_on}\"\nrescue Recurly::Errors::NotFoundError\n
+            \ # If the resource was not found, you may want to alert the user or\n
+            \ # just return nil\n  puts \"Resource Not Found\"\nend\n"
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AddOnUpdate addOnUpdate = new AddOnUpdate();
+                addOnUpdate.setName("New Add-On Name");
+
+                final AddOn addOn = client.updatePlanAddOn(planId, addOnId, addOnUpdate);
+                System.out.println("Updated add-on " + addOn.getCode());
+                System.out.println(addOn.getName());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $add_on_update = [
+                    "name" => "New AddOn Name",
+                ];
+                $add_on = $client->updatePlanAddOn($plan_id, $add_on_id, $add_on_update);
+
+                echo ' Updated Plan AddOn:' . PHP_EOL;
+                var_dump($add_on);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.AddOnUpdate{\n\tName: recurly.String(\"New
+            Add-On Name\"),\n}\nplanAddOn, err := client.UpdatePlanAddOn(planID, planAddOnID,
+            updateReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Updated Plan
+            Add-On: %v\", planAddOn)"
+          name: Go
     delete:
       tags:
       - add-on
@@ -12265,6 +19954,99 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Removed Plan
           Add-On: %v\", planAddOn)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const addOn = await client.removePlanAddOn(planId, addOnId)
+              console.log('Removed plan add-on: ', addOn)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                add_on = client.remove_plan_add_on(plan_id, add_on_id)
+                print("Removed Plan Add-On %s" % add_on_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                AddOn addOn = client.RemovePlanAddOn(planId, planAddOnId);
+                Console.WriteLine($"Removed Plan Add-On: {addOn.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: "begin\n  add_on = @client.remove_plan_add_on(\n    plan_id: plan_id,
+            \n    add_on_id: add_on_id\n  )\n  puts \"Removed add-on #{add_on}\"\nrescue
+            Recurly::Errors::NotFoundError\n  # If the resource was not found, you
+            may want to alert the user or\n  # just return nil\n  puts \"Resource
+            Not Found\"\nend\n"
+          name: Ruby
+        - language: java
+          code: |-
+            try {
+              final AddOn addOn = client.removePlanAddOn(planId, addOnId);
+              System.out.println("Removed add-on " + addOn.getCode());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $add_on = $client->removePlanAddOn($plan_id, $add_on_id);
+
+                echo 'Removed Plan AddOn:' . PHP_EOL;
+                var_dump($add_on);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "planAddOn, err := client.RemovePlanAddOn(planID, planAddOnID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Removed Plan
+            Add-On: %v\", planAddOn)"
+          name: Go
   "/price_segments":
     get:
       tags:
@@ -12433,6 +20215,75 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, addOn := range addOns.Data()
           {\n\t\tfmt.Printf(\"Add On %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taddOn.Id,\n\t\t\taddOn.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const addOns = client.listAddOns({ params: { limit: 200 } })
+
+            for await (const addOn of addOns.each()) {
+              console.log(addOn.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            add_ons = client.list_add_ons(params=params).items()
+            for add_on in add_ons:
+                print("Add-On %s" % add_on.code)
+          name: Python
+        - language: csharp
+          code: |
+            var addOns = client.ListAddOns();
+            foreach(AddOn addOn in addOns)
+            {
+                Console.WriteLine(addOn.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            add_ons = @client.list_add_ons(
+              params: params
+            )
+            add_ons.each do |add_on|
+              puts "AddOn: #{add_on.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListAddOnsParams params = new ListAddOnsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<AddOn> addOns = client.listAddOns(params);
+
+            for (AddOn addOn : addOns) {
+                System.out.println(addOn.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $add_ons = $client->listAddOns($options);
+
+            foreach($add_ons as $addon) {
+              echo 'Add-on: ' . $addon->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListAddOnsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\naddOns, err
+            := client.ListAddOns(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor addOns.HasMore() {\n\terr := addOns.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, addOn := range addOns.Data()
+            {\n\t\tfmt.Printf(\"Add On %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\taddOn.Id,\n\t\t\taddOn.Code,\n\t\t)\n\t}\n}"
+          name: Go
   "/add_ons/{add_on_id}":
     get:
       tags:
@@ -12549,6 +20400,103 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Add-On:
           %s\", addOn.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const addOn = await client.getAddOn(addOnId)
+              console.log('Fetched add-on: ', addOn)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                add_on = client.get_add_on(add_on_id)
+                print("Got Add-On %s" % add_on)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                AddOn addOn = client.GetAddOn(addOnId);
+                Console.WriteLine($"Fetched add-on: {addOn.Code}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              add_on = @client.get_add_on(add_on_id: add_on_id)
+              puts "Got add-on #{add_on}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final AddOn addOn = client.getAddOn(addOnId);
+                System.out.println("Fetched add-on " + addOn.getCode());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $add_on = $client->getAddOn($add_on_id);
+
+                echo 'Got Plan Add-On:' . PHP_EOL;
+                var_dump($add_on);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "addOn, err := client.GetAddOn(planAddOnID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched
+            Add-On: %s\", addOn.Id)"
+          name: Go
   "/shipping_methods":
     get:
       tags:
@@ -12650,6 +20598,75 @@ paths:
           := shippingMethods.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, method := range
           shippingMethods.Data() {\n\t\tfmt.Printf(\"Shipping Method %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tmethod.Id,\n\t\t\tmethod.Code,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const methods = client.listShippingMethods({ params: { limit: 200 } })
+
+            for await (const method of methods.each()) {
+              console.log(method.code)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            shipping_methods = client.list_shipping_methods(params=params).items()
+            for shipping_method in shipping_methods:
+                print("Shipping Method %s" % shipping_method.code)
+          name: Python
+        - language: csharp
+          code: |
+            var shippingMethods = client.ListShippingMethods();
+            foreach(ShippingMethod shippingMethod in shippingMethods)
+            {
+                Console.WriteLine(shippingMethod.Code);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            shipping_methods = @client.list_shipping_methods(
+              params: params
+            )
+            shipping_methods.each do |shipping_method|
+              puts "Shipping Method: #{shipping_method.code}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListShippingMethodsParams params = new ListShippingMethodsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<ShippingMethod> shippingMethods = client.listShippingMethods(params);
+
+            for (ShippingMethod shippingMethod : shippingMethods) {
+                System.out.println(shippingMethod.getCode());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $shipping_methods = $client->listShippingMethods($options);
+
+            foreach($shipping_methods as $shipping_method) {
+              echo 'Shipping Method: ' . $shipping_method->getCode() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListShippingMethodsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nshippingMethods,
+            err := client.ListShippingMethods(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor shippingMethods.HasMore() {\n\terr
+            := shippingMethods.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
+            to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, method := range
+            shippingMethods.Data() {\n\t\tfmt.Printf(\"Shipping Method %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tmethod.Id,\n\t\t\tmethod.Code,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - shipping_method
@@ -12899,6 +20916,77 @@ paths:
           subscriptions.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, subscription :=
           range subscriptions.Data() {\n\t\tfmt.Printf(\"Subscription %3d: %s\\n\",\n\t\t\ti,\n\t\t\tsubscription.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const subscriptions = client.listSubscriptions({ params: { limit: 200 } })
+
+            for await (const subscription of subscriptions.each()) {
+              console.log(subscription.uuid)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            subscriptions = client.list_subscriptions(params=params).items()
+            for subscription in subscriptions:
+                print(subscription.uuid)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListSubscriptionsParams()
+            {
+                Limit = 200
+            };
+            var subscriptions = client.ListSubscriptions(optionalParams);
+            foreach(Subscription subscription in subscriptions)
+            {
+                Console.WriteLine(subscription.Uuid);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            subscriptions = @client.list_subscriptions(params: params)
+            subscriptions.each do |subscription|
+              puts "Subscription: #{subscription.uuid}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListSubscriptionsParams params = new ListSubscriptionsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Subscription> subscriptions = client.listSubscriptions(params);
+
+            for (Subscription subscription : subscriptions) {
+                System.out.println(subscription.getUuid());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $subscriptions = $client->listSubscriptions($options);
+
+            foreach($subscriptions as $sub) {
+              echo 'Subscription: ' . $sub->getUuid() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListSubscriptionsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nsubscriptions,
+            err := client.ListSubscriptions(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor subscriptions.HasMore() {\n\terr
+            := subscriptions.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
+            to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, subscription
+            := range subscriptions.Data() {\n\t\tfmt.Printf(\"Subscription %3d: %s\\n\",\n\t\t\ti,\n\t\t\tsubscription.Id,\n\t\t)\n\t}\n}"
+          name: Go
     post:
       tags:
       - subscription
@@ -13075,6 +21163,153 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Subscription:
           %s\", subscription.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let subscriptionReq = {
+                planCode: planCode,
+                currency: `USD`,
+                account: {
+                  code: accountCode
+                }
+              }
+              let sub = await client.createSubscription(subscriptionReq)
+              console.log('Created subscription: ', sub.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                sub_create = {
+                    "plan_code": plan_code,
+                    "currency": "USD",
+                    "account": {"code": account_code},
+                }
+                sub = client.create_subscription(sub_create)
+                print("Created Subscription %s" % sub)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var subReq = new SubscriptionCreate()
+                {
+                    Currency = "USD",
+                    Account = new AccountCreate()
+                    {
+                        Code = accountCode
+                    },
+                    PlanCode = planCode,
+                };
+                Subscription subscription = client.CreateSubscription(subReq);
+                Console.WriteLine($"Created Subscription with Id: {subscription.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription_create = {
+                plan_code: plan_code,
+                currency: "USD",
+                # This can be an existing account or a new account
+                account: {
+                  code: account_code,
+                }
+              }
+              subscription = @client.create_subscription(
+                body: subscription_create
+              )
+              puts "Created Subscription #{subscription}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                SubscriptionCreate subscriptionCreate = new SubscriptionCreate();
+                AccountCreate accountCreate = new AccountCreate();
+
+                accountCreate.setCode(accountCode);
+                subscriptionCreate.setCurrency("USD");
+                subscriptionCreate.setAccount(accountCreate);
+                subscriptionCreate.setPlanCode(planCode);
+
+                Subscription subscription = client.createSubscription(subscriptionCreate);
+                System.out.println("Created Subscription with Id: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $sub_create = [
+                    "plan_code" => $plan_code,
+                    "currency" => "USD",
+                    "account" => [
+                        "code" => $account_code
+                    ],
+                ];
+
+                $subscription = $client->createSubscription($sub_create);
+
+                echo 'Created Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "subReq := &recurly.SubscriptionCreate{\n\tPlanCode: recurly.String(planCode),\n\tAccount:
+            &recurly.AccountCreate{\n\t\tCode: recurly.String(accountCode),\n\t},\n\tCurrency:
+            recurly.String(\"USD\"),\n}\n\nsubscription, err := client.CreateSubscription(subReq)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Subscription:
+            %s\", subscription.Id)"
+          name: Go
   "/subscriptions/{subscription_id}":
     get:
       tags:
@@ -13193,6 +21428,105 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Subscription:
           %s\", sub.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const subscription = await client.getSubscription(subscriptionId)
+              console.log('Fetched subscription: ', subscription.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                subscription = client.get_subscription(subscription_id)
+                print("Got Subscription %s" % subscription)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Subscription subscription = client.GetSubscription(sub.Id);
+                Console.WriteLine($"Fetched Subscription {subscription.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription = @client.get_subscription(
+                subscription_id: subscription_id
+              )
+              puts "Got Subscription #{subscription}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Subscription subscription = client.getSubscription(subscriptionId);
+                System.out.println("Fetched Subscription: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $subscription = $client->getSubscription($subscription_id);
+
+                echo 'Got Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "sub, err := client.GetSubscription(subID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeNotFound {\n\t\tfmt.Printf(\"Resource
+            not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Subscription:
+            %s\", sub.Id)"
+          name: Go
     put:
       tags:
       - subscription
@@ -13340,6 +21674,132 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Modified Subscription:
           %s\", sub.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const update = {
+                termsAndConditions: "Some new terms and conditions",
+                customerNotes: "Some new customer notes"
+              }
+              const subscription = await client.updateSubscription(subscriptionId, update)
+              console.log('Modified subscription: ', subscription.uuid)
+            } catch(err) {
+
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                sub_update = {"customer_notes": "New Notes", "terms_and_conditions": "New TaC"}
+                subscription = client.update_subscription(subscription_id, sub_update)
+                print("Modified Subscription %s" % subscription)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var updateReq = new SubscriptionUpdate()
+                {
+                    TermsAndConditions = "Some New Terms and Conditions",
+                    CustomerNotes = "Some New Customer Notes"
+                };
+                Subscription subscription = client.UpdateSubscription(subscriptionId, updateReq);
+                Console.WriteLine($"Modified Subscription {subscription.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription_update = {
+                customer_notes: "New Notes",
+                terms_and_conditions: "New ToC"
+              }
+              subscription = @client.update_subscription(
+                subscription_id: subscription_id,
+                body: subscription_update
+              )
+              puts "Modified Subscription #{subscription}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final SubscriptionUpdate subUpdate = new SubscriptionUpdate();
+                subUpdate.setTermsAndConditions("Some new terms and conditions");
+                subUpdate.setCustomerNotes("Some new customer notes");
+                final Subscription subscription = client.updateSubscription(subscriptionId, subUpdate);
+                System.out.println("Modified Subscription: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $changes = [
+                    "terms_and_conditions" => "Some new terms and conditions",
+                    "customer_notes" => "Some new customer notes"
+                ];
+
+                $subscription = $client->updateSubscription($subscription_id, $changes);
+
+                echo 'Modified Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "updateReq := &recurly.SubscriptionUpdate{\n\tTermsAndConditions:
+            recurly.String(\"Some new terms and conditions\"),\n\tCustomerNotes:      recurly.String(\"Some
+            new customer notes\"),\n}\nsub, err := client.UpdateSubscription(subID,
+            updateReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Modified Subscription:
+            %s\", sub.Id)"
+          name: Go
     delete:
       tags:
       - subscription
@@ -13500,6 +21960,112 @@ paths:
           not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Terminated
           Subscription: %v\", subscription)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const subscription = await client.terminateSubscription(subscriptionId)
+              console.log('Terminated subscription: ', subscription.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                subscription = client.terminate_subscription(subscription_id)
+                print("Terminated Subscription %s" % subscription)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var optionalParams = new TerminateSubscriptionParams()
+                {
+                    Refund = RefundType.None
+                };
+                Subscription subscription = client.TerminateSubscription(subscriptionId, optionalParams);
+                Console.WriteLine($"Terminated Subscription {subscription.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription = @client.terminate_subscription(
+                subscription_id: subscription_id,
+              )
+              puts "Terminated Subscription #{subscription}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                TerminateSubscriptionParams queryParams = new TerminateSubscriptionParams();
+                queryParams.setRefund(Constants.RefundType.NONE); // "full" for a full refund, "partial" for prorated refund
+                client.terminateSubscription(subscriptionId, queryParams);
+                System.out.println("Terminated Subscription: " + subscriptionId);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $subscription = $client->terminateSubscription($subscription_id);
+
+                echo 'Terminated Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "terminateParams := &recurly.TerminateSubscriptionParams{}\nsubscription,
+            err := client.TerminateSubscription(subID, terminateParams)\nif e, ok
+            := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Terminated
+            Subscription: %v\", subscription)"
+          name: Go
   "/subscriptions/{subscription_id}/cancel":
     put:
       tags:
@@ -13637,6 +22203,107 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Canceled Subscription:
           %s\", subscription.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let expiredSub = await client.cancelSubscription(subscriptionId)
+              console.log('Canceled Subscription: ', expiredSub.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                subscription = client.cancel_subscription(subscription_id)
+                print("Canceled Subscription %s" % subscription)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Subscription subscription = client.CancelSubscription(subscriptionId);
+                Console.WriteLine($"Canceled Subscription {subscription.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription = @client.cancel_subscription(
+                subscription_id: subscription_id
+              )
+              puts "Canceled Subscription #{subscription}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Subscription subscription = client.cancelSubscription(subscriptionId);
+                System.out.println("Canceled Subscription: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $subscription = $client->cancelSubscription($subscription_id);
+
+                echo 'Canceled Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "cancelParams := &recurly.CancelSubscriptionParams{\n\tBody: &recurly.SubscriptionCancel{\n\t\tTimeframe:
+            recurly.String(\"bill_date\"),\n\t},\n}\n\nsubscription, err := client.CancelSubscription(subID,
+            cancelParams)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type ==
+            recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed validation: %v\",
+            e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected Recurly error:
+            %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Canceled Subscription: %s\",
+            subscription.Id)"
+          name: Go
   "/subscriptions/{subscription_id}/reactivate":
     put:
       tags:
@@ -13767,6 +22434,106 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
           Subscription: %s\", sub.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const subscription = await client.reactivateSubscription(subscriptionId)
+              console.log('Reactivated subscription: ', subscription.uuid)
+            } catch(err) {
+
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                subscription = client.reactivate_subscription(subscription_id)
+                print("Reactivated Subscription %s" % subscription)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Subscription subscription = client.ReactivateSubscription(subscriptionId);
+                Console.WriteLine($"Reactivated Subscription {subscription.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription = @client.reactivate_subscription(
+                subscription_id: subscription_id
+              )
+              puts "Reactivated Canceled Subscription #{subscription}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Subscription subscription = client.reactivateSubscription(subscriptionId);
+                System.out.println("Reactivated Subscription: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $subscription = $client->reactivateSubscription($subscription_id);
+
+                echo 'Reactivated Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "sub, err := client.ReactivateSubscription(subID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
+            Subscription: %s\", sub.Id)"
+          name: Go
   "/subscriptions/{subscription_id}/pause":
     put:
       tags:
@@ -13921,6 +22688,122 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Paused Subscription:
           %s\", sub.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let pauseReq = {
+                remaining_pause_cycles: 2,
+              }
+              const subscription = await client.pauseSubscription(subscriptionId, pauseReq)
+              console.log('Paused subscription: ', subscription.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                sub_pause = {"remaining_pause_cycles": 10}
+                subscription = client.pause_subscription(subscription_id, sub_pause)
+                print("Paused Subscription %s" % subscription)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var pauseReq = new SubscriptionPause() {
+                  RemainingPauseCycles = 2
+                };
+                Subscription subscription = client.PauseSubscription(subscriptionId, pauseReq);
+                Console.WriteLine($"Paused Subscription {subscription.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription_pause = {
+                remaining_pause_cycles: 10
+              }
+              subscription = @client.pause_subscription(
+                subscription_id: subscription_id,
+                body: subscription_pause
+              )
+              puts "Paused Subscription #{subscription}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final SubscriptionPause subPause = new SubscriptionPause();
+                subPause.setRemainingPauseCycles(10);
+
+                final Subscription subscription = client.pauseSubscription(subscriptionId, subPause);
+                System.out.println("Paused Subscription: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $sub_pause = [ "remaining_pause_cycles" => 10 ];
+                $subscription = $client->pauseSubscription($subscription_id, $sub_pause);
+
+                echo 'Paused Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "pauseReq := &recurly.SubscriptionPause{\n\tRemainingPauseCycles:
+            recurly.Int(1),\n}\nsub, err := client.PauseSubscription(subID, pauseReq)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Paused Subscription:
+            %s\", sub.Id)"
+          name: Go
   "/subscriptions/{subscription_id}/resume":
     put:
       tags:
@@ -14052,6 +22935,106 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Resumed Subscription:
           %s\", sub.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const subscription = await client.resumeSubscription(subscriptionId)
+              console.log('Resumed subscription: ', subscription.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                subscription = client.resume_subscription(subscription_id)
+                print("Resumed Subscription %s" % subscription)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Subscription subscription = client.ResumeSubscription(subscriptionId);
+                Console.WriteLine($"Resumed Subscription {subscription.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              subscription = @client.resume_subscription(
+                subscription_id: subscription_id
+              )
+              puts "Resumed Subscription #{subscription}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final Subscription subscription = client.resumeSubscription(subscriptionId);
+                System.out.println("Resumed Subscription: " + subscription.getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $subscription = $client->resumeSubscription($subscription_id);
+
+                echo 'Resumed Subscription:' . PHP_EOL;
+                var_dump($subscription);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "sub, err := client.ResumeSubscription(subID)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Resumed Subscription:
+            %s\", sub.Id)"
+          name: Go
   "/subscriptions/{subscription_id}/convert_trial":
     put:
       tags:
@@ -14219,6 +23202,105 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Renewal
           Preview with total: %f\", invoiceCollection.ChargeInvoice.Total)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const invoiceCollection = await client.getPreviewRenewal(subscriptionId)
+              console.log('Fetched Renewal Preview with total: ', invoiceCollection.chargeInvoice.total)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                invoice_collection = client.get_preview_renewal(subscription_id)
+                print("Fetched Renewal Preview with total: %s" % invoice_collection.charge_invoice.total)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                InvoiceCollection invoiceCollection = client.GetPreviewRenewal(subscriptionId);
+                Console.WriteLine($"Fetched Renewal Preview with total {invoiceCollection.ChargeInvoice.Total}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              invoice_collection = @client.get_preview_renewal(
+                subscription_id: subscription_id
+              )
+              puts "Fetched Renewal Preview with total: #{invoice_collection.charge_invoice.total}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final InvoiceCollection invoiceCollection = client.getPreviewRenewal(subscriptionId);
+                System.out.println("Fetched Renewal Preview with total: " + invoiceCollection.getChargeInvoice().getTotal());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $invoiceCollection = $client->getPreviewRenewal($subscription_id);
+
+                echo 'Fetched Renewal Preview with total: ' . $invoiceCollection->getChargeInvoice()->getTotal() . PHP_EOL;
+                var_dump($invoiceCollection);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "invoiceCollection, err := client.GetPreviewRenewal(subID)\nif e,
+            ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Renewal
+            Preview with total: %f\", invoiceCollection.ChargeInvoice.Total)"
+          name: Go
   "/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -14350,6 +23432,105 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched subscription
           change: %s\", subscriptionChange.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const change = await client.getSubscriptionChange(subscriptionId)
+              console.log('Fetched subscription change: ', change.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                change = client.get_subscription_change(subscription_id)
+                print("Got SubscriptionChange %s" % change)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                SubscriptionChange change = client.GetSubscriptionChange(subscriptionId);
+                Console.WriteLine($"Fetched subscription change {change.Id}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              change = @client.get_subscription_change(
+                subscription_id: subscription_id
+              )
+              puts "Got SubscriptionChange #{change}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                final SubscriptionChange change = client.getSubscriptionChange(subscriptionId);
+                System.out.println("Fetched Subscription change " + change.getId());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $change = $client->getSubscriptionChange($subscription_id);
+
+                echo 'Got Pending Subscription Change:' . PHP_EOL;
+                var_dump($change);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "subscriptionChange, err := client.GetSubscriptionChange(subID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched subscription
+            change: %s\", subscriptionChange.Id)"
+          name: Go
     post:
       tags:
       - subscription_change
@@ -14519,6 +23700,132 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Subscription
           changed: %s\", subscriptionChange.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const subscriptionChangeCreate = {
+                planCode: newPlanCode,
+                timeframe: 'now'
+              }
+
+              const change = await client.createSubscriptionChange(subscriptionId, subscriptionChangeCreate)
+              console.log('Created subscription change: ', change.id)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                sub_change_create = {"plan_code": new_plan_code, "timeframe": "now"}
+                change = client.create_subscription_change(subscription_id, sub_change_create)
+                print("Created SubscriptionChange %s" % change)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var changeReq = new SubscriptionChangeCreate()
+                {
+                    PlanCode = newPlanCode,
+                    Timeframe = ChangeTimeframe.Now // choose "now" or "renewal"
+                };
+                SubscriptionChange change = client.CreateSubscriptionChange(subscriptionId, changeReq);
+                Console.WriteLine($"Created subscription change {change.Id}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              change_create = {
+                timeframe: "now",
+                plan_code: new_plan_code
+              }
+              change = @client.create_subscription_change(
+                subscription_id: subscription_id,
+                body: change_create
+              )
+              puts "Created SubscriptionChange #{change}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                SubscriptionChangeCreate changeCreate = new SubscriptionChangeCreate();
+
+                changeCreate.setPlanCode(newPlanCode);
+                changeCreate.setTimeframe(Constants.ChangeTimeframe.NOW); // choose "now" or "renewal"
+
+                SubscriptionChange change = client.createSubscriptionChange(subscriptionId, changeCreate);
+                System.out.println("Created subscription " + change.getId());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $change_create = [
+                    "plan_code" => $new_plan_code,
+                    "timeframe" => "now"
+                ];
+                $change = $client->createSubscriptionChange($subscription_id, $change_create);
+
+                echo 'Created Subscription Change:' . PHP_EOL;
+                var_dump($change);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "changeReq := &recurly.SubscriptionChangeCreate{\n\tPlanCode:  recurly.String(newPlanCode),\n\tTimeframe:
+            recurly.String(\"now\"),\n}\nsubscriptionChange, err := client.CreateSubscriptionChange(subID,
+            changeReq)\nif e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeValidation
+            {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Subscription
+            changed: %s\", subscriptionChange.Id)"
+          name: Go
     delete:
       tags:
       - subscription_change
@@ -14632,6 +23939,103 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Subscription
           Change: %v\", subscriptionChange)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              await client.removeSubscriptionChange(subscriptionId)
+              console.log('Removed subscription change: ', subscriptionId)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                client.remove_subscription_change(subscription_id)
+                print("Removed SubscriptionChange from Subscription id=%s" % subscription_id)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                client.RemoveSubscriptionChange(subscriptionId);
+                Console.WriteLine($"Removed subscription change from {subscriptionId}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              @client.remove_subscription_change(
+                subscription_id: subscription_id
+              )
+              puts "Removed SubscriptionChange #{subscription_id}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                client.removeSubscriptionChange(subscriptionId);
+                System.out.println("Removed Subscription change from " + subscriptionId);
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $client->removeSubscriptionChange($subscription_id);
+                echo 'Removed Subscription Change: ' . $subscription_id . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "subscriptionChange, err := client.RemoveSubscriptionChange(subID)\nif
+            e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed
+            Subscription Change: %v\", subscriptionChange)"
+          name: Go
   "/subscriptions/{subscription_id}/change/preview":
     post:
       tags:
@@ -14780,6 +24184,77 @@ paths:
           subInvoices.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, invoice := range
           subInvoices.Data() {\n\t\tfmt.Printf(\"Subscription Invoice %3d: %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const invoices = client.listSubscriptionInvoices(subscriptionId, { params: { limit: 200 } })
+
+            for await (const invoice of invoices.each()) {
+              console.log(invoice.number)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            invoices = client.list_subscription_invoices(subscription_id, params=params).items()
+            for invoice in invoices:
+                print(invoice.number)
+          name: Python
+        - language: csharp
+          code: |
+            var subscriptionInvoices = client.ListSubscriptionInvoices(subscriptionId);
+            foreach(Invoice invoice in subscriptionInvoices)
+            {
+                Console.WriteLine(invoice.Number);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            invoices = @client.list_subscription_invoices(
+              subscription_id: subscription_id,
+              params: params
+            )
+            invoices.each do |invoice|
+              puts "Invoice: #{invoice.number}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListSubscriptionInvoicesParams params = new ListSubscriptionInvoicesParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Invoice> invoices = client.listSubscriptionInvoices(subscriptionId, params);
+
+            for (Invoice invoice : invoices) {
+                System.out.println(invoice.getNumber());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $subscription_invoices = $client->listSubscriptionInvoices($subscription_id, $options);
+
+            foreach($subscription_invoices as $sub_invoice) {
+              echo 'Subscription Invoice: ' . $sub_invoice->getNumber() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListSubscriptionInvoicesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nsubInvoices,
+            err := client.ListSubscriptionInvoices(subID, listParams)\nif err != nil
+            {\n\tfmt.Println(\"Unexpected error: %v\", err)\n\treturn\n}\n\nfor subInvoices.HasMore()
+            {\n\terr := subInvoices.Fetch()\n\tif e, ok := err.(*recurly.Error); ok
+            {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
+            i, invoice := range subInvoices.Data() {\n\t\tfmt.Printf(\"Subscription
+            Invoice %3d: %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/subscriptions/{subscription_id}/line_items":
     get:
       tags:
@@ -14887,6 +24362,77 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, lineItem := range subLineItems.Data() {\n\t\tfmt.Printf(\"Subscription
           Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const lineItems = client.listSubscriptionLineItems(subscriptionId, { params: { limit: 200 } })
+
+            for await (const lineItem of lineItems.each()) {
+              console.log(lineItem.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            line_items = client.list_subscription_line_items(subscription_id, params=params).items()
+            for line_item in line_items:
+                print(line_item.id)
+          name: Python
+        - language: csharp
+          code: |
+            var subscriptionLineItems = client.ListSubscriptionLineItems(subscriptionId);
+            foreach(LineItem lineItem in subscriptionLineItems)
+            {
+                Console.WriteLine(lineItem.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            line_items = @client.list_subscription_line_items(
+              subscription_id: subscription_id,
+              params: params
+            )
+            line_items.each do |line_item|
+              puts "LineItem: #{line_item.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListSubscriptionLineItemsParams params = new ListSubscriptionLineItemsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<LineItem> lineItems = client.listSubscriptionLineItems(subscriptionId, params);
+
+            for (LineItem lineItem : lineItems) {
+                System.out.println(lineItem.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $subscription_line_items = $client->listSubscriptionLineItems($subscription_id, $options);
+
+            foreach($subscription_line_items as $line_item) {
+              echo 'Subscription Invoice: ' . $line_item->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListSubscriptionLineItemsParams{\n\tSort:
+            \ recurly.String(\"created_at\"),\n\tOrder: recurly.String(\"desc\"),\n\tLimit:
+            recurly.Int(200),\n}\nsubLineItems, err := client.ListSubscriptionLineItems(subID,
+            listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected error: %v\",
+            err)\n\treturn\n}\n\nfor subLineItems.HasMore() {\n\terr := subLineItems.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, lineItem := range subLineItems.Data()
+            {\n\t\tfmt.Printf(\"Subscription Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/subscriptions/{subscription_id}/coupon_redemptions":
     get:
       tags:
@@ -14983,6 +24529,77 @@ paths:
           e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range subCouponRedemptions.Data()
           {\n\t\tfmt.Printf(\"Subscription Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const redemptions = client.listSubscriptionCouponRedemptions(subscriptionId, { params: { limit: 200 } })
+
+            for await (const redemption of redemptions.each()) {
+              console.log(redemption.id)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            redemptions = client.list_subscription_coupon_redemptions(
+                subscription_id, params=params
+            ).items()
+            for redemption in redemptions:
+                print(redemption.uuid)
+          name: Python
+        - language: csharp
+          code: |
+            var subscriptionCouponRedemptions = client.ListSubscriptionCouponRedemptions(subscriptionId);
+            foreach(CouponRedemption redemption in subscriptionCouponRedemptions)
+            {
+                Console.WriteLine(redemption.Id);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            coupon_redemptions = @client.list_subscription_coupon_redemptions(
+              subscription_id: subscription_id,
+              params: params
+            )
+            coupon_redemptions.each do |redemption|
+              puts "CouponRedemption: #{redemption.id}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListSubscriptionCouponRedemptionsParams params = new ListSubscriptionCouponRedemptionsParams();
+            final Pager<CouponRedemption> redemptions = client.listSubscriptionCouponRedemptions(subscriptionId, params);
+
+            for (CouponRedemption redemption : redemptions) {
+                System.out.println(redemption.getId());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $subscription_coupon_redemptions = $client->listSubscriptionCouponRedemptions($subscription_id, $options);
+
+            foreach($subscription_coupon_redemptions as $redemption) {
+              echo 'Subscription Coupon Redemption: ' . $redemption->getId() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListSubscriptionCouponRedemptionsParams{\n\tSort:
+            recurly.String(\"created_at\"),\n}\nsubCouponRedemptions, err := client.ListSubscriptionCouponRedemptions(subID,
+            listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected error: %v\",
+            err)\n\treturn\n}\n\nfor subCouponRedemptions.HasMore() {\n\terr := subCouponRedemptions.Fetch()\n\tif
+            e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+            next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range subCouponRedemptions.Data()
+            {\n\t\tfmt.Printf(\"Subscription Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/subscriptions/{subscription_id}/coupon_redemptions/{coupon_redemption_id}":
     get:
       tags:
@@ -15354,6 +24971,77 @@ paths:
           transactions.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, transaction :=
           range transactions.Data() {\n\t\tfmt.Printf(\"Transaction %3d: %s\\n\",\n\t\t\ti,\n\t\t\ttransaction.Id,\n\t\t)\n\t}\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            const transactions = client.listTransactions({ params: { limit: 200 } })
+
+            for await (const transaction of transactions.each()) {
+              console.log(transaction.uuid)
+            }
+          name: Node.js
+        - language: python
+          code: |
+            params = {"limit": 200}
+            transactions = client.list_transactions(params=params).items()
+            for transaction in transactions:
+                print(transaction.uuid)
+          name: Python
+        - language: csharp
+          code: |
+            var optionalParams = new ListTransactionsParams()
+            {
+                Limit = 200
+            };
+            var transactions = client.ListTransactions(optionalParams);
+            foreach(Transaction transaction in transactions)
+            {
+                Console.WriteLine(transaction.Uuid);
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            params = {
+              limit: 200
+            }
+            transactions = @client.list_transactions(params: params)
+            transactions.each do |transaction|
+              puts "Transaction: #{transaction.uuid}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            ListTransactionsParams params = new ListTransactionsParams();
+            params.setLimit(200); // Pull 200 records at a time
+            final Pager<Transaction> transactions = client.listTransactions(params);
+
+            for (Transaction transaction : transactions) {
+                System.out.println(transaction.getUuid());
+            }
+          name: Java
+        - language: php
+          code: |
+            $options = [
+              'params' => [
+                'limit' => 200
+              ]
+            ];
+            $transactions = $client->listTransactions($options);
+
+            foreach($transactions as $transaction) {
+              echo 'Transaction: ' . $transaction->getUuid() . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "listParams := &recurly.ListTransactionsParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
+            recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\ntransactions,
+            err := client.ListTransactions(listParams)\nif err != nil {\n\tfmt.Println(\"Unexpected
+            error: %v\", err)\n\treturn\n}\n\nfor transactions.HasMore() {\n\terr
+            := transactions.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
+            to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, transaction
+            := range transactions.Data() {\n\t\tfmt.Printf(\"Transaction %3d: %s\\n\",\n\t\t\ti,\n\t\t\ttransaction.Id,\n\t\t)\n\t}\n}"
+          name: Go
   "/transactions/{transaction_id}":
     get:
       tags:
@@ -15470,6 +25158,103 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction.Id)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const transaction = await client.getTransaction(transactionId)
+              console.log('Fetched transaction: ', transaction.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.NotFoundError) {
+                // If the request was not found, you may want to alert the user or
+                // just return null
+                console.log('Resource Not Found')
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+              transaction = client.get_transaction(transaction_id)
+              print("Got Transaction %s" % transaction)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                Transaction transaction = client.GetTransaction(transactionId);
+                Console.WriteLine($"Fetched transaction {transaction.Uuid}");
+            }
+            catch (Recurly.Errors.NotFound ex)
+            {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              transaction = @client.get_transaction(transaction_id: transaction_id)
+              puts "Got Transaction #{transaction}"
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                Transaction transaction = client.getTransaction(transactionId);
+                System.out.println("Fetched transaction " + transaction.getUuid());
+            } catch (NotFoundException e) {
+                // If the resource was not found
+                // we may want to alert the user or just return null
+                System.out.println("Resource Not Found: " + e.getError().getMessage());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $transaction = $client->getTransaction($transaction_id);
+
+                echo 'Got Transaction:' . PHP_EOL;
+                var_dump($transaction);
+            } catch (\Recurly\Errors\NotFound $e) {
+                // Could not find the resource, you may want to inform the user
+                // or just return a NULL
+                echo 'Could not find resource.' . PHP_EOL;
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // Something bad happened... tell the user so that they can fix it?
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "transaction, err := client.GetTransaction(transactionID)\nif e, ok
+            := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+            {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Transaction:
+            %v\", transaction.Id)"
+          name: Go
   "/unique_coupon_codes/{unique_coupon_code_id}":
     parameters:
     - "$ref": "#/components/parameters/unique_coupon_code_id"
@@ -15804,6 +25589,213 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Purchase:
           %s\", collection.ChargeInvoice.Number)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let purchaseReq = {
+                currency: 'USD',
+                account: {
+                  code: accountCode,
+                  firstName: 'Benjamin',
+                  lastName: 'Du Monde',
+                  billingInfo: {
+                    tokenId: rjsTokenId
+                  }
+                },
+                subscriptions: [
+                  { planCode: planCode },
+                ]
+              }
+              let invoiceCollection = await client.createPurchase(purchaseReq)
+              console.log('Created Charge Invoice: ', invoiceCollection.chargeInvoice)
+              console.log('Created Credit Invoices: ', invoiceCollection.creditInvoices)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                purchase = {
+                    "currency": "USD",
+                    "account": {
+                        "code": account_code,
+                        "first_name": "Benjamin",
+                        "last_name": "Du Monde",
+                        "billing_info": {"token_id": rjs_token_id},
+                    },
+                    "subscriptions": [{"plan_code": plan_code}],
+                }
+                invoice_collection = client.create_purchase(purchase)
+                print("Created Charge Invoice %s" % invoice_collection.charge_invoice)
+                print("Created Credit Invoices %s" % invoice_collection.credit_invoices)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var purchaseReq = new PurchaseCreate()
+                {
+                    Currency = "USD",
+                    Account = new AccountPurchase()
+                    {
+                        Code = accountCode,
+                        FirstName = "Benjamin",
+                        LastName = "Du Monde",
+                        BillingInfo = new BillingInfoCreate()
+                        {
+                            TokenId = rjsTokenId
+                        }
+                    },
+                    Subscriptions = new List<SubscriptionPurchase>()
+                    {
+                        new SubscriptionPurchase() { PlanCode = planCode }
+                    }
+                };
+                InvoiceCollection collection = client.CreatePurchase(purchaseReq);
+                Console.WriteLine($"Created ChargeInvoice with Number: {collection.ChargeInvoice.Number}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              purchase = {
+                currency: "USD",
+                account: {
+                  code: account_code,
+                  first_name: "Benjamin",
+                  last_name: "Du Monde",
+                  billing_info: {
+                    token_id: rjs_token_id
+                  },
+                },
+                subscriptions: [
+                  { plan_code: plan_code }
+                ]
+              }
+              invoice_collection = @client.create_purchase(
+                body: purchase
+              )
+              puts "Created Charge Invoice #{invoice_collection.charge_invoice}"
+              puts "Created Credit Invoices #{invoice_collection.credit_invoices}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+
+                AccountPurchase account = new AccountPurchase();
+                account.setCode(accountCode);
+                account.setFirstName("Benjamin");
+                account.setLastName("DuMonde");
+
+                BillingInfoCreate billing = new BillingInfoCreate();
+                billing.setTokenId(rjsTokenId);
+                account.setBillingInfo(billing);
+
+                List<SubscriptionPurchase> subscriptions = new ArrayList<SubscriptionPurchase>();
+                SubscriptionPurchase sub = new SubscriptionPurchase();
+                sub.setPlanCode(planCode);
+                subscriptions.add(sub);
+
+                PurchaseCreate purchase = new PurchaseCreate();
+                purchase.setCurrency("USD");
+                purchase.setAccount(account);
+                purchase.setSubscriptions(subscriptions);
+
+                InvoiceCollection collection = client.createPurchase(purchase);
+                System.out.println("Created ChargeInvoice with Id: " + collection.getChargeInvoice().getId());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+                System.out.println("Params: " + e.getError().getParams());
+            } catch (TransactionException e) {
+                TransactionError tError = e.getError().getTransactionError();
+                if (tError.getCategory() == Constants.ErrorCategory.THREE_D_SECURE_ACTION_REQUIRED) {
+                    String actionTokenId = tError.getThreeDSecureActionTokenId();
+                    System.out.println("Got 3DSecure TransactionError token: " + actionTokenId);
+                }
+            }
+            catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $purchase_create = [
+                    "currency" => "USD",
+                    "account" => [
+                        "code" => $account_code,
+                        "first_name" => "Douglas",
+                        "last_name" => "Du Monde",
+                        "billing_info" => [
+                            "token_id" => $rjs_token_id
+                        ],
+                    ],
+                    "subscriptions" => [
+                        [
+                            "plan_code" => $plan_code
+                        ]
+                    ]
+                ];
+                $invoice_collection = $client->createPurchase($purchase_create);
+                echo 'Created Invoices:' . PHP_EOL;
+                var_dump($invoice_collection);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"USD\"),\n\tAccount:
+            &recurly.AccountPurchase{\n\t\tCode: recurly.String(accountCode),\n\t},\n\tSubscriptions:
+            &[]recurly.SubscriptionPurchase{\n\t\t{\n\t\t\tPlanCode:     recurly.String(planCode),\n\t\t\tNextBillDate:
+            recurly.Time(time.Date(2078, time.November, 10, 23, 0, 0, 0, time.UTC)),\n\t\t},\n\t},\n\tShipping:
+            &recurly.ShippingPurchase{\n\t\tAddressId: recurly.String(shippingAddressID),\n\t},\n}\n\ncollection,
+            err := client.CreatePurchase(purchaseReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Created Purchase:
+            %s\", collection.ChargeInvoice.Number)"
+          name: Go
   "/purchases/preview":
     post:
       tags:
@@ -16038,6 +26030,208 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Preview Charge
           Invoice %v\", collection.ChargeInvoice)"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              let purchaseReq = {
+                currency: 'USD',
+                account: {
+                  firstName: 'Benjamin',
+                  lastName: 'Du Monde',
+                  code: accountCode,
+                  billingInfo: {
+                    tokenId: rjsTokenId
+                  }
+                },
+                subscriptions: [
+                  { planCode: planCode },
+                ]
+              }
+              let invoiceCollection = await client.previewPurchase(purchaseReq)
+              console.log('Preview Charge Invoice: ', invoiceCollection.chargeInvoice)
+              console.log('Preview Credit Invoices: ', invoiceCollection.creditInvoices)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                purchase = {
+                    "currency": "USD",
+                    "account": {
+                        "code": account_code,
+                        "first_name": "Benjamin",
+                        "last_name": "Du Monde",
+                        "billing_info": {"token_id": rjs_token_id},
+                    },
+                    "subscriptions": [{"plan_code": plan_code}],
+                }
+                invoice_collection = client.preview_purchase(purchase)
+                print("Preview Charge Invoice %s" % invoice_collection.charge_invoice)
+                print("Preview Credit Invoices %s" % invoice_collection.credit_invoices)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var purchaseReq = new PurchaseCreate()
+                {
+                    Currency = "USD",
+                    Account = new AccountPurchase()
+                    {
+                        Code = accountCode,
+                        FirstName = "Benjamin",
+                        LastName = "Du Monde",
+                        BillingInfo = new BillingInfoCreate()
+                        {
+                            TokenId = rjsTokenId
+                        }
+                    },
+                    Subscriptions = new List<SubscriptionPurchase>()
+                    {
+                        new SubscriptionPurchase() { PlanCode = planCode }
+                    }
+                };
+                InvoiceCollection collection = client.PreviewPurchase(purchaseReq);
+                Console.WriteLine($"Preview ChargeInvoice with Total: {collection.ChargeInvoice.Total}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              purchase = {
+                currency: "USD",
+                account: {
+                  code: account_code,
+                  first_name: "Benjamin",
+                  last_name: "Du Monde",
+                  billing_info: {
+                    token_id: rjs_token_id
+                  },
+                },
+                subscriptions: [
+                  { plan_code: plan_code }
+                ]
+              }
+              invoice_collection = @client.preview_purchase(
+                body: purchase
+              )
+              puts "Preview Charge Invoice #{invoice_collection.charge_invoice}"
+              puts "Preview Credit Invoices #{invoice_collection.credit_invoices}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+
+                AccountPurchase account = new AccountPurchase();
+                account.setCode(accountCode);
+                account.setFirstName("Joanna");
+                account.setLastName("DuMonde");
+
+                BillingInfoCreate billing = new BillingInfoCreate();
+                billing.setTokenId(rjsTokenId);
+                account.setBillingInfo(billing);
+
+                List<SubscriptionPurchase> subscriptions = new ArrayList<SubscriptionPurchase>();
+                SubscriptionPurchase sub = new SubscriptionPurchase();
+                sub.setPlanCode(planCode);
+                subscriptions.add(sub);
+
+                PurchaseCreate purchase = new PurchaseCreate();
+                purchase.setCurrency("USD");
+                purchase.setAccount(account);
+                purchase.setSubscriptions(subscriptions);
+
+                InvoiceCollection collection = client.previewPurchase(purchase);
+                System.out.println("Preview Charge Invoice:" + collection.getChargeInvoice());
+                System.out.println("Preview Credit Invoices: " + collection.getCreditInvoices());
+
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+                System.out.println("Params: " + e.getError().getParams());
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $purchase_preview = [
+                    "currency" => "USD",
+                    "account" => [
+                        "code" => $account_code,
+                        "first_name" => "Douglas",
+                        "last_name" => "Du Monde",
+                        "billing_info" => [
+                            "token_id" => $rjs_token_id
+                        ],
+                    ],
+                    "subscriptions" => [
+                        [
+                            "plan_code" => $plan_code
+                        ]
+                    ]
+                ];
+                $invoice_collection = $client->previewPurchase($purchase_preview);
+                echo 'Preview Invoices:' . PHP_EOL;
+                var_dump($invoice_collection);
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"USD\"),\n\tAccount:
+            &recurly.AccountPurchase{\n\t\tCode: recurly.String(account.Code),\n\t},\n\tSubscriptions:
+            &[]recurly.SubscriptionPurchase{\n\t\t{\n\t\t\tPlanCode:     recurly.String(plan.Code),\n\t\t\tNextBillDate:
+            recurly.Time(time.Date(2078, time.November, 10, 23, 0, 0, 0, time.UTC)),\n\t\t},\n\t},\n\tShipping:
+            &recurly.ShippingPurchase{\n\t\tAddressId: recurly.String(shippingAddressID),\n\t},\n}\ncollection,
+            err := client.PreviewPurchase(purchaseReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Preview Charge
+            Invoice %v\", collection.ChargeInvoice)"
+          name: Go
   "/purchases/pending":
     post:
       tags:
@@ -16310,6 +26504,239 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Created ChargeInvoice
           with UUID: %s.\\n\", collection.ChargeInvoice.Uuid)\n"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const purchaseReq = {
+                currency: 'EUR',
+                account: {
+                  code: accountCode,
+                  email: 'example@recurly.com',
+                  billingInfo: {
+                    firstName: 'Benjamin',
+                    lastName: 'Du Monde',
+                    onlineBankingPaymentType: 'ideal'
+                  },
+                },
+                lineItems: [
+                  {
+                    currency: 'EUR',
+                    unitAmount: 1000,
+                    type: 'charge'
+                  }
+                ]
+              };
+              const invoiceCollection = await client.createPendingPurchase(purchaseReq)
+              console.log('Created ChargeInvoice with UUID: ', invoiceCollection.chargeInvoice.uuid)
+            } catch (err) {
+              if (err instanceof recurly.errors.ValidationError) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                console.log('Failed validation', err.params)
+              } else {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                console.log('Unknown Error: ', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                purchase = {
+                    "currency": "EUR",
+                    "account": {
+                        "code": account_code,
+                        "email": "benjamin@example.com",
+                        "billing_info": {
+                            "first_name": "Benjamin",
+                            "last_name": "Du Monde",
+                            "online_banking_payment_type": "ideal"
+                        }
+                    },
+                    "line_items": [
+                        {
+                            "currency": "EUR",
+                            "unit_amount": 1000,
+                            "type": "charge"
+                        }
+                    ],
+                }
+                invoice_collection = client.create_pending_purchase(purchase)
+                print("Created ChargeInvoice with UUID %s" % invoice_collection.charge_invoice.uuid)
+            except recurly.errors.ValidationError as e:
+                # If the request was invalid, you may want to tell your user
+                # why. You can find the invalid params and reasons in e.error.params
+                print("ValidationError: %s" % e.error.message)
+                print(e.error.params)
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                var purchaseReq = new PurchaseCreate()
+                {
+                    Currency = "EUR",
+                    Account = new AccountPurchase()
+                    {
+                        Code = accountCode,
+                        Email = "benjamin@example.com",
+                        BillingInfo = new BillingInfoCreate()
+                        {
+                            FirstName = "Benjamin",
+                            LastName = "Du Monde",
+                            OnlineBankingPaymentType = OnlineBankingPaymentType.Ideal
+                        }
+                    },
+                    LineItems = new List<LineItemCreate>()
+                    {
+                        new LineItemCreate()
+                        {
+                            Currency = "EUR",
+                            UnitAmount = 1000,
+                            Type = LineItemType.Charge
+                        }
+                    }
+                };
+                InvoiceCollection collection = client.CreatePendingPurchase(purchaseReq);
+                Console.WriteLine($"Created ChargeInvoice with UUID: {collection.ChargeInvoice.Uuid}");
+            }
+            catch (Recurly.Errors.Validation ex)
+            {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in ex.Error.Params
+                Console.WriteLine($"Failed validation: {ex.Error.Message}");
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              purchase = {
+                currency: 'EUR',
+                account: {
+                  code: account_code,
+                  email: 'benjamin@example.com',
+                  billing_info: {
+                    first_name: 'Benjamin',
+                    last_name: 'Du Monde',
+                    online_banking_payment_type: 'ideal'
+                  },
+                },
+                line_items: [
+                  {
+                    currency: 'EUR',
+                    unit_amount: 1000,
+                    type: 'charge'
+                  }
+                ]
+              }
+              invoice_collection = @client.create_pending_purchase(body: purchase)
+              puts "Created ChargeInvoice with UUID: #{invoice_collection.charge_invoice.uuid}"
+            rescue Recurly::Errors::ValidationError => e
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.recurly_error.params
+              puts "ValidationError: #{e.recurly_error.params}"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                AccountPurchase account = new AccountPurchase();
+                account.setCode(accountCode);
+                account.setEmail("benjamin@example.com");
+
+                BillingInfoCreate billingInfo = new BillingInfoCreate();
+                billingInfo.setFirstName("Benjamin");
+                billingInfo.setLastName("Du Monde");
+                billingInfo.setOnlineBankingPaymentType(Constants.OnlineBankingPaymentType.IDEAL);
+                account.setBillingInfo(billingInfo);
+
+                List<LineItemCreate> lineItems = new ArrayList<LineItemCreate>();
+                LineItemCreate lineItem = new LineItemCreate();
+                lineItem.setCurrency("EUR");
+                lineItem.setUnitAmount(new BigDecimal("1000.0"));
+                lineItem.setType(Constants.LineItemType.CHARGE);
+                lineItems.add(lineItem);
+
+                PurchaseCreate purchase = new PurchaseCreate();
+                purchase.setCurrency("EUR");
+                purchase.setAccount(account);
+                purchase.setLineItems(lineItems);
+
+                InvoiceCollection collection = client.createPendingPurchase(purchase);
+                System.out.println("Created ChargeInvoice with UUID: " + collection.getChargeInvoice().getUuid());
+            } catch (ValidationException e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in e.getError().getParams()
+                System.out.println("Failed validation: " + e.getError().getMessage());
+                System.out.println("Params: " + e.getError().getParams());
+            } catch (TransactionException e) {
+                TransactionError tError = e.getError().getTransactionError();
+                if (tError.getCategory() == Constants.ErrorCategory.THREE_D_SECURE_ACTION_REQUIRED) {
+                    String actionTokenId = tError.getThreeDSecureActionTokenId();
+                    System.out.println("Got 3DSecure TransactionError token: " + actionTokenId);
+                }
+            }
+            catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $purchase_create = [
+                    "currency" => "EUR",
+                    "account" => [
+                        "code" => $account_code,
+                        "email" => "benjamin@example.com",
+                        "billing_info" => [
+                            "first_name" => "Benjamin",
+                            "last_name" => "Du Monde",
+                            "online_banking_payment_type" => "ideal"
+                        ],
+                    ],
+                    "line_items" => [
+                        [
+                            "currency" => "EUR",
+                            "unit_amount" => 1000,
+                            "type" => "charge",
+                        ]
+                    ]
+                ];
+                $invoice_collection = $client->createPendingPurchase($purchase_create);
+                echo 'Created ChargeInvoice with UUID' . $invoice_collection->getChargeInvoice()->getUuid() . PHP_EOL;
+            } catch (\Recurly\Errors\Validation $e) {
+                // If the request was not valid, you may want to tell your user
+                // why. You can find the invalid params and reasons in err.params
+                var_dump($e);
+            } catch (\Recurly\RecurlyError $e) {
+                // If we don't know what to do with the err, we should
+                // probably re-raise and let our web framework and logger handle it
+                var_dump($e);
+            }
+          name: PHP
+        - language: go
+          code: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"USD\"),\n\tAccount:
+            &recurly.AccountPurchase{\n\t\tCode:  recurly.String(accountCode),\n\t\tEmail:
+            recurly.String(\"benjamin@example.com\"),\n\t\tBillingInfo: &recurly.BillingInfoCreate{\n\t\t\tFirstName:
+            \               recurly.String(\"Benjamin\"),\n\t\t\tLastName:                 recurly.String(\"Du
+            Monde\"),\n\t\t\tOnlineBankingPaymentType: recurly.String(\"ideal\"),\n\t\t},\n\t},\n\tLineItems:
+            &[]recurly.LineItemCreate{\n\t\t{\n\t\t\tCurrency:   recurly.String(\"USD\"),\n\t\t\tUnitAmount:
+            recurly.Float(1000),\n\t\t\tType:       recurly.String(\"charge\"),\n\t\t},\n\t},\n}\ncollection,
+            err := client.CreatePendingPurchase(purchaseReq)\nif e, ok := err.(*recurly.Error);
+            ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
+            validation: %v\", e)\n\t\treturn nil, err\n\t}\n\n\tfmt.Printf(\"Unexpected
+            Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Created
+            ChargeInvoice with UUID: %s.\\n\", collection.ChargeInvoice.Uuid)\n"
+          name: Go
   "/purchases/authorize":
     post:
       tags:
@@ -16546,6 +26973,91 @@ paths:
           ok {\n\tfmt.Printf(\"Unexpected Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfor
           _, date := range exportDates.Dates {\n\tfmt.Println(\"Exports are available
           for: \", date)\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const export_dates = await client.getExportDates()
+              export_dates.dates.forEach(date => {
+                console.log(`Exports are available for: ${date}`)
+              })
+            } catch (err) {
+              if (err instanceof recurly.ApiError) {
+                console.log('Unexpected error', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                export_dates = client.get_export_dates()
+                for date in export_dates.dates:
+                    print( "Exports are available for: %s" % date)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                ExportDates exportDates = client.GetExportDates();
+                foreach (var date in exportDates.Dates)
+                {
+                    System.Console.WriteLine($"Exports are available for: {date}");
+                }
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              export_dates = @client.get_export_dates()
+              export_dates.dates.each do |date|
+                puts "Exports are available for: #{date}"
+              end
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                ExportDates exportDates = client.getExportDates();
+                for (String date : exportDates.getDates()) {
+                    System.out.println("Exports are available for: " + date);
+                }
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $export_dates = $client->getExportDates();
+                foreach($export_dates->getDates() as $date)
+                {
+                    echo "Exports are available for: {$date}" . PHP_EOL;
+                }
+            } catch (\Recurly\RecurlyError $e) {
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "exportDates, err := client.GetExportDates()\nif e, ok := err.(*recurly.Error);
+            ok {\n\tfmt.Printf(\"Unexpected Recurly error: %v\", e)\n\treturn nil,
+            err\n}\n\nfor _, date := range exportDates.Dates {\n\tfmt.Println(\"Exports
+            are available for: \", date)\n}"
+          name: Go
   "/export_dates/{export_date}/export_files":
     parameters:
     - "$ref": "#/components/parameters/export_date"
@@ -16658,6 +27170,91 @@ paths:
           err.(*recurly.Error); ok {\n\tfmt.Printf(\"Unexpected Recurly error: %v\",
           e)\n\treturn nil, err\n}\n\nfor _, file := range exportFiles.Files {\n\tfmt.Println(\"Export
           file download URL: \", file.Href)\n}"
+      x-readme:
+        code-samples:
+        - language: node
+          code: |
+            try {
+              const export_files = await client.getExportFiles(export_date)
+              export_files.files.forEach(file => {
+                console.log(`Export file download URL: ${file.href}`)
+              })
+            } catch (err) {
+              if (err instanceof recurly.ApiError) {
+                console.log('Unexpected error', err)
+              }
+            }
+          name: Node.js
+        - language: python
+          code: |
+            try:
+                export_files = client.get_export_files(export_date)
+                for file in export_files.files:
+                    print( "Export file download URL: %s" % file.href)
+            except recurly.errors.NotFoundError:
+                # If the resource was not found, you may want to alert the user or
+                # just return nil
+                print("Resource Not Found")
+          name: Python
+        - language: csharp
+          code: |
+            try
+            {
+                ExportFiles exportFiles = client.GetExportFiles(exportDate: exportDate);
+                foreach (var file in exportFiles.Files)
+                {
+                    System.Console.WriteLine($"Export file download URL: {file.Href}");
+                }
+            }
+            catch (Recurly.Errors.ApiError ex)
+            {
+                // Use ApiError to catch a generic error from the API
+                Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+            }
+          name: ".NET"
+        - language: ruby
+          code: |
+            begin
+              export_files = @client.get_export_files(export_date: export_date)
+              export_files.files.each do |file|
+                puts "Export file download URL: #{file.href}"
+              end
+            rescue Recurly::Errors::NotFoundError
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              puts "Resource Not Found"
+            end
+          name: Ruby
+        - language: java
+          code: |
+            try {
+                ExportFiles exportFiles = client.getExportFiles(exportDate);
+                for (ExportFile file : exportFiles.getFiles()) {
+                    System.out.println("Export file download URL: " + file.getHref());
+                }
+            } catch (ApiException e) {
+                // Use ApiException to catch a generic error from the API
+                System.out.println("Unexpected Recurly Error: " + e.getError());
+            }
+          name: Java
+        - language: php
+          code: |
+            try {
+                $export_files = $client->getExportFiles($export_date);
+                foreach($export_files->getFiles() as $file)
+                {
+                    echo "Export file download URL: {$file->getHref()}" . PHP_EOL;
+                }
+            } catch (\Recurly\RecurlyError $e) {
+                echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+            }
+          name: PHP
+        - language: go
+          code: "exportFiles, err := client.GetExportFiles(exportDate)\nif e, ok :=
+            err.(*recurly.Error); ok {\n\tfmt.Printf(\"Unexpected Recurly error: %v\",
+            e)\n\treturn nil, err\n}\n\nfor _, file := range exportFiles.Files {\n\tfmt.Println(\"Export
+            file download URL: \", file.Href)\n}"
+          name: Go
   "/dunning_campaigns":
     get:
       tags:
@@ -18829,6 +29426,12 @@ components:
             third-party gateway object of varying types.
           items:
             "$ref": "#/components/schemas/PaymentGatewayReferences"
+        payment_method:
+          "$ref": "#/components/schemas/RecoveryPaymentMethodCreate"
+          description: Merchant-supplied fallback payment method metadata. Recurly's
+            own gateway-token lookup is authoritative and will override any of these
+            fields it can determine itself; these fields are only used to fill gaps
+            when that lookup is unavailable.
         network_transaction_id:
           type: string
           title: Network Transaction ID
@@ -18844,13 +29447,65 @@ components:
           type: array
           title: Transactions
           description: Transactions from previous collection attempts for this payment
-            method.
+            method. Optional, unless this billing_info is the primary payment method
+            and the account's dunning campaign skips Recurly's own retry attempts
+            entirely -- in that case at least one entry is required.
           items:
             "$ref": "#/components/schemas/RecoveryTransactionCreate"
       required:
       - gateway_code
       - payment_gateway_references
-      - transactions
+    RecoveryPaymentMethodCreate:
+      type: object
+      title: Recovery payment method
+      description: |
+        Merchant-supplied fallback for payment method metadata on the revenue recovery
+        endpoint. Recurly's own gateway-token lookup is authoritative for these fields;
+        a value supplied here is only used to fill a gap when that lookup is restricted
+        or fails, and is overwritten if that lookup later succeeds.
+
+        Not accepted on the Purchase endpoint or the standard billing_info/billing_infos
+        endpoints — Recover only.
+      properties:
+        object:
+          "$ref": "#/components/schemas/RecoveryPaymentMethodEnum"
+          description: The payment method type.
+        card_type:
+          description: The card brand (e.g. `Visa`, `MasterCard`). Present for `credit_card`,
+            `apple_pay`, and `google_pay`/`google_pay_device_pan`; omitted for `paypal_billing_agreement`.
+          "$ref": "#/components/schemas/CardTypeEnum"
+        first_six:
+          type: string
+          description: |
+            For a plain card, the card's own first six digits (BIN).
+
+            For a tokenized wallet payment (`apple_pay`, `google_pay`, or
+            `google_pay_device_pan`), this is the DPAN's (the wallet/device token's own
+            number) first six digits — **not** the underlying card's (FPAN). The FPAN is
+            never accepted or represented; no separate wallet-specific field is provided.
+          maxLength: 6
+        last_four:
+          type: string
+          description: The card's (or, for a tokenized wallet payment, the DPAN's)
+            last four digits. See `first_six` for the DPAN-vs-FPAN distinction on
+            wallets.
+          maxLength: 4
+        exp_month:
+          type: integer
+          description: Expiration month.
+          maxLength: 2
+        exp_year:
+          type: integer
+          description: Expiration year.
+          maxLength: 4
+    RecoveryPaymentMethodEnum:
+      type: string
+      enum:
+      - credit_card
+      - apple_pay
+      - google_pay
+      - google_pay_device_pan
+      - paypal_billing_agreement
     RecoveryAccountCreate:
       type: object
       properties:
@@ -20099,8 +30754,24 @@ components:
           type: string
           title: Redeem by
           description: The date and time the coupon will expire and can no longer
-            be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
+            be redeemed. Time is always 11:59:59, the end-of-day Pacific time. Null
+            for bulk coupons configured with a relative redeem-by interval (see redeem_by_interval_unit
+            and redeem_by_interval_amount).
           format: date-time
+        redeem_by_interval_unit:
+          title: Redeem by interval unit
+          description: For a bulk coupon with a relative redeem-by, the unit of the
+            interval after which each generated unique code expires. Null unless the
+            coupon uses a relative redeem-by.
+          readOnly: true
+          "$ref": "#/components/schemas/CouponRedeemByIntervalUnitEnum"
+        redeem_by_interval_amount:
+          type: integer
+          title: Redeem by interval amount
+          description: For a bulk coupon with a relative redeem-by, the number of
+            redeem_by_interval_unit intervals after a code's generation that it remains
+            redeemable. Null unless the coupon uses a relative redeem-by.
+          readOnly: true
         created_at:
           type: string
           title: Created at
@@ -20531,7 +31202,19 @@ components:
           type: string
           title: Redeem by
           description: The date and time the coupon will expire and can no longer
-            be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
+            be redeemed. Time is always 11:59:59, the end-of-day Pacific time. Mutually
+            exclusive with redeem_by_interval_unit/redeem_by_interval_amount.
+        redeem_by_interval_unit:
+          title: Redeem by interval unit
+          description: Unit of the relative redemption window. Must be paired with
+            redeem_by_interval_amount. Mutually exclusive with redeem_by_date. Bulk
+            coupons only.
+          "$ref": "#/components/schemas/CouponRedeemByIntervalUnitEnum"
+        redeem_by_interval_amount:
+          type: integer
+          title: Redeem by interval amount
+          description: Quantity of redeem_by_interval_unit. Must be paired with redeem_by_interval_unit.
+          minimum: 1
     CreditPayment:
       type: object
       properties:
@@ -25305,6 +35988,12 @@ components:
           "$ref": "#/components/schemas/CollectionMethodEnum"
         payment_method:
           "$ref": "#/components/schemas/PaymentMethod"
+        payment_gateway_references:
+          type: array
+          description: Array of Payment Gateway References captured at transaction
+            time, each a reference to a third-party gateway object of varying types.
+          items:
+            "$ref": "#/components/schemas/PaymentGatewayReferences"
         ip_address_v4:
           type: string
           title: IP address
@@ -25541,6 +36230,15 @@ components:
           description: The date and time the coupon was expired early or reached its
             `max_redemptions`.
           format: date-time
+        redeem_by_date:
+          type: string
+          title: Redeem by
+          description: Absolute expiry computed and stored at code-generation time.
+            Set only for Window (relative redeem-by) coupons. Null for Anytime coupons
+            and Specific Date coupons — those resolve expiry from the parent coupon's
+            redeem_by at redemption time, not at code-generation time.
+          format: date-time
+          readOnly: true
     UniqueCouponCodeList:
       type: object
       properties:
@@ -26939,12 +37637,22 @@ components:
           "$ref": "#/components/schemas/CardTypeEnum"
         first_six:
           type: string
-          description: Credit card number's first six digits.
+          description: |
+            Credit card number's first six digits.
+
+            For a tokenized wallet payment (`apple_pay`, `google_pay`, or
+            `google_pay_device_pan`), this is the DPAN's (the wallet/device token's own
+            number) first six digits, not the underlying card's (FPAN).
           maxLength: 6
         last_four:
           type: string
-          description: Credit card number's last four digits. Will refer to bank account
-            if payment method is ACH.
+          description: |
+            Credit card number's last four digits. Will refer to bank account if payment
+            method is ACH.
+
+            For a tokenized wallet payment (`apple_pay`, `google_pay`, or
+            `google_pay_device_pan`), this is the DPAN's last four digits, not the
+            underlying card's (FPAN).
           maxLength: 4
         last_two:
           type: string
@@ -28025,6 +38733,15 @@ components:
       enum:
       - days
       - months
+    CouponRedeemByIntervalUnitEnum:
+      type: string
+      title: Redeem by interval unit
+      description: Unit of the relative redemption window. Bulk coupons only.
+      enum:
+      - day
+      - week
+      - month
+      - year
     AddressRequirementEnum:
       type: string
       enum:

--- a/src/main/java/com/recurly/v3/Constants.java
+++ b/src/main/java/com/recurly/v3/Constants.java
@@ -10,6 +10,26 @@ import com.google.gson.annotations.SerializedName;
 
 public class Constants {
   
+    public enum RecoveryPaymentMethod {
+      UNDEFINED,
+    
+      @SerializedName("credit_card")
+      CREDIT_CARD,
+    
+      @SerializedName("apple_pay")
+      APPLE_PAY,
+    
+      @SerializedName("google_pay")
+      GOOGLE_PAY,
+    
+      @SerializedName("google_pay_device_pan")
+      GOOGLE_PAY_DEVICE_PAN,
+    
+      @SerializedName("paypal_billing_agreement")
+      PAYPAL_BILLING_AGREEMENT,
+    
+    };
+  
     public enum ProrationSettingsCharge {
       UNDEFINED,
     
@@ -1170,6 +1190,23 @@ public class Constants {
     
       @SerializedName("months")
       MONTHS,
+    
+    };
+  
+    public enum CouponRedeemByIntervalUnit {
+      UNDEFINED,
+    
+      @SerializedName("day")
+      DAY,
+    
+      @SerializedName("week")
+      WEEK,
+    
+      @SerializedName("month")
+      MONTH,
+    
+      @SerializedName("year")
+      YEAR,
     
     };
   

--- a/src/main/java/com/recurly/v3/http/DefaultHttpAdapter.java
+++ b/src/main/java/com/recurly/v3/http/DefaultHttpAdapter.java
@@ -36,10 +36,7 @@ public class DefaultHttpAdapter implements HttpAdapter {
 
   @Override
   public HttpResponse execute(
-      final String method,
-      final String url,
-      final Map<String, String> headers,
-      final String body)
+      final String method, final String url, final Map<String, String> headers, final String body)
       throws IOException {
     final boolean debug = Utils.envEnabled("RECURLY_INSECURE") && Utils.envEnabled("RECURLY_DEBUG");
     if (debug) {
@@ -93,7 +90,8 @@ public class DefaultHttpAdapter implements HttpAdapter {
       }
 
       final String contentEncoding = findHeaderIgnoreCase(responseHeaders, "Content-Encoding");
-      final boolean gzipEncoded = contentEncoding != null && "gzip".equalsIgnoreCase(contentEncoding.trim());
+      final boolean gzipEncoded =
+          contentEncoding != null && "gzip".equalsIgnoreCase(contentEncoding.trim());
 
       final byte[] responseBodyBytes;
       if (inputStream == null) {
@@ -112,10 +110,17 @@ public class DefaultHttpAdapter implements HttpAdapter {
 
       if (debug) {
         System.out.println(
-            "<-- " + statusCode + " " + url + " (" + (System.currentTimeMillis() - startMs) + "ms)");
+            "<-- "
+                + statusCode
+                + " "
+                + url
+                + " ("
+                + (System.currentTimeMillis() - startMs)
+                + "ms)");
       }
 
-      final HttpResponse response = new HttpResponse(statusCode, responseHeaders, responseBodyBytes);
+      final HttpResponse response =
+          new HttpResponse(statusCode, responseHeaders, responseBodyBytes);
       success = true;
       return response;
     } finally {
@@ -147,6 +152,4 @@ public class DefaultHttpAdapter implements HttpAdapter {
     }
     return buffer.toByteArray();
   }
-
-  
 }

--- a/src/main/java/com/recurly/v3/http/HttpAdapter.java
+++ b/src/main/java/com/recurly/v3/http/HttpAdapter.java
@@ -29,8 +29,8 @@ import java.util.Map;
  * The client imposes no timeout of its own. Set connect, read, and write timeouts inside the
  * implementation.
  *
- * <p>See {@code docs/http-adapter-implementation-guide.md} for a full contract reference and
- * worked examples.
+ * <p>See {@code docs/http-adapter-implementation-guide.md} for a full contract reference and worked
+ * examples.
  */
 public interface HttpAdapter {
 
@@ -44,16 +44,16 @@ public interface HttpAdapter {
    *       {@code HEAD}.
    *   <li>{@code url} — fully-qualified URL including scheme, host, path, and any query string.
    *       Never {@code null}.
-   *   <li>{@code headers} — all request headers the client wants sent (Authorization,
-   *       Accept, Content-Type, User-Agent, etc.). Forward every client-supplied entry
-   *       unmodified — do not remove or override them. Implementations may add their own
-   *       transport-layer headers (e.g. {@code Accept-Encoding}) as long as they do not conflict
-   *       with a header the client already set.
+   *   <li>{@code headers} — all request headers the client wants sent (Authorization, Accept,
+   *       Content-Type, User-Agent, etc.). Forward every client-supplied entry unmodified — do not
+   *       remove or override them. Implementations may add their own transport-layer headers (e.g.
+   *       {@code Accept-Encoding}) as long as they do not conflict with a header the client already
+   *       set.
    *   <li>{@code body} — UTF-8 JSON string when a request payload is present; {@code null} when
-   *       there is none. {@code GET}, {@code HEAD}, and {@code DELETE} never carry a body.
-   *       {@code POST} and {@code PUT} typically carry a body but may receive {@code null} (e.g.
-   *       no request object) — implementations must still send the request with
-   *       {@code Content-Length: 0}.
+   *       there is none. {@code GET}, {@code HEAD}, and {@code DELETE} never carry a body. {@code
+   *       POST} and {@code PUT} typically carry a body but may receive {@code null} (e.g. no
+   *       request object) — implementations must still send the request with {@code Content-Length:
+   *       0}.
    * </ul>
    *
    * <p><b>Return value</b><br>
@@ -63,8 +63,8 @@ public interface HttpAdapter {
    *   <li>The HTTP status code exactly as received.
    *   <li>All response headers. {@link HttpResponse} normalises header names to lower-case
    *       internally, so case in the map passed to the constructor does not matter. The client
-   *       reads {@code content-type}, {@code x-request-id}, {@code recurly-deprecated},
-   *       {@code recurly-sunset-date}, and {@code recurly-total-records}.
+   *       reads {@code content-type}, {@code x-request-id}, {@code recurly-deprecated}, {@code
+   *       recurly-sunset-date}, and {@code recurly-total-records}.
    *   <li>The complete response body as a byte array. Read the body fully before returning; do not
    *       return a lazy or streaming reference. Pass an empty {@code byte[]} (never {@code null})
    *       when there is no body.
@@ -76,8 +76,8 @@ public interface HttpAdapter {
    * HTTP-level errors (4xx/5xx) — return the response and let the client map those to typed
    * exceptions.
    *
-   * @param method HTTP method ({@code GET}, {@code POST}, {@code PUT}, {@code DELETE},
-   *     {@code HEAD})
+   * @param method HTTP method ({@code GET}, {@code POST}, {@code PUT}, {@code DELETE}, {@code
+   *     HEAD})
    * @param url absolute URL to request
    * @param headers request headers to send; must be forwarded unmodified (adapters may add their
    *     own non-conflicting transport-layer headers)

--- a/src/main/java/com/recurly/v3/http/HttpResponse.java
+++ b/src/main/java/com/recurly/v3/http/HttpResponse.java
@@ -36,7 +36,9 @@ public class HttpResponse {
     return headers;
   }
 
-  /** Returns a copy of the response body. Mutations to the returned array do not affect this object. */
+  /**
+   * Returns a copy of the response body. Mutations to the returned array do not affect this object.
+   */
   public byte[] getBody() {
     return body.clone();
   }

--- a/src/main/java/com/recurly/v3/requests/CouponCreate.java
+++ b/src/main/java/com/recurly/v3/requests/CouponCreate.java
@@ -151,11 +151,25 @@ public class CouponCreate extends Request {
 
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always
-   * 11:59:59, the end-of-day Pacific time.
+   * 11:59:59, the end-of-day Pacific time. Mutually exclusive with
+   * redeem_by_interval_unit/redeem_by_interval_amount.
    */
   @SerializedName("redeem_by_date")
   @Expose
   private String redeemByDate;
+
+  /** Quantity of redeem_by_interval_unit. Must be paired with redeem_by_interval_unit. */
+  @SerializedName("redeem_by_interval_amount")
+  @Expose
+  private Integer redeemByIntervalAmount;
+
+  /**
+   * Unit of the relative redemption window. Must be paired with redeem_by_interval_amount. Mutually
+   * exclusive with redeem_by_date. Bulk coupons only.
+   */
+  @SerializedName("redeem_by_interval_unit")
+  @Expose
+  private Constants.CouponRedeemByIntervalUnit redeemByIntervalUnit;
 
   /**
    * Whether the discount is for all eligible charges on the account, or only a specific
@@ -485,7 +499,8 @@ public class CouponCreate extends Request {
 
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always
-   * 11:59:59, the end-of-day Pacific time.
+   * 11:59:59, the end-of-day Pacific time. Mutually exclusive with
+   * redeem_by_interval_unit/redeem_by_interval_amount.
    */
   public String getRedeemByDate() {
     return this.redeemByDate;
@@ -493,10 +508,41 @@ public class CouponCreate extends Request {
 
   /**
    * @param redeemByDate The date and time the coupon will expire and can no longer be redeemed.
-   *     Time is always 11:59:59, the end-of-day Pacific time.
+   *     Time is always 11:59:59, the end-of-day Pacific time. Mutually exclusive with
+   *     redeem_by_interval_unit/redeem_by_interval_amount.
    */
   public void setRedeemByDate(final String redeemByDate) {
     this.redeemByDate = redeemByDate;
+  }
+
+  /** Quantity of redeem_by_interval_unit. Must be paired with redeem_by_interval_unit. */
+  public Integer getRedeemByIntervalAmount() {
+    return this.redeemByIntervalAmount;
+  }
+
+  /**
+   * @param redeemByIntervalAmount Quantity of redeem_by_interval_unit. Must be paired with
+   *     redeem_by_interval_unit.
+   */
+  public void setRedeemByIntervalAmount(final Integer redeemByIntervalAmount) {
+    this.redeemByIntervalAmount = redeemByIntervalAmount;
+  }
+
+  /**
+   * Unit of the relative redemption window. Must be paired with redeem_by_interval_amount. Mutually
+   * exclusive with redeem_by_date. Bulk coupons only.
+   */
+  public Constants.CouponRedeemByIntervalUnit getRedeemByIntervalUnit() {
+    return this.redeemByIntervalUnit;
+  }
+
+  /**
+   * @param redeemByIntervalUnit Unit of the relative redemption window. Must be paired with
+   *     redeem_by_interval_amount. Mutually exclusive with redeem_by_date. Bulk coupons only.
+   */
+  public void setRedeemByIntervalUnit(
+      final Constants.CouponRedeemByIntervalUnit redeemByIntervalUnit) {
+    this.redeemByIntervalUnit = redeemByIntervalUnit;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/requests/CouponUpdate.java
+++ b/src/main/java/com/recurly/v3/requests/CouponUpdate.java
@@ -7,6 +7,7 @@ package com.recurly.v3.requests;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
 import com.recurly.v3.Request;
 import com.recurly.v3.resources.*;
 
@@ -49,11 +50,25 @@ public class CouponUpdate extends Request {
 
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always
-   * 11:59:59, the end-of-day Pacific time.
+   * 11:59:59, the end-of-day Pacific time. Mutually exclusive with
+   * redeem_by_interval_unit/redeem_by_interval_amount.
    */
   @SerializedName("redeem_by_date")
   @Expose
   private String redeemByDate;
+
+  /** Quantity of redeem_by_interval_unit. Must be paired with redeem_by_interval_unit. */
+  @SerializedName("redeem_by_interval_amount")
+  @Expose
+  private Integer redeemByIntervalAmount;
+
+  /**
+   * Unit of the relative redemption window. Must be paired with redeem_by_interval_amount. Mutually
+   * exclusive with redeem_by_date. Bulk coupons only.
+   */
+  @SerializedName("redeem_by_interval_unit")
+  @Expose
+  private Constants.CouponRedeemByIntervalUnit redeemByIntervalUnit;
 
   /**
    * This description will show up when a customer redeems a coupon on your Hosted Payment Pages, or
@@ -132,7 +147,8 @@ public class CouponUpdate extends Request {
 
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always
-   * 11:59:59, the end-of-day Pacific time.
+   * 11:59:59, the end-of-day Pacific time. Mutually exclusive with
+   * redeem_by_interval_unit/redeem_by_interval_amount.
    */
   public String getRedeemByDate() {
     return this.redeemByDate;
@@ -140,9 +156,40 @@ public class CouponUpdate extends Request {
 
   /**
    * @param redeemByDate The date and time the coupon will expire and can no longer be redeemed.
-   *     Time is always 11:59:59, the end-of-day Pacific time.
+   *     Time is always 11:59:59, the end-of-day Pacific time. Mutually exclusive with
+   *     redeem_by_interval_unit/redeem_by_interval_amount.
    */
   public void setRedeemByDate(final String redeemByDate) {
     this.redeemByDate = redeemByDate;
+  }
+
+  /** Quantity of redeem_by_interval_unit. Must be paired with redeem_by_interval_unit. */
+  public Integer getRedeemByIntervalAmount() {
+    return this.redeemByIntervalAmount;
+  }
+
+  /**
+   * @param redeemByIntervalAmount Quantity of redeem_by_interval_unit. Must be paired with
+   *     redeem_by_interval_unit.
+   */
+  public void setRedeemByIntervalAmount(final Integer redeemByIntervalAmount) {
+    this.redeemByIntervalAmount = redeemByIntervalAmount;
+  }
+
+  /**
+   * Unit of the relative redemption window. Must be paired with redeem_by_interval_amount. Mutually
+   * exclusive with redeem_by_date. Bulk coupons only.
+   */
+  public Constants.CouponRedeemByIntervalUnit getRedeemByIntervalUnit() {
+    return this.redeemByIntervalUnit;
+  }
+
+  /**
+   * @param redeemByIntervalUnit Unit of the relative redemption window. Must be paired with
+   *     redeem_by_interval_amount. Mutually exclusive with redeem_by_date. Bulk coupons only.
+   */
+  public void setRedeemByIntervalUnit(
+      final Constants.CouponRedeemByIntervalUnit redeemByIntervalUnit) {
+    this.redeemByIntervalUnit = redeemByIntervalUnit;
   }
 }

--- a/src/main/java/com/recurly/v3/requests/RecoveryBillingInfoCreate.java
+++ b/src/main/java/com/recurly/v3/requests/RecoveryBillingInfoCreate.java
@@ -74,6 +74,15 @@ public class RecoveryBillingInfoCreate extends Request {
   private List<PaymentGatewayReferences> paymentGatewayReferences;
 
   /**
+   * Merchant-supplied fallback payment method metadata. Recurly's own gateway-token lookup is
+   * authoritative and will override any of these fields it can determine itself; these fields are
+   * only used to fill gaps when that lookup is unavailable.
+   */
+  @SerializedName("payment_method")
+  @Expose
+  private RecoveryPaymentMethodCreate paymentMethod;
+
+  /**
    * The `primary_payment_method` field is used to designate the primary billing info on the
    * account. An account can have a maximum of 1 primary. If a user sets a different payment method
    * as a primary, then the existing primary will no longer be marked as such.
@@ -82,7 +91,11 @@ public class RecoveryBillingInfoCreate extends Request {
   @Expose
   private Boolean primaryPaymentMethod;
 
-  /** Transactions from previous collection attempts for this payment method. */
+  /**
+   * Transactions from previous collection attempts for this payment method. Optional, unless this
+   * billing_info is the primary payment method and the account's dunning campaign skips Recurly's
+   * own retry attempts entirely -- in that case at least one entry is required.
+   */
   @SerializedName("transactions")
   @Expose
   private List<RecoveryTransactionCreate> transactions;
@@ -223,6 +236,24 @@ public class RecoveryBillingInfoCreate extends Request {
   }
 
   /**
+   * Merchant-supplied fallback payment method metadata. Recurly's own gateway-token lookup is
+   * authoritative and will override any of these fields it can determine itself; these fields are
+   * only used to fill gaps when that lookup is unavailable.
+   */
+  public RecoveryPaymentMethodCreate getPaymentMethod() {
+    return this.paymentMethod;
+  }
+
+  /**
+   * @param paymentMethod Merchant-supplied fallback payment method metadata. Recurly's own
+   *     gateway-token lookup is authoritative and will override any of these fields it can
+   *     determine itself; these fields are only used to fill gaps when that lookup is unavailable.
+   */
+  public void setPaymentMethod(final RecoveryPaymentMethodCreate paymentMethod) {
+    this.paymentMethod = paymentMethod;
+  }
+
+  /**
    * The `primary_payment_method` field is used to designate the primary billing info on the
    * account. An account can have a maximum of 1 primary. If a user sets a different payment method
    * as a primary, then the existing primary will no longer be marked as such.
@@ -241,13 +272,20 @@ public class RecoveryBillingInfoCreate extends Request {
     this.primaryPaymentMethod = primaryPaymentMethod;
   }
 
-  /** Transactions from previous collection attempts for this payment method. */
+  /**
+   * Transactions from previous collection attempts for this payment method. Optional, unless this
+   * billing_info is the primary payment method and the account's dunning campaign skips Recurly's
+   * own retry attempts entirely -- in that case at least one entry is required.
+   */
   public List<RecoveryTransactionCreate> getTransactions() {
     return this.transactions;
   }
 
   /**
    * @param transactions Transactions from previous collection attempts for this payment method.
+   *     Optional, unless this billing_info is the primary payment method and the account's dunning
+   *     campaign skips Recurly's own retry attempts entirely -- in that case at least one entry is
+   *     required.
    */
   public void setTransactions(final List<RecoveryTransactionCreate> transactions) {
     this.transactions = transactions;

--- a/src/main/java/com/recurly/v3/requests/RecoveryPaymentMethodCreate.java
+++ b/src/main/java/com/recurly/v3/requests/RecoveryPaymentMethodCreate.java
@@ -1,0 +1,150 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process and thus any edits you
+ * make by hand will be lost. If you wish to make a change to this file, please create a Github
+ * issue explaining the changes you need and we will usher them to the appropriate places.
+ */
+package com.recurly.v3.requests;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.recurly.v3.Constants;
+import com.recurly.v3.Request;
+import com.recurly.v3.resources.*;
+
+public class RecoveryPaymentMethodCreate extends Request {
+
+  /**
+   * The card brand (e.g. `Visa`, `MasterCard`). Present for `credit_card`, `apple_pay`, and
+   * `google_pay`/`google_pay_device_pan`; omitted for `paypal_billing_agreement`.
+   */
+  @SerializedName("card_type")
+  @Expose
+  private Constants.CardType cardType;
+
+  /** Expiration month. */
+  @SerializedName("exp_month")
+  @Expose
+  private Integer expMonth;
+
+  /** Expiration year. */
+  @SerializedName("exp_year")
+  @Expose
+  private Integer expYear;
+
+  /**
+   * For a plain card, the card's own first six digits (BIN).
+   *
+   * <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`), this
+   * is the DPAN's (the wallet/device token's own number) first six digits — **not** the underlying
+   * card's (FPAN). The FPAN is never accepted or represented; no separate wallet-specific field is
+   * provided.
+   */
+  @SerializedName("first_six")
+  @Expose
+  private String firstSix;
+
+  /**
+   * The card's (or, for a tokenized wallet payment, the DPAN's) last four digits. See `first_six`
+   * for the DPAN-vs-FPAN distinction on wallets.
+   */
+  @SerializedName("last_four")
+  @Expose
+  private String lastFour;
+
+  /** The payment method type. */
+  @SerializedName("object")
+  @Expose
+  private Constants.RecoveryPaymentMethod object;
+
+  /**
+   * The card brand (e.g. `Visa`, `MasterCard`). Present for `credit_card`, `apple_pay`, and
+   * `google_pay`/`google_pay_device_pan`; omitted for `paypal_billing_agreement`.
+   */
+  public Constants.CardType getCardType() {
+    return this.cardType;
+  }
+
+  /**
+   * @param cardType The card brand (e.g. `Visa`, `MasterCard`). Present for `credit_card`,
+   *     `apple_pay`, and `google_pay`/`google_pay_device_pan`; omitted for
+   *     `paypal_billing_agreement`.
+   */
+  public void setCardType(final Constants.CardType cardType) {
+    this.cardType = cardType;
+  }
+
+  /** Expiration month. */
+  public Integer getExpMonth() {
+    return this.expMonth;
+  }
+
+  /**
+   * @param expMonth Expiration month.
+   */
+  public void setExpMonth(final Integer expMonth) {
+    this.expMonth = expMonth;
+  }
+
+  /** Expiration year. */
+  public Integer getExpYear() {
+    return this.expYear;
+  }
+
+  /**
+   * @param expYear Expiration year.
+   */
+  public void setExpYear(final Integer expYear) {
+    this.expYear = expYear;
+  }
+
+  /**
+   * For a plain card, the card's own first six digits (BIN).
+   *
+   * <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`), this
+   * is the DPAN's (the wallet/device token's own number) first six digits — **not** the underlying
+   * card's (FPAN). The FPAN is never accepted or represented; no separate wallet-specific field is
+   * provided.
+   */
+  public String getFirstSix() {
+    return this.firstSix;
+  }
+
+  /**
+   * @param firstSix For a plain card, the card's own first six digits (BIN).
+   *     <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`),
+   *     this is the DPAN's (the wallet/device token's own number) first six digits — **not** the
+   *     underlying card's (FPAN). The FPAN is never accepted or represented; no separate
+   *     wallet-specific field is provided.
+   */
+  public void setFirstSix(final String firstSix) {
+    this.firstSix = firstSix;
+  }
+
+  /**
+   * The card's (or, for a tokenized wallet payment, the DPAN's) last four digits. See `first_six`
+   * for the DPAN-vs-FPAN distinction on wallets.
+   */
+  public String getLastFour() {
+    return this.lastFour;
+  }
+
+  /**
+   * @param lastFour The card's (or, for a tokenized wallet payment, the DPAN's) last four digits.
+   *     See `first_six` for the DPAN-vs-FPAN distinction on wallets.
+   */
+  public void setLastFour(final String lastFour) {
+    this.lastFour = lastFour;
+  }
+
+  /** The payment method type. */
+  public Constants.RecoveryPaymentMethod getObject() {
+    return this.object;
+  }
+
+  /**
+   * @param object The payment method type.
+   */
+  public void setObject(final Constants.RecoveryPaymentMethod object) {
+    this.object = object;
+  }
+}

--- a/src/main/java/com/recurly/v3/resources/Coupon.java
+++ b/src/main/java/com/recurly/v3/resources/Coupon.java
@@ -151,11 +151,29 @@ public class Coupon extends Resource {
 
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always
-   * 11:59:59, the end-of-day Pacific time.
+   * 11:59:59, the end-of-day Pacific time. Null for bulk coupons configured with a relative
+   * redeem-by interval (see redeem_by_interval_unit and redeem_by_interval_amount).
    */
   @SerializedName("redeem_by")
   @Expose
   private ZonedDateTime redeemBy;
+
+  /**
+   * For a bulk coupon with a relative redeem-by, the number of redeem_by_interval_unit intervals
+   * after a code's generation that it remains redeemable. Null unless the coupon uses a relative
+   * redeem-by.
+   */
+  @SerializedName("redeem_by_interval_amount")
+  @Expose
+  private Integer redeemByIntervalAmount;
+
+  /**
+   * For a bulk coupon with a relative redeem-by, the unit of the interval after which each
+   * generated unique code expires. Null unless the coupon uses a relative redeem-by.
+   */
+  @SerializedName("redeem_by_interval_unit")
+  @Expose
+  private Constants.CouponRedeemByIntervalUnit redeemByIntervalUnit;
 
   /**
    * Whether the discount is for all eligible charges on the account, or only a specific
@@ -500,7 +518,8 @@ public class Coupon extends Resource {
 
   /**
    * The date and time the coupon will expire and can no longer be redeemed. Time is always
-   * 11:59:59, the end-of-day Pacific time.
+   * 11:59:59, the end-of-day Pacific time. Null for bulk coupons configured with a relative
+   * redeem-by interval (see redeem_by_interval_unit and redeem_by_interval_amount).
    */
   public ZonedDateTime getRedeemBy() {
     return this.redeemBy;
@@ -508,10 +527,47 @@ public class Coupon extends Resource {
 
   /**
    * @param redeemBy The date and time the coupon will expire and can no longer be redeemed. Time is
-   *     always 11:59:59, the end-of-day Pacific time.
+   *     always 11:59:59, the end-of-day Pacific time. Null for bulk coupons configured with a
+   *     relative redeem-by interval (see redeem_by_interval_unit and redeem_by_interval_amount).
    */
   public void setRedeemBy(final ZonedDateTime redeemBy) {
     this.redeemBy = redeemBy;
+  }
+
+  /**
+   * For a bulk coupon with a relative redeem-by, the number of redeem_by_interval_unit intervals
+   * after a code's generation that it remains redeemable. Null unless the coupon uses a relative
+   * redeem-by.
+   */
+  public Integer getRedeemByIntervalAmount() {
+    return this.redeemByIntervalAmount;
+  }
+
+  /**
+   * @param redeemByIntervalAmount For a bulk coupon with a relative redeem-by, the number of
+   *     redeem_by_interval_unit intervals after a code's generation that it remains redeemable.
+   *     Null unless the coupon uses a relative redeem-by.
+   */
+  public void setRedeemByIntervalAmount(final Integer redeemByIntervalAmount) {
+    this.redeemByIntervalAmount = redeemByIntervalAmount;
+  }
+
+  /**
+   * For a bulk coupon with a relative redeem-by, the unit of the interval after which each
+   * generated unique code expires. Null unless the coupon uses a relative redeem-by.
+   */
+  public Constants.CouponRedeemByIntervalUnit getRedeemByIntervalUnit() {
+    return this.redeemByIntervalUnit;
+  }
+
+  /**
+   * @param redeemByIntervalUnit For a bulk coupon with a relative redeem-by, the unit of the
+   *     interval after which each generated unique code expires. Null unless the coupon uses a
+   *     relative redeem-by.
+   */
+  public void setRedeemByIntervalUnit(
+      final Constants.CouponRedeemByIntervalUnit redeemByIntervalUnit) {
+    this.redeemByIntervalUnit = redeemByIntervalUnit;
   }
 
   /**

--- a/src/main/java/com/recurly/v3/resources/PaymentMethod.java
+++ b/src/main/java/com/recurly/v3/resources/PaymentMethod.java
@@ -50,7 +50,13 @@ public class PaymentMethod extends Resource {
   @Expose
   private Integer expYear;
 
-  /** Credit card number's first six digits. */
+  /**
+   * Credit card number's first six digits.
+   *
+   * <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`), this
+   * is the DPAN's (the wallet/device token's own number) first six digits, not the underlying
+   * card's (FPAN).
+   */
   @SerializedName("first_six")
   @Expose
   private String firstSix;
@@ -75,7 +81,12 @@ public class PaymentMethod extends Resource {
   @Expose
   private String gatewayToken;
 
-  /** Credit card number's last four digits. Will refer to bank account if payment method is ACH. */
+  /**
+   * Credit card number's last four digits. Will refer to bank account if payment method is ACH.
+   *
+   * <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`), this
+   * is the DPAN's last four digits, not the underlying card's (FPAN).
+   */
   @SerializedName("last_four")
   @Expose
   private String lastFour;
@@ -199,13 +210,22 @@ public class PaymentMethod extends Resource {
     this.expYear = expYear;
   }
 
-  /** Credit card number's first six digits. */
+  /**
+   * Credit card number's first six digits.
+   *
+   * <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`), this
+   * is the DPAN's (the wallet/device token's own number) first six digits, not the underlying
+   * card's (FPAN).
+   */
   public String getFirstSix() {
     return this.firstSix;
   }
 
   /**
    * @param firstSix Credit card number's first six digits.
+   *     <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`),
+   *     this is the DPAN's (the wallet/device token's own number) first six digits, not the
+   *     underlying card's (FPAN).
    */
   public void setFirstSix(final String firstSix) {
     this.firstSix = firstSix;
@@ -259,7 +279,12 @@ public class PaymentMethod extends Resource {
     this.gatewayToken = gatewayToken;
   }
 
-  /** Credit card number's last four digits. Will refer to bank account if payment method is ACH. */
+  /**
+   * Credit card number's last four digits. Will refer to bank account if payment method is ACH.
+   *
+   * <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`), this
+   * is the DPAN's last four digits, not the underlying card's (FPAN).
+   */
   public String getLastFour() {
     return this.lastFour;
   }
@@ -267,6 +292,8 @@ public class PaymentMethod extends Resource {
   /**
    * @param lastFour Credit card number's last four digits. Will refer to bank account if payment
    *     method is ACH.
+   *     <p>For a tokenized wallet payment (`apple_pay`, `google_pay`, or `google_pay_device_pan`),
+   *     this is the DPAN's last four digits, not the underlying card's (FPAN).
    */
   public void setLastFour(final String lastFour) {
     this.lastFour = lastFour;

--- a/src/main/java/com/recurly/v3/resources/Transaction.java
+++ b/src/main/java/com/recurly/v3/resources/Transaction.java
@@ -214,6 +214,14 @@ public class Transaction extends Resource {
   @Expose
   private TransactionPaymentGateway paymentGateway;
 
+  /**
+   * Array of Payment Gateway References captured at transaction time, each a reference to a
+   * third-party gateway object of varying types.
+   */
+  @SerializedName("payment_gateway_references")
+  @Expose
+  private List<PaymentGatewayReferences> paymentGatewayReferences;
+
   @SerializedName("payment_method")
   @Expose
   private PaymentMethod paymentMethod;
@@ -748,6 +756,23 @@ public class Transaction extends Resource {
    */
   public void setPaymentGateway(final TransactionPaymentGateway paymentGateway) {
     this.paymentGateway = paymentGateway;
+  }
+
+  /**
+   * Array of Payment Gateway References captured at transaction time, each a reference to a
+   * third-party gateway object of varying types.
+   */
+  public List<PaymentGatewayReferences> getPaymentGatewayReferences() {
+    return this.paymentGatewayReferences;
+  }
+
+  /**
+   * @param paymentGatewayReferences Array of Payment Gateway References captured at transaction
+   *     time, each a reference to a third-party gateway object of varying types.
+   */
+  public void setPaymentGatewayReferences(
+      final List<PaymentGatewayReferences> paymentGatewayReferences) {
+    this.paymentGatewayReferences = paymentGatewayReferences;
   }
 
   public PaymentMethod getPaymentMethod() {

--- a/src/main/java/com/recurly/v3/resources/UniqueCouponCode.java
+++ b/src/main/java/com/recurly/v3/resources/UniqueCouponCode.java
@@ -48,6 +48,15 @@ public class UniqueCouponCode extends Resource {
   @Expose
   private String object;
 
+  /**
+   * Absolute expiry computed and stored at code-generation time. Set only for Window (relative
+   * redeem-by) coupons. Null for Anytime coupons and Specific Date coupons — those resolve expiry
+   * from the parent coupon's redeem_by at redemption time, not at code-generation time.
+   */
+  @SerializedName("redeem_by_date")
+  @Expose
+  private ZonedDateTime redeemByDate;
+
   /** The date and time the unique coupon code was redeemed. */
   @SerializedName("redeemed_at")
   @Expose
@@ -146,6 +155,25 @@ public class UniqueCouponCode extends Resource {
    */
   public void setObject(final String object) {
     this.object = object;
+  }
+
+  /**
+   * Absolute expiry computed and stored at code-generation time. Set only for Window (relative
+   * redeem-by) coupons. Null for Anytime coupons and Specific Date coupons — those resolve expiry
+   * from the parent coupon's redeem_by at redemption time, not at code-generation time.
+   */
+  public ZonedDateTime getRedeemByDate() {
+    return this.redeemByDate;
+  }
+
+  /**
+   * @param redeemByDate Absolute expiry computed and stored at code-generation time. Set only for
+   *     Window (relative redeem-by) coupons. Null for Anytime coupons and Specific Date coupons —
+   *     those resolve expiry from the parent coupon's redeem_by at redemption time, not at
+   *     code-generation time.
+   */
+  public void setRedeemByDate(final ZonedDateTime redeemByDate) {
+    this.redeemByDate = redeemByDate;
   }
 
   /** The date and time the unique coupon code was redeemed. */


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `Coupon` / `CouponCreate` / `CouponUpdate` now support `redeem_by_interval_unit` and `redeem_by_interval_amount` — a relative redeem-by window for bulk coupons (mutually exclusive with `redeem_by_date`).
- `UniqueCouponCode` now exposes `redeem_by_date` (read-only) — the absolute expiry computed at code-generation time for Window (relative redeem-by) coupons; null for Anytime/Specific Date coupons.
- `InvoiceCreate`, `RecoveryInvoiceCreate`, `SubscriptionCreate`, and `SubscriptionUpdate` now accept `transaction_descriptor_suffix` — optionally overrides the suffix of the composed transaction descriptor sent to the gateway.
- `Transaction` now exposes `payment_gateway_references` — Payment Gateway References captured at transaction time.
- `RecoveryBillingInfoCreate` now accepts `payment_method` — merchant-supplied fallback payment method metadata. Recurly's own gateway-token lookup is authoritative and overrides these fields where it can; they only fill gaps when that lookup is unavailable.
- `RecoveryBillingInfoCreate.transactions` is now required when this billing_info is the primary payment method and the account's dunning campaign skips Recurly's own retry attempts entirely.

**New types**
- `RecoveryPaymentMethodCreate` (new object): merchant-supplied payment method metadata for revenue recovery — `object`, `card_type`, `exp_month`, `exp_year`, `first_six`, `last_four`.
- `RecoveryPaymentMethod` (new enum): `credit_card`, `apple_pay`, `google_pay`, `google_pay_device_pan`, `paypal_billing_agreement`.

**Documentation clarifications**
- `PaymentMethod.first_six` / `PaymentMethod.last_four`: clarified that for a tokenized wallet payment (`apple_pay`, `google_pay`, `google_pay_device_pan`), these reflect the DPAN (the wallet/device token's own number), not the underlying card's (FPAN).
- API docs: documented `Idempotency-Key` header support for `POST`/`PUT`/`PATCH`/`DELETE` requests, including replay/conflict behavior and current SDK support (Ruby only for now).
